### PR TITLE
Release 1.30.1

### DIFF
--- a/release-notes/1.30.1.md
+++ b/release-notes/1.30.1.md
@@ -1,0 +1,12 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.30.1/system.json
+
+## Compatible Foundry versions
+
+![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12.327](https://img.shields.io/badge/Foundry-v12.327-green)
+
+**Note**: This system update includes both support for Foundry v12 and the 13th Age 2e beta packet rules. Backup before updating!
+
+## Bug Fixes
+- Fixed a bug where AC constantly decreased on Foundry v12.

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -1,7 +1,7 @@
 name: archmage
 id: archmage
 title: 13th Age
-version: "1.30.0"
+version: "1.30.1"
 authors:
   - name: Matt Smith
     discord: asacolips#1867
@@ -279,7 +279,7 @@ languages:
 socket: true
 url: https://github.com/asacolips-projects/13th-age
 manifest: https://asacolips-artifacts.s3.amazonaws.com/archmage/latest/system.json
-download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.30.0/archmage.zip
+download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.30.1/archmage.zip
 changelog: https://github.com/asacolips-projects/13th-age/blob/main/CHANGELOG.md
 initiative: 1d20 + (@abilities?.dex.mod || 0) + @attributes.init.value + @attributes.level.value
 gridDistance: "1"


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.30.1/system.json

## Compatible Foundry versions

![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12.327](https://img.shields.io/badge/Foundry-v12.327-green)

**Note**: This system update includes both support for Foundry v12 and the 13th Age 2e beta packet rules. Backup before updating!

## Bug Fixes
- Fixed a bug where AC constantly decreased on Foundry v12.