### PR TITLE
Bugfix for decreasing AC on Foundry v12

### DIFF
--- a/src/module/actor/actor-sheet-v2.js
+++ b/src/module/actor/actor-sheet-v2.js
@@ -1083,4 +1083,22 @@ export class ActorArchmageSheetV2 extends ActorSheet {
       actor.createEmbeddedDocuments('Item', powers);
     }
   }
+
+  /** @override */
+  _getSubmitData(updateData={}) {
+    // Bugfix for Foundry v12.
+    if (foundry.utils.isNewerVersion(game.version, '12')) {
+      // Retrieve the data from the upstream method.
+      let data = super._getSubmitData(updateData);
+      // Retrieve a copy of the existing actor data.
+      let old = foundry.utils.flattenObject(this.object);
+  
+      // Limit data to just the new data.
+      return foundry.utils.diffObject(old, data);
+    }
+    // Keep old behavior for v11.
+    else {
+      return super._getSubmitData(updateData);
+    }
+  }
 }

--- a/src/module/actor/actor-sheet-v2.js
+++ b/src/module/actor/actor-sheet-v2.js
@@ -1089,12 +1089,12 @@ export class ActorArchmageSheetV2 extends ActorSheet {
     // Bugfix for Foundry v12.
     if (foundry.utils.isNewerVersion(game.version, '12')) {
       // Retrieve the data from the upstream method.
-      let data = super._getSubmitData(updateData);
+      let newData = super._getSubmitData(updateData);
       // Retrieve a copy of the existing actor data.
-      let old = foundry.utils.flattenObject(this.object);
+      let oldData = foundry.utils.flattenObject(this.object);
   
       // Limit data to just the new data.
-      return foundry.utils.diffObject(old, data);
+      return foundry.utils.diffObject(oldData, newData);
     }
     // Keep old behavior for v11.
     else {


### PR DESCRIPTION
- Added override for the `_getSubmitData()` method of the actor sheet to return a diff of the form data on v12. This appears to be a regression with how form data is returned on v12, and so there's a version check to allow the existing behavior to keep working on v11.