### PR TITLE
Release 1.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,25 @@
+# 1.29.1
+
+## Release Notes
+https://github.com/asacolips-projects/13th-age/releases/tag/1.29.1
+
+![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12](https://img.shields.io/badge/Foundry-v12-yellow)
+
+## Summary
+
+### Changes
+
+- Migrated to GitHub
+
+### Fixes
+
+- Fixed a bug with settings groups
+- Fixed a bug with ongoing damage parsing
+
 # 1.29.0
 
 ## Release Notes
-https://gitlab.com/asacolips-projects/foundry-mods/archmage/-/releases/1.29.0
+https://github.com/asacolips-projects/13th-age/releases/tag/1.29.0
 
 ![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12](https://img.shields.io/badge/Foundry-v12-yellow)
 
@@ -23,7 +41,7 @@ https://gitlab.com/asacolips-projects/foundry-mods/archmage/-/releases/1.29.0
 # 1.28.0
 
 ## Release Notes
-https://gitlab.com/asacolips-projects/foundry-mods/archmage/-/releases/1.28.0
+https://github.com/asacolips-projects/13th-age/releases/tag/1.28.0
 
 ![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12](https://img.shields.io/badge/Foundry-v12-yellow)
 

--- a/release-notes/release-notes-1.29.1.md
+++ b/release-notes/release-notes-1.29.1.md
@@ -1,0 +1,21 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.29.1/system.json
+
+## Compatible Foundry versions
+
+![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12](https://img.shields.io/badge/Foundry-v12-yellow)
+
+**Note**: Foundry v12 is currently in the development phase. Full compatibility with it is not guaranteed.
+
+## Changes
+
+- We moved to GitHub! This shouldn't directly affect your game, but there are a few small things to keep in mind related to it.
+  - Our manifest has moved. It's now stored at https://asacolips-artifacts.s3.amazonaws.com/archmage/latest/system.json and specific versions are at https://asacolips-artifacts.s3.amazonaws.com/archmage/1.29.1/system.json
+  - Existing issues have been migrated and can be found here: https://github.com/asacolips-projects/13th-age/issues
+  - Pull requests can be created here: https://github.com/asacolips-projects/13th-age/pulls
+
+## Fixes
+
+- Fixed a bug where players would see empty groups when viewing the settings page for the system. Players have fewer settings than GMs, so they should currently only be able to see the Automation, Appearance, and Accessibility groups.
+- Fixed a bug where ongoing damage wouldn't properly parse on chat cards if it was using a raw number like `5 ongoing damage` instead of `[[5]] ongoing damage`. Now both will work!

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -1,7 +1,7 @@
 name: archmage
 id: archmage
 title: 13th Age
-version: "1.29.0"
+version: "1.29.1"
 authors:
   - name: Matt Smith
     discord: asacolips#1867
@@ -406,10 +406,10 @@ languages:
     path: languages/es.json
 
 socket: true
-url: https://gitlab.com/asacolips-projects/foundry-mods/archmage
-manifest: https://gitlab.com/asacolips-projects/foundry-mods/archmage/-/raw/master/system.json
-download: https://gitlab.com/asacolips-projects/foundry-mods/archmage/-/jobs/artifacts/1.29.0/raw/archmage.zip?job=build-prod
-changelog: https://gitlab.com/asacolips-projects/foundry-mods/archmage/-/blob/master/CHANGELOG.md
+url: https://github.com/asacolips-projects/13th-age
+manifest: https://asacolips-artifacts.s3.amazonaws.com/archmage/latest/system.json
+download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.29.1/archmage.zip
+changelog: https://github.com/asacolips-projects/13th-age/blob/main/CHANGELOG.md
 initiative: 1d20 + (@abilities?.dex.mod || 0) + @attributes.init.value + @attributes.level.value
 gridDistance: "1"
 gridUnits: ''


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.29.1/system.json

## Compatible Foundry versions

![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12](https://img.shields.io/badge/Foundry-v12-yellow)

**Note**: Foundry v12 is currently in the development phase. Full compatibility with it is not guaranteed.

## Changes

- We moved to GitHub! This shouldn't directly affect your game, but there are a few small things to keep in mind related to it.
  - Our manifest has moved. It's now stored at https://asacolips-artifacts.s3.amazonaws.com/archmage/latest/system.json and specific versions are at https://asacolips-artifacts.s3.amazonaws.com/archmage/1.29.1/system.json
  - Existing issues have been migrated and can be found here: https://github.com/asacolips-projects/13th-age/issues
  - Pull requests can be created here: https://github.com/asacolips-projects/13th-age/pulls

## Fixes

- Fixed a bug where players would see empty groups when viewing the settings page for the system. Players have fewer settings than GMs, so they should currently only be able to see the Automation, Appearance, and Accessibility groups.
- Fixed a bug where ongoing damage wouldn't properly parse on chat cards if it was using a raw number like `5 ongoing damage` instead of `[[5]] ongoing damage`. Now both will work!