### PR TITLE
NPC adjustment: convert to mob

### DIFF
--- a/src/vue/ArchmageNpcSheet.vue
+++ b/src/vue/ArchmageNpcSheet.vue
@@ -39,6 +39,7 @@
           <!-- Modify Level tab -->
           <Tab group="primary" :tab="tabs.primary.modifyLevel">
             <NpcModifyLevel :actor="actor" />
+            <NpcConvertToMob :actor="actor" />
           </Tab>
           <!-- Settings tab -->
           <Tab group="primary" :tab="tabs.primary.settings">
@@ -80,6 +81,7 @@ import NpcActions from '@/components/actor/npc/NpcActions.vue';
 import NpcAttributes from '@/components/actor/npc/NpcAttributes.vue';
 import NpcSettings from '@/components/actor/npc/NpcSettings.vue';
 import NpcModifyLevel from '@/components/actor/npc/NpcModifyLevel.vue';
+import NpcConvertToMob from './components/actor/npc/NpcConvertToMob.vue';
 import Tabs from '@/components/parts/Tabs.vue';
 import Tab from '@/components/parts/Tab.vue';
 
@@ -94,6 +96,7 @@ export default {
     NpcAttributes,
     NpcSettings,
     NpcModifyLevel,
+    NpcConvertToMob,
     CharDetails,
     CharEffects,
   },

--- a/src/vue/components/actor/npc/NpcConvertToMob.vue
+++ b/src/vue/components/actor/npc/NpcConvertToMob.vue
@@ -1,0 +1,41 @@
+<template>
+	<h3>Convert to Mob</h3>
+	<p>Converts this actor to a mob, with more HP and a multi-attack that loses attacks as the HP are drained.</p>
+	<section class="section section-mob-convert flexrow">
+		<label><strong>Number of mooks:</strong></label>
+		<input type="number" min="2" step="1" v-model="mookCount">
+		<button class="button button--confirm" @click="convertToMob" :disabled="mobConversionDisabled" type="button">Convert
+			to Mob</button>
+	</section>
+</template>
+
+<script>
+import { ref } from 'vue';
+export default {
+	name: 'NpcConvertToMob',
+	props: ['actor'],
+	setup(props) {
+		const mookCount = ref(2)
+		return { mookCount }
+	},
+}
+</script>
+
+<style lang="scss">
+.archmage-v2.npc-sheet {
+	.section-mob-convert {
+		margin: $padding-lg;
+		align-items: center;
+		gap: 1rem;
+
+		label {
+			flex-grow: 0;
+			white-space: nowrap;
+		}
+
+		button {
+			flex-basis: 200px;
+		}
+	}
+}
+</style>

--- a/src/vue/components/actor/npc/NpcModifyLevel.vue
+++ b/src/vue/components/actor/npc/NpcModifyLevel.vue
@@ -1,4 +1,5 @@
 <template>
+  <h3>Adjust Level</h3>
   <section class="section section--level-edit flexrow">
     <div class="unit unit--modify-level">
       <label><strong>{{localize('ARCHMAGE.AUTOLEVEL.newLevel')}}: {{newLevel}}</strong></label>


### PR DESCRIPTION
This provides an automation to convert a single-monster NPC actor into a mob of N, by multiplying the HP by N and adding `([[ceil(@hp.value/N)]] attacks)` to attack rolls.

- [ ] Layout rough draft
  - [ ] Probably a round 2
- [ ] Implement the conversion
  - [ ] Only once, maybe using a flag
- [ ] Consider bumping the token size up by 1?
- [ ] Find all the corner cases
- [ ] i18n