### PR TITLE
Feature/bard songs improvements

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -395,7 +395,7 @@ ARCHMAGE:
     powerType: Type
     powerUsage: Usage
   MONKFORMS:
-    aelabel: Monk AC bonus
+    aelabel: Monk form AC bonus
     finishing: finishing
     flow: flow
     opening: opening
@@ -621,6 +621,8 @@ ARCHMAGE:
     spellLevel10: 10th Level Spell
     spellLevel10Placeholder: "[[10d6]] damage"
     spellLevelTrigger: Level Spell
+    sustainedOrFinal: "Do you want to use the Final Verse instead of the Sustained Effect?"
+    sustainedOrFinalTitle: "Use Final Verse"
     sustainPower: "Sustain {power} on {target}+"
     rollTable: RollTable
     rollTablePlaceholder: Sneak Attack

--- a/src/packs/src/animal-companions/Animal_Companion__0__dqP04pMpErh1b5tB.yml
+++ b/src/packs/src/animal-companions/Animal_Companion__0__dqP04pMpErh1b5tB.yml
@@ -107,7 +107,7 @@ token:
   name: Animal Companion (0)
   img: systems/archmage/assets/icons/tokens/monsters/beast.webp
   displayName: 0
-  actorLink: false
+  actorLink: true
   width: 1
   height: 1
   scale: 1

--- a/src/packs/src/animal-companions/Animal_Companion__10__47xkCqCAUpnXr753.yml
+++ b/src/packs/src/animal-companions/Animal_Companion__10__47xkCqCAUpnXr753.yml
@@ -107,7 +107,7 @@ token:
   name: Animal Companion (10)
   img: systems/archmage/assets/icons/tokens/monsters/beast.webp
   displayName: 0
-  actorLink: false
+  actorLink: true
   width: 1
   height: 1
   scale: 1

--- a/src/packs/src/animal-companions/Animal_Companion__1__StCkXfQv04KLYNX3.yml
+++ b/src/packs/src/animal-companions/Animal_Companion__1__StCkXfQv04KLYNX3.yml
@@ -107,7 +107,7 @@ token:
   name: Animal Companion (1)
   img: systems/archmage/assets/icons/tokens/monsters/beast.webp
   displayName: 0
-  actorLink: false
+  actorLink: true
   width: 1
   height: 1
   scale: 1

--- a/src/packs/src/animal-companions/Animal_Companion__2__wMpIChbY2ImdYjNf.yml
+++ b/src/packs/src/animal-companions/Animal_Companion__2__wMpIChbY2ImdYjNf.yml
@@ -107,7 +107,7 @@ token:
   name: Animal Companion (2)
   img: systems/archmage/assets/icons/tokens/monsters/beast.webp
   displayName: 0
-  actorLink: false
+  actorLink: true
   width: 1
   height: 1
   scale: 1

--- a/src/packs/src/animal-companions/Animal_Companion__3__DTd5k2ZL5Cr4y66R.yml
+++ b/src/packs/src/animal-companions/Animal_Companion__3__DTd5k2ZL5Cr4y66R.yml
@@ -107,7 +107,7 @@ token:
   name: Animal Companion (3)
   img: systems/archmage/assets/icons/tokens/monsters/beast.webp
   displayName: 0
-  actorLink: false
+  actorLink: true
   width: 1
   height: 1
   scale: 1

--- a/src/packs/src/animal-companions/Animal_Companion__4__Ly5Ok6xCe8WphhSz.yml
+++ b/src/packs/src/animal-companions/Animal_Companion__4__Ly5Ok6xCe8WphhSz.yml
@@ -107,7 +107,7 @@ token:
   name: Animal Companion (4)
   img: systems/archmage/assets/icons/tokens/monsters/beast.webp
   displayName: 0
-  actorLink: false
+  actorLink: true
   width: 1
   height: 1
   scale: 1

--- a/src/packs/src/animal-companions/Animal_Companion__5__ZXATsaLAT66zG4Fr.yml
+++ b/src/packs/src/animal-companions/Animal_Companion__5__ZXATsaLAT66zG4Fr.yml
@@ -107,7 +107,7 @@ token:
   name: Animal Companion (5)
   img: systems/archmage/assets/icons/tokens/monsters/beast.webp
   displayName: 0
-  actorLink: false
+  actorLink: true
   width: 1
   height: 1
   scale: 1

--- a/src/packs/src/animal-companions/Animal_Companion__6__1eTIftphsKz2gELN.yml
+++ b/src/packs/src/animal-companions/Animal_Companion__6__1eTIftphsKz2gELN.yml
@@ -107,7 +107,7 @@ token:
   name: Animal Companion (6)
   img: systems/archmage/assets/icons/tokens/monsters/beast.webp
   displayName: 0
-  actorLink: false
+  actorLink: true
   width: 1
   height: 1
   scale: 1

--- a/src/packs/src/animal-companions/Animal_Companion__7__RPDjkE3VnbWzGZTK.yml
+++ b/src/packs/src/animal-companions/Animal_Companion__7__RPDjkE3VnbWzGZTK.yml
@@ -107,7 +107,7 @@ token:
   name: Animal Companion (7)
   img: systems/archmage/assets/icons/tokens/monsters/beast.webp
   displayName: 0
-  actorLink: false
+  actorLink: true
   width: 1
   height: 1
   scale: 1

--- a/src/packs/src/animal-companions/Animal_Companion__8__daTDmyd7OMevXzRq.yml
+++ b/src/packs/src/animal-companions/Animal_Companion__8__daTDmyd7OMevXzRq.yml
@@ -107,7 +107,7 @@ token:
   name: Animal Companion (8)
   img: systems/archmage/assets/icons/tokens/monsters/beast.webp
   displayName: 0
-  actorLink: false
+  actorLink: true
   width: 1
   height: 1
   scale: 1

--- a/src/packs/src/animal-companions/Animal_Companion__9__jbYpZ8yNr9lGXjMr.yml
+++ b/src/packs/src/animal-companions/Animal_Companion__9__jbYpZ8yNr9lGXjMr.yml
@@ -107,7 +107,7 @@ token:
   name: Animal Companion (9)
   img: systems/archmage/assets/icons/tokens/monsters/beast.webp
   displayName: 0
-  actorLink: false
+  actorLink: true
   width: 1
   height: 1
   scale: 1

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -1,7 +1,7 @@
 name: archmage
 id: archmage
 title: 13th Age
-version: "1.29.1"
+version: "1.29.2"
 authors:
   - name: Matt Smith
     discord: asacolips#1867


### PR DESCRIPTION
- Add dialog to ask whether an active song (with an active reminder AE) is meant to be used for their Sustained Effect or Final Verse
- Skip usage check for sustained/final verse songs

TODO:
- Make final verse auto-remove reminder
- Render green background on Opening/Sustained Effect on first use and sustained, on Final Verse on final
- Create system macro to fully automate Song of Heroes
    - Create hekper method to target all allies (tokens with ownership? Or just linked?)