### PR TITLE
Occultist spells: parse "always" for retain-focus instructions

### DIFF
--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -681,7 +681,7 @@ export class ItemArchmage extends Item {
 
   async _handleRetainFocus(itemToRender, hitEvalRes, actorUpdateData, chatData) {
     if (itemToRender.type != "power") return;
-    if (!itemToRender.actor.system.resources?.perCombat?.focus?.enabled != true) return;
+    if (itemToRender.actor.system.resources?.perCombat?.focus?.enabled != true) return;
 
     const match = itemToRender.system.always?.value?.match(RETAIN_FOCUS_REGEX);
     if (match) {

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -687,7 +687,12 @@ export class ItemArchmage extends Item {
       const naturalRoll = hitEvalRes.$rolls[0].d20result
       if (naturalRoll >= low && naturalRoll <= high) {
         delete actorUpdateData['system.resources.perCombat.focus.current']
-        // TODO: highlight the "always" part of chatData
+
+        const labelText = game.i18n.localize(`ARCHMAGE.CHAT.always`)
+        chatData.content = chatData.content.replace(
+          `<div class="card-prop"><strong>${labelText}:`,
+          `<div class="card-prop trigger-active"><strong>${labelText}:`
+        )
       }
     }
   }

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -680,6 +680,9 @@ export class ItemArchmage extends Item {
   }
 
   async _handleRetainFocus(itemToRender, hitEvalRes, actorUpdateData, chatData) {
+    if (itemToRender.type != "power") return;
+    if (!itemToRender.actor.system.resources.perCombat.focus.enabled) return;
+
     const match = itemToRender.system.always?.value?.match(RETAIN_FOCUS_REGEX);
     if (match) {
       const low = parseInt(match[1])

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -681,7 +681,7 @@ export class ItemArchmage extends Item {
 
   async _handleRetainFocus(itemToRender, hitEvalRes, actorUpdateData, chatData) {
     if (itemToRender.type != "power") return;
-    if (!itemToRender.actor.system.resources?.perCombat?.focus?.enabled) return;
+    if (!itemToRender.actor.system.resources?.perCombat?.focus?.enabled != true) return;
 
     const match = itemToRender.system.always?.value?.match(RETAIN_FOCUS_REGEX);
     if (match) {

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -681,7 +681,7 @@ export class ItemArchmage extends Item {
 
   async _handleRetainFocus(itemToRender, hitEvalRes, actorUpdateData, chatData) {
     if (itemToRender.type != "power") return;
-    if (!itemToRender.actor.system.resources.perCombat.focus.enabled) return;
+    if (!itemToRender.actor.system.resources?.perCombat?.focus?.enabled) return;
 
     const match = itemToRender.system.always?.value?.match(RETAIN_FOCUS_REGEX);
     if (match) {


### PR DESCRIPTION
- [x] Parse the `always` content for something like `Retain focus: <N>-<M>`
- [x] If present, recognize natural rolls in that range and do not change the focus value
- [x] Highlight the output chat card's "always" field if this has happened