### PR TITLE
Release 1.29.3

### DIFF
--- a/.github/workflows/foundry-package-release.mjs
+++ b/.github/workflows/foundry-package-release.mjs
@@ -21,53 +21,58 @@ const release_data = {
   "compatibility": {
     "minimum": `${system.compatibility.minimum}`,
     "verified": `${system.compatibility.verified}`,
+    "maximum": `${system.compatibility.maximum}`,
   }
 };
 
-/**
- * Reimplements Foundry's isNumeric() function.
- * 
- * Test whether a value is numeric.
- * This is the highest performing algorithm currently available, per https://jsperf.com/isnan-vs-typeof/5
- * @memberof Number
- * @param {*} n       A value to test
- * @return {boolean}  Is it a number?
- */
-function isNumeric(n) {
-  if ( n instanceof Array ) return false;
-  else if ( [null, ""].includes(n) ) return false;
-  return +n === +n;
-}
+// ====== OBSOLETE =================================
 
-/**
- * Reimplements Foundry's isNewerVersion() helper.
- *
- * Return whether a target version (v1) is more advanced than some other reference version (v0).
- * Supports either numeric or string version comparison with version parts separated by periods.
- * @param {number|string} v1    The target version
- * @param {number|string} v0    The reference version
- * @return {boolean}            Is v1 a more advanced version than v0?
- */
-function isNewerVersion(v1, v0) {
-  if ( (typeof v1 === "number") && (typeof v0 === "number") ) return v1 > v0;
-  let v1Parts = String(v1).split(".");
-  let v0Parts = String(v0).split(".");
-  for ( let [i, p1] of v1Parts.entries() ) {
-    let p0 = v0Parts[i];
-    if ( p0 === undefined ) return true;
-    if ( isNumeric(p0) && isNumeric(p1) ) {
-      if ( Number(p1) !== Number(p0) ) return Number(p1) > Number(p0);
-    }
-    if ( p1 !== p0 ) return p1 > p0;
-  }
-  if ( v0Parts.length > v1Parts.length ) return false;
-  return !v1Parts.equals(v0Parts);
-}
+// /**
+//  * Reimplements Foundry's isNumeric() function.
+//  * 
+//  * Test whether a value is numeric.
+//  * This is the highest performing algorithm currently available, per https://jsperf.com/isnan-vs-typeof/5
+//  * @memberof Number
+//  * @param {*} n       A value to test
+//  * @return {boolean}  Is it a number?
+//  */
+// function isNumeric(n) {
+//   if ( n instanceof Array ) return false;
+//   else if ( [null, ""].includes(n) ) return false;
+//   return +n === +n;
+// }
 
-// Verify compatibility is valid before adding.
-if (system?.compatibility?.maximum && isNewerVersion(system.compatibility.maximum, system.compatibility.verified)) {
-  release_data.compatibility.maximum = system.compatibility.maximum;
-}
+// /**
+//  * Reimplements Foundry's isNewerVersion() helper.
+//  *
+//  * Return whether a target version (v1) is more advanced than some other reference version (v0).
+//  * Supports either numeric or string version comparison with version parts separated by periods.
+//  * @param {number|string} v1    The target version
+//  * @param {number|string} v0    The reference version
+//  * @return {boolean}            Is v1 a more advanced version than v0?
+//  */
+// function isNewerVersion(v1, v0) {
+//   if ( (typeof v1 === "number") && (typeof v0 === "number") ) return v1 > v0;
+//   let v1Parts = String(v1).split(".");
+//   let v0Parts = String(v0).split(".");
+//   for ( let [i, p1] of v1Parts.entries() ) {
+//     let p0 = v0Parts[i];
+//     if ( p0 === undefined ) return true;
+//     if ( isNumeric(p0) && isNumeric(p1) ) {
+//       if ( Number(p1) !== Number(p0) ) return Number(p1) > Number(p0);
+//     }
+//     if ( p1 !== p0 ) return p1 > p0;
+//   }
+//   if ( v0Parts.length > v1Parts.length ) return false;
+//   return !v1Parts.equals(v0Parts);
+// }
+
+// // Verify compatibility is valid before adding.
+// if (system?.compatibility?.maximum && isNewerVersion(system.compatibility.maximum, system.compatibility.verified)) {
+//   release_data.compatibility.maximum = system.compatibility.maximum;
+// }
+
+// ====== END OBSOLETE =============================
 
 const response = await fetch("https://api.foundryvtt.com/_api/packages/release_version/", {
   headers: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 1.29.3
+https://github.com/asacolips-projects/13th-age/releases/tag/1.29.3
+
+![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green)
+
+# 1.29.2
+
+## Release Notes
+https://github.com/asacolips-projects/13th-age/releases/tag/1.29.2
+
+![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green)
+
 # 1.29.1
 
 ## Release Notes

--- a/release-notes/1.29.3.md
+++ b/release-notes/1.29.3.md
@@ -1,0 +1,34 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.29.3/system.json
+
+## Compatible Foundry versions
+
+![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green)
+
+**Note**: This version of the system is NOT compatible with Foundry v12. That will be coming in the next minor release of the system, 1.30.0.
+
+## Bug Fixes
+- Support spaces instead of dashes in race recognition code.
+- Fix feat deletion sometimes failing to properly clean up after itself.
+- Avoid displaying AE chat card for dead (not unconscious) combatants.
+- Updated character sheets to display even level spells if using the 2e alpha rules setting.
+
+## Bard Song Improvements
+- Add dialog to ask whether an active song (with an active reminder AE) is meant to be used for their `Opening/Sustained Effect` or `Final Verse`.
+- Skip usage check for sustained/final verse songs.
+- Remove the auto-generated sustain reminder upon singing the final verse.
+- Highlight effect pertaining to the row being sung.
+- Add helper method to select all allies (approximated by linked tokens) in a fight, including or excluding the caster.
+- Add helper method to apply AE(s) to one or more tokens (bypassing permissions).
+- Add song usage information to data accessible by embedded macros.
+- Add system macro to automate the application of Song of Heroes' opening/sustained effect, including duration and additional benefits at higher levels.
+
+## Content Updates
+- Make animal companion actors linked by default.
+- Fix multiple errors in Gelatinous Cubahedron.
+- Add missing text to Hellwasp.
+- Updated magic items compendium organization with the following changes:
+  - Consolidated magic items compendiums into a single "SRD Magic Items" compendium.
+  - Moved the new compendium into the "Player Options" compendium folder. You may need to delete the previous "Magic Items" compendium folder if it's now empty due to the move.
+  - Organized the magic items within the new compendium using folders based on the system's chakras.

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -1,7 +1,7 @@
 name: archmage
 id: archmage
 title: 13th Age
-version: "1.29.2"
+version: "1.29.3"
 authors:
   - name: Matt Smith
     discord: asacolips#1867
@@ -17,7 +17,7 @@ compatibleCoreVersion: "11"
 compatibility:
   minimum: "11"
   verified: "11.315"
-  maximum: "12"
+  maximum: "11"
 
 esmodules:
   - module/archmage.js
@@ -279,7 +279,7 @@ languages:
 socket: true
 url: https://github.com/asacolips-projects/13th-age
 manifest: https://asacolips-artifacts.s3.amazonaws.com/archmage/latest/system.json
-download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.29.1/archmage.zip
+download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.29.3/archmage.zip
 changelog: https://github.com/asacolips-projects/13th-age/blob/main/CHANGELOG.md
 initiative: 1d20 + (@abilities?.dex.mod || 0) + @attributes.init.value + @attributes.level.value
 gridDistance: "1"

--- a/src/vue/components/parts/Power.vue
+++ b/src/vue/components/parts/Power.vue
@@ -69,6 +69,7 @@ export default {
           'spellLevel7',
           'spellLevel8',
           'spellLevel9',
+          'spellLevel10',
         ]
         : [
           'spellLevel3',


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.29.3/system.json

## Compatible Foundry versions

![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green)

**Note**: This version of the system is NOT compatible with Foundry v12. That will be coming in the next minor release of the system, 1.30.0.

## Bug Fixes
- Support spaces instead of dashes in race recognition code.
- Fix feat deletion sometimes failing to properly clean up after itself.
- Avoid displaying AE chat card for dead (not unconscious) combatants.
- Updated character sheets to display even level spells if using the 2e alpha rules setting.

## Bard Song Improvements
- Add dialog to ask whether an active song (with an active reminder AE) is meant to be used for their `Opening/Sustained Effect` or `Final Verse`.
- Skip usage check for sustained/final verse songs.
- Remove the auto-generated sustain reminder upon singing the final verse.
- Highlight effect pertaining to the row being sung.
- Add helper method to select all allies (approximated by linked tokens) in a fight, including or excluding the caster.
- Add helper method to apply AE(s) to one or more tokens (bypassing permissions).
- Add song usage information to data accessible by embedded macros.
- Add system macro to automate the application of Song of Heroes' opening/sustained effect, including duration and additional benefits at higher levels.

## Content Updates
- Make animal companion actors linked by default.
- Fix multiple errors in Gelatinous Cubahedron.
- Add missing text to Hellwasp.
- Updated magic items compendium organization with the following changes:
  - Consolidated magic items compendiums into a single "SRD Magic Items" compendium.
  - Moved the new compendium into the "Player Options" compendium folder. You may need to delete the previous "Magic Items" compendium folder if it's now empty due to the move.
  - Organized the magic items within the new compendium using folders based on the system's chakras.