### PR TITLE
Release 1.30.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Foundry v11](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12](https://img.shields.io/badge/Foundry-v12-yellow)
+![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12.327](https://img.shields.io/badge/Foundry-v12.327-green)
 
 # Description
 

--- a/release-notes/1.30.0.md
+++ b/release-notes/1.30.0.md
@@ -8,11 +8,48 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.30.0/syste
 
 **Note**: This system includes both support for Foundry v12 and the 13th Age 2e beta packet rules. Backup before updating!
 
+## Foundry v12
+Added support for Foundry v12 to the system. This was implemented in a way that we didn't have to disable v11 support, so you'll still see warnings in your console for API calls that were deprecated as of v12. Those will go away in a future version when we removed v11 support.
+
+## 2e Beta Packet Support
+We've added support for the 2e Beta Packet rules to the system! Currently, this is only _mechanical_ support. Unlike the alpha packet, we will eventually have compendium content to go along with the playable draft rules, but we're currently targeting the upcoming Gamma Packet rather than the Beta Packet for a backer-exclusive module. The system's eventual version of the 2e compendium content will be dependent on the timeline of the final rules and their accompanying SRD.
+
+- Updated NPC data structure and sheet to separate size from strength. This also includes a migration to update existing actors to use the new format.
+- Updated NPC sheet header to wrap if it has too many properties (size, level, strength, etc.). This is most common triple-strength aberrations due to the text length of those two properties.
+- Adjust base stat calculations to reflect changes in the beta packet if 2e is enabled.
+- Update epic tier weapon damage and recovery scaling to use flat 10/20/30 bonuses if 2e is enabled.
+- Update conditions if 2e is enabled.
+    - Add new Charmed and Frenzied conditions.
+    - Update Vulnerable, Confused, Stunned and Hindered conditions.
+- Rename `daily` to `arc` if 2e is enabled.
+    - Note: macros will continue to use the internal name `daily`, but the UI will show the new name.
+- Support 2e style breath weapon spells if 2e enabled.
+    - Disable recently added breath reminder.
+    - Automatically add E.D. to breath spell's crit range.
+- Add a character flag to automate the barbarian's Grim Determination if 2e is enabled.
+- Add bonuses to each ability score skill check to magic items.
+- Support up to 5 special rolls in monster actions.
+- Rename `Omega` tier to `Iconic`.
+- Move death save failures and all resource resets from combat deletion to rests; 'skulls' only reset down to 1 if 2e is enabled.
+- Add 11th level field to powers.
+- Add modifier (alt) use powers at +1 level.
+- Add Associated Icon field to magic items.
+- Add Reroll vs. AC and Reroll Save bonuses to magic items, and automate their tracking and usage on a new character sheet panel.
+- Move disengage to defenses panel and bonus to settings.
+- Add dialog to easily set disengage penalties when engaged to multiple foes.
+- Auto-set additional class (custom) resources if 2e enabled.
+- Adjust 2e ability scores hint.
+- Automate combat rhythm rolling 2d20 when using a maneuver of the correct type.
+
 ## Bug Fixes
-- TBD
+- Fixed a previous feature that auto-sets token size on monster size change.
+- Updated character sheets to display even level spell rows on powers if 2e is enabled and they're not empty.
 
 ## Features
-- TBD
+- Parse the `always` content for something like `Retain focus: <N>-<M>`
+  - If present, recognize natural rolls in that range and do not change the focus value.
+  - Highlight the output chat card's "always" field if this has happened.
 
-## Content Updates
-- TBD
+## Credits
+
+Thanks go out to @ben, @LegoFed3, and @asacolips for their contributions in this release!

--- a/release-notes/1.30.0.md
+++ b/release-notes/1.30.0.md
@@ -6,17 +6,17 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.30.0/syste
 
 ![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12.327](https://img.shields.io/badge/Foundry-v12.327-green)
 
-**Note**: This system includes both support for Foundry v12 and the 13th Age 2e beta packet rules. Backup before updating!
+**Note**: This system update includes both support for Foundry v12 and the 13th Age 2e beta packet rules. Backup before updating!
 
 ## Foundry v12
-Added support for Foundry v12 to the system. This was implemented in a way that we didn't have to disable v11 support, so you'll still see warnings in your console for API calls that were deprecated as of v12. Those will go away in a future version when we removed v11 support.
+Added support for Foundry v12 to the system. This was implemented in a way such that we didn't have to disable v11 support, so you'll still see warnings in your console for API calls that were deprecated as of v12. Those will go away in a future version when we will remove v11 support.
 
 ## 2e Beta Packet Support
-We've added support for the 2e Beta Packet rules to the system! Currently, this is only _mechanical_ support. Unlike the alpha packet, we will eventually have compendium content to go along with the playable draft rules, but we're currently targeting the upcoming Gamma Packet rather than the Beta Packet for a backer-exclusive module. The system's eventual version of the 2e compendium content will be dependent on the timeline of the final rules and their accompanying SRD.
+We've added support for the 2e Beta Packet rules to the system! Currently, this is only _mechanical_ support. Unlike the alpha packet, we will eventually have compendium content to go along with the playable draft rules, but we're currently targeting the upcoming Gamma Packet rather than the Beta Packet for a backer-exclusive module. The system's eventual public version of the 2e compendium content will be dependent on the timeline of the final rules and their accompanying SRD.
 
 - Updated NPC data structure and sheet to separate size from strength. This also includes a migration to update existing actors to use the new format.
-- Updated NPC sheet header to wrap if it has too many properties (size, level, strength, etc.). This is most common triple-strength aberrations due to the text length of those two properties.
-- Adjust base stat calculations to reflect changes in the beta packet if 2e is enabled.
+- Updated NPC sheet header to wrap if it has too many properties (size, level, strength, etc.). This is most common for triple-strength aberrations due to the text length of those two properties.
+- Adjust base stat auto-configuration to reflect changes in the beta packet if 2e is enabled.
 - Update epic tier weapon damage and recovery scaling to use flat 10/20/30 bonuses if 2e is enabled.
 - Update conditions if 2e is enabled.
     - Add new Charmed and Frenzied conditions.
@@ -27,22 +27,23 @@ We've added support for the 2e Beta Packet rules to the system! Currently, this 
     - Disable recently added breath reminder.
     - Automatically add E.D. to breath spell's crit range.
 - Add a character flag to automate the barbarian's Grim Determination if 2e is enabled.
-- Add bonuses to each ability score skill check to magic items.
+- Add fields for bonuses to each ability score skill check to magic items.
+- Also add magic items bonus to disengage checks to initiative if 2e is enabled.
 - Support up to 5 special rolls in monster actions.
 - Rename `Omega` tier to `Iconic`.
 - Move death save failures and all resource resets from combat deletion to rests; 'skulls' only reset down to 1 if 2e is enabled.
 - Add 11th level field to powers.
-- Add modifier (alt) use powers at +1 level.
-- Add Associated Icon field to magic items.
-- Add Reroll vs. AC and Reroll Save bonuses to magic items, and automate their tracking and usage on a new character sheet panel.
+- Add modifier (alt) to use powers at +1 level.
+- Add `Associated Icon` field to magic items.
+- Add `Reroll vs. AC` and `Reroll Save` bonuses to magic items, and automate their tracking and usage on a new character sheet panel.
 - Move disengage to defenses panel and bonus to settings.
-- Add dialog to easily set disengage penalties when engaged to multiple foes.
+- Add dialog to easily specify circumstantial disengage penalties when engaged to multiple foes.
 - Auto-set additional class (custom) resources if 2e enabled.
 - Adjust 2e ability scores hint.
 - Automate combat rhythm rolling 2d20 when using a maneuver of the correct type.
 
 ## Bug Fixes
-- Fixed a previous feature that auto-sets token size on monster size change.
+- Fixed and reworked a previous feature that auto-sets token size on monster size change.
 - Updated character sheets to display even level spell rows on powers if 2e is enabled and they're not empty.
 
 ## Features

--- a/release-notes/1.30.0.md
+++ b/release-notes/1.30.0.md
@@ -45,6 +45,7 @@ We've added support for the 2e Beta Packet rules to the system! Currently, this 
 ## Bug Fixes
 - Fixed and reworked a previous feature that auto-sets token size on monster size change.
 - Updated character sheets to display even level spell rows on powers if 2e is enabled and they're not empty.
+- Fixed the Active Effect's disengage modifier being applied to the wrong property under the hood.
 
 ## Features
 - Parse the `always` content for something like `Retain focus: <N>-<M>`

--- a/release-notes/1.30.0.md
+++ b/release-notes/1.30.0.md
@@ -1,0 +1,18 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.30.0/system.json
+
+## Compatible Foundry versions
+
+![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12.327](https://img.shields.io/badge/Foundry-v12.327-green)
+
+**Note**: This system includes both support for Foundry v12 and the 13th Age 2e beta packet rules. Backup before updating!
+
+## Bug Fixes
+- TBD
+
+## Features
+- TBD
+
+## Content Updates
+- TBD

--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -262,6 +262,7 @@ ARCHMAGE:
       recovery: Recovery
       rerollAc: Reroll vs. AC
       rerollAcDesc: Reroll an attack that targeted your AC
+      rerolls: Rerolls
       rerollSave: Reroll Save
       rerollSaveDesc: Reroll a save
       rhythm: Combat Rhythm

--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -780,7 +780,7 @@ ARCHMAGE:
     '1_24_0': "13th Age 1.24.0: Updating PC initiative to remove the Improved Initiative flag."
     '1_25_0': "13th Age 1.25.0: Updating Powers cost field to new resources syntax."
     '1_26_0': "13th Age 1.26.0: Updating Powers feat structure."
-    '1_31_0': "13th Age 1.31.0: Updating NPC actors to separate Size and Strength."
+    '1_30_0': "13th Age 1.30.0: Updating NPC actors to separate Size and Strength."
   TOOLTIP:
     portrait: Portrait image.<br>Click to edit (may need permissions).
     pcAbility: |

--- a/src/module/active-effects/effect-sheet.js
+++ b/src/module/active-effects/effect-sheet.js
@@ -100,7 +100,7 @@ export class EffectArchmageSheet extends ActiveEffectConfig {
     addChange("system.attributes.hp.max");
     addChange("system.attributes.recoveries.value");
     addChange("system.attributes.saves.bonus");
-    addChange("system.attributes.disengage");
+    addChange("system.attributes.disengageBonus");
     addChange("system.attributes.critMod.def.value");
 
     // Update the existing changes to replace duplicates.

--- a/src/scripts/migrate/archmage-updates.js
+++ b/src/scripts/migrate/archmage-updates.js
@@ -159,7 +159,7 @@ class ArchmageUpdateHandler {
     }
 
     // Append NPC migration for version 1.31.0
-    if (this.versionBelow('1.31.0')) {
+    if (this.versionBelow('1.30.0')) {
       updateData = this.__migrateNPCSplitSizeStrength(actor, updateData);
     }
 
@@ -390,7 +390,7 @@ class ArchmageUpdateHandler {
   async executeMigration() {
     // Exit early if the version matches.
     // @todo Update this for each new version that requires a migration.
-    if (!this.versionBelow('1.31.0')) {
+    if (!this.versionBelow('1.30.0')) {
       return;
     }
 
@@ -419,8 +419,8 @@ class ArchmageUpdateHandler {
       ui.notifications.info(game.i18n.localize('ARCHMAGE.MIGRATIONS.1_26_0'), {permanent: true});
     }
 
-    if (this.versionBelow('1.31.0')) {
-      ui.notifications.info(game.i18n.localize('ARCHMAGE.MIGRATIONS.1_31_0'), {permanent: true});
+    if (this.versionBelow('1.30.0')) {
+      ui.notifications.info(game.i18n.localize('ARCHMAGE.MIGRATIONS.1_30_0'), {permanent: true});
     }
 
     // 1. Update world actors.

--- a/src/scripts/migrate/archmage-updates.js
+++ b/src/scripts/migrate/archmage-updates.js
@@ -534,7 +534,8 @@ class ArchmageUpdateHandler {
 
   async migrateCompendiums() {
     for ( let pack of game.packs ) {
-      if ( pack.metadata.packageType !== "world" ) continue;
+      // Skip compendiums that ship with the system.
+      if ( pack.metadata.packageType == "system" ) continue;
       // if ( pack.metadata.packageType !== "system" ) continue; // Auto-update system compendiums
       if ( !["Actor", "Scene", "Item"].includes(pack.documentName) ) continue;
 

--- a/src/scripts/migrate/archmage-updates.js
+++ b/src/scripts/migrate/archmage-updates.js
@@ -158,7 +158,7 @@ class ArchmageUpdateHandler {
       updateData = this.__migratePCImprovedInitFlag(actor, updateData);
     }
 
-    // Append NPC migration for version 1.31.0
+    // Append NPC migration for version 1.30.0
     if (this.versionBelow('1.30.0')) {
       updateData = this.__migrateNPCSplitSizeStrength(actor, updateData);
     }
@@ -331,7 +331,7 @@ class ArchmageUpdateHandler {
   /* -------------------------------------------*/
 
   /**
-   * 1.31.0: Update NPC structure to separate strength and size.
+   * 1.30.0: Update NPC structure to separate strength and size.
    *
    * @param {object} actor Actor document to update.
    * @param {object} updateData Update data object to merge changes into.

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -1,7 +1,7 @@
 name: archmage
 id: archmage
 title: 13th Age
-version: "1.29.3"
+version: "1.30.0"
 authors:
   - name: Matt Smith
     discord: asacolips#1867
@@ -279,7 +279,7 @@ languages:
 socket: true
 url: https://github.com/asacolips-projects/13th-age
 manifest: https://asacolips-artifacts.s3.amazonaws.com/archmage/latest/system.json
-download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.29.3/archmage.zip
+download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.30.0/archmage.zip
 changelog: https://github.com/asacolips-projects/13th-age/blob/main/CHANGELOG.md
 initiative: 1d20 + (@abilities?.dex.mod || 0) + @attributes.init.value + @attributes.level.value
 gridDistance: "1"

--- a/src/templates/active-effects/effect.html
+++ b/src/templates/active-effects/effect.html
@@ -153,7 +153,7 @@
 
                     <div class="settings-group">
                         <strong class="attribute-name">{{localize 'ARCHMAGE.ITEM.disengageBonus'}}</strong>
-                        <input class="attribute-input" name="system.attributes.disengage" type="text" value="{{system.attributes.disengage}}"
+                        <input class="attribute-input" name="system.attributes.disengageBonus" type="text" value="{{system.attributes.disengageBonus}}"
                                data-dtype="Number" placeholder="0" />
                     </div>
                     {{/unless}}


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.30.0/system.json

## Compatible Foundry versions

![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12.327](https://img.shields.io/badge/Foundry-v12.327-green)

**Note**: This system update includes both support for Foundry v12 and the 13th Age 2e beta packet rules. Backup before updating!

## Foundry v12
Added support for Foundry v12 to the system. This was implemented in a way such that we didn't have to disable v11 support, so you'll still see warnings in your console for API calls that were deprecated as of v12. Those will go away in a future version when we will remove v11 support.

## 2e Beta Packet Support
We've added support for the 2e Beta Packet rules to the system! Currently, this is only _mechanical_ support. Unlike the alpha packet, we will eventually have compendium content to go along with the playable draft rules, but we're currently targeting the upcoming Gamma Packet rather than the Beta Packet for a backer-exclusive module. The system's eventual public version of the 2e compendium content will be dependent on the timeline of the final rules and their accompanying SRD.

- Updated NPC data structure and sheet to separate size from strength. This also includes a migration to update existing actors to use the new format.
- Updated NPC sheet header to wrap if it has too many properties (size, level, strength, etc.). This is most common for triple-strength aberrations due to the text length of those two properties.
- Adjust base stat auto-configuration to reflect changes in the beta packet if 2e is enabled.
- Update epic tier weapon damage and recovery scaling to use flat 10/20/30 bonuses if 2e is enabled.
- Update conditions if 2e is enabled.
    - Add new Charmed and Frenzied conditions.
    - Update Vulnerable, Confused, Stunned and Hindered conditions.
- Rename `daily` to `arc` if 2e is enabled.
    - Note: macros will continue to use the internal name `daily`, but the UI will show the new name.
- Support 2e style breath weapon spells if 2e enabled.
    - Disable recently added breath reminder.
    - Automatically add E.D. to breath spell's crit range.
- Add a character flag to automate the barbarian's Grim Determination if 2e is enabled.
- Add fields for bonuses to each ability score skill check to magic items.
- Also add magic items bonus to disengage checks to initiative if 2e is enabled.
- Support up to 5 special rolls in monster actions.
- Rename `Omega` tier to `Iconic`.
- Move death save failures and all resource resets from combat deletion to rests; 'skulls' only reset down to 1 if 2e is enabled.
- Add 11th level field to powers.
- Add modifier (alt) to use powers at +1 level.
- Add `Associated Icon` field to magic items.
- Add `Reroll vs. AC` and `Reroll Save` bonuses to magic items, and automate their tracking and usage on a new character sheet panel.
- Move disengage to defenses panel and bonus to settings.
- Add dialog to easily specify circumstantial disengage penalties when engaged to multiple foes.
- Auto-set additional class (custom) resources if 2e enabled.
- Adjust 2e ability scores hint.
- Automate combat rhythm rolling 2d20 when using a maneuver of the correct type.

## Bug Fixes
- Fixed and reworked a previous feature that auto-sets token size on monster size change.
- Updated character sheets to display even level spell rows on powers if 2e is enabled and they're not empty.
- Fixed the Active Effect's disengage modifier being applied to the wrong property under the hood.

## Features
- Parse the `always` content for something like `Retain focus: <N>-<M>`
  - If present, recognize natural rolls in that range and do not change the focus value.
  - Highlight the output chat card's "always" field if this has happened.

## Credits

Thanks go out to @ben, @LegoFed3, and @asacolips for their contributions in this release!