### PR TITLE
Display even-level spell effects when 2e rules are enabled

### DIFF
--- a/src/vue/components/parts/Power.vue
+++ b/src/vue/components/parts/Power.vue
@@ -59,6 +59,23 @@ export default {
       return this.actor?.flags?.archmage?.diceFormulaMode ?? 'short';
     },
     powerDetailFields() {
+      const spellFields = game.settings.get("archmage", "secondEdition")
+        ? [
+          'spellLevel2',
+          'spellLevel3',
+          'spellLevel4',
+          'spellLevel5',
+          'spellLevel6',
+          'spellLevel7',
+          'spellLevel8',
+          'spellLevel9',
+        ]
+        : [
+          'spellLevel3',
+          'spellLevel5',
+          'spellLevel7',
+          'spellLevel9',
+        ]
       let powerFields = [
         'trigger',
         'sustainOn',
@@ -79,10 +96,7 @@ export default {
         'finalVerse',
         'special',
         'effect',
-        'spellLevel3',
-        'spellLevel5',
-        'spellLevel7',
-        'spellLevel9',
+        ...spellFields,
         'spellChain',
         'breathWeapon',
         'recharge',


### PR DESCRIPTION
Fixes this issue in the PC power display:

![CleanShot 2024-05-19 at 07 08 42](https://github.com/asacolips-projects/13th-age/assets/39902/60866d56-813c-49b6-afd3-305a037a32df)
