### PR TITLE
Fix missing SRD monster entries

### DIFF
--- a/src/packs/src/srd-monsters/Barbed_Vines_aiQAeHLj31uboPt5.yml
+++ b/src/packs/src/srd-monsters/Barbed_Vines_aiQAeHLj31uboPt5.yml
@@ -1,5 +1,6 @@
 name: Barbed Vines
 type: npc
+_id: aiQAeHLj31uboPt5
 img: systems/archmage/assets/icons/tokens/monsters/plant.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Big_Flux_Elemental_VOMmPqrT2EuYGHKb.yml
+++ b/src/packs/src/srd-monsters/Big_Flux_Elemental_VOMmPqrT2EuYGHKb.yml
@@ -1,5 +1,6 @@
 name: Big Flux Elemental
 type: npc
+_id: VOMmPqrT2EuYGHKb
 img: systems/archmage/assets/icons/tokens/monsters/elemental.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Bone_Imp_Archer_GsaLjhm6bCOc374O.yml
+++ b/src/packs/src/srd-monsters/Bone_Imp_Archer_GsaLjhm6bCOc374O.yml
@@ -1,5 +1,6 @@
 name: Bone Imp Archer
 type: npc
+_id: GsaLjhm6bCOc374O
 img: systems/archmage/assets/icons/tokens/monsters/demon.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Bone_Imp_Mage_Eater_yKsOGGsL2JnQIEln.yml
+++ b/src/packs/src/srd-monsters/Bone_Imp_Mage_Eater_yKsOGGsL2JnQIEln.yml
@@ -1,5 +1,6 @@
 name: Bone Imp Mage-Eater
 type: npc
+_id: yKsOGGsL2JnQIEln
 img: systems/archmage/assets/icons/tokens/monsters/demon.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Bone_Imp_Skullbiter_4DXoOYTwXyTkcn3w.yml
+++ b/src/packs/src/srd-monsters/Bone_Imp_Skullbiter_4DXoOYTwXyTkcn3w.yml
@@ -1,5 +1,6 @@
 name: Bone Imp Skullbiter
 type: npc
+_id: 4DXoOYTwXyTkcn3w
 img: systems/archmage/assets/icons/tokens/monsters/demon.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Bone_Imp_Tormentor_LoCY28MBhLmEXpNy.yml
+++ b/src/packs/src/srd-monsters/Bone_Imp_Tormentor_LoCY28MBhLmEXpNy.yml
@@ -1,5 +1,6 @@
 name: Bone Imp Tormentor
 type: npc
+_id: LoCY28MBhLmEXpNy
 img: systems/archmage/assets/icons/tokens/monsters/demon.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Briar_Elf_Assassin_0CdcNIeN2QEM0rSK.yml
+++ b/src/packs/src/srd-monsters/Briar_Elf_Assassin_0CdcNIeN2QEM0rSK.yml
@@ -1,5 +1,6 @@
 name: Briar Elf Assassin
 type: npc
+_id: 0CdcNIeN2QEM0rSK
 img: systems/archmage/assets/icons/tokens/monsters/humanoid.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Briar_Elf_Slayer_ru2KadKILTLgFzc4.yml
+++ b/src/packs/src/srd-monsters/Briar_Elf_Slayer_ru2KadKILTLgFzc4.yml
@@ -1,5 +1,6 @@
 name: Briar Elf Slayer
 type: npc
+_id: ru2KadKILTLgFzc4
 img: systems/archmage/assets/icons/tokens/monsters/humanoid.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Briar_Elf_Sorcerer_Ev8kF94zDseE8Wva.yml
+++ b/src/packs/src/srd-monsters/Briar_Elf_Sorcerer_Ev8kF94zDseE8Wva.yml
@@ -1,5 +1,6 @@
 name: Briar Elf Sorcerer
 type: npc
+_id: Ev8kF94zDseE8Wva
 img: systems/archmage/assets/icons/tokens/monsters/humanoid.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Briar_Elf_Sovereign_JtzTaTZD1dGKWWiN.yml
+++ b/src/packs/src/srd-monsters/Briar_Elf_Sovereign_JtzTaTZD1dGKWWiN.yml
@@ -1,5 +1,6 @@
 name: Briar Elf Sovereign
 type: npc
+_id: JtzTaTZD1dGKWWiN
 img: systems/archmage/assets/icons/tokens/monsters/humanoid.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Briar_Elf_Stalker_3Hy9FJ1iym1SKrXM.yml
+++ b/src/packs/src/srd-monsters/Briar_Elf_Stalker_3Hy9FJ1iym1SKrXM.yml
@@ -1,5 +1,6 @@
 name: Briar Elf Stalker
 type: npc
+_id: 3Hy9FJ1iym1SKrXM
 img: systems/archmage/assets/icons/tokens/monsters/humanoid.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Briar_Elf_Warrior_HgoLiefMFANQmDtA.yml
+++ b/src/packs/src/srd-monsters/Briar_Elf_Warrior_HgoLiefMFANQmDtA.yml
@@ -1,5 +1,6 @@
 name: Briar Elf Warrior
 type: npc
+_id: HgoLiefMFANQmDtA
 img: systems/archmage/assets/icons/tokens/monsters/humanoid.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Briar_Tree_hWeK3ukWMNbf0QuB.yml
+++ b/src/packs/src/srd-monsters/Briar_Tree_hWeK3ukWMNbf0QuB.yml
@@ -1,5 +1,6 @@
 name: Briar Tree
 type: npc
+_id: hWeK3ukWMNbf0QuB
 img: systems/archmage/assets/icons/tokens/monsters/plant.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Coin_Collector_Zombie_SVktQNf3ZxOYxAxQ.yml
+++ b/src/packs/src/srd-monsters/Coin_Collector_Zombie_SVktQNf3ZxOYxAxQ.yml
@@ -1,5 +1,6 @@
 name: Coin Collector Zombie
 type: npc
+_id: SVktQNf3ZxOYxAxQ
 img: systems/archmage/assets/icons/tokens/monsters/undead.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Coin_Zombie_clCdy1qTfHeM5CER.yml
+++ b/src/packs/src/srd-monsters/Coin_Zombie_clCdy1qTfHeM5CER.yml
@@ -1,5 +1,6 @@
 name: Coin Zombie
 type: npc
+_id: clCdy1qTfHeM5CER
 img: systems/archmage/assets/icons/tokens/monsters/undead.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Derro_Berserker_FwVWLmUQAGzVMBYQ.yml
+++ b/src/packs/src/srd-monsters/Derro_Berserker_FwVWLmUQAGzVMBYQ.yml
@@ -1,5 +1,6 @@
 name: Derro Berserker
 type: npc
+_id: FwVWLmUQAGzVMBYQ
 img: systems/archmage/assets/icons/tokens/monsters/humanoid.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Elemental_Beast_Template__Earth_06cof8vebYAe2YRf.yml
+++ b/src/packs/src/srd-monsters/Elemental_Beast_Template__Earth_06cof8vebYAe2YRf.yml
@@ -1,5 +1,6 @@
 name: 'Elemental Beast Template: Earth'
 type: npc
+_id: dPromlCaBfcllsNo
 img: systems/archmage/assets/icons/tokens/monsters/token-neutral.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Elemental_Beast_Template__Earth_06cof8vebYAe2YRf.yml
+++ b/src/packs/src/srd-monsters/Elemental_Beast_Template__Earth_06cof8vebYAe2YRf.yml
@@ -1,6 +1,6 @@
 name: 'Elemental Beast Template: Earth'
 type: npc
-_id: dPromlCaBfcllsNo
+_id: 06cof8vebYAe2YRf
 img: systems/archmage/assets/icons/tokens/monsters/token-neutral.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Elemental_Beast_Template__Fire_FWOn0j9F14gpCIx7.yml
+++ b/src/packs/src/srd-monsters/Elemental_Beast_Template__Fire_FWOn0j9F14gpCIx7.yml
@@ -1,6 +1,6 @@
 name: 'Elemental Beast Template: Fire'
 type: npc
-_id: dPromlCaBfcllsNp
+_id: FWOn0j9F14gpCIx7
 img: systems/archmage/assets/icons/tokens/monsters/token-neutral.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Elemental_Beast_Template__Fire_FWOn0j9F14gpCIx7.yml
+++ b/src/packs/src/srd-monsters/Elemental_Beast_Template__Fire_FWOn0j9F14gpCIx7.yml
@@ -1,5 +1,6 @@
 name: 'Elemental Beast Template: Fire'
 type: npc
+_id: dPromlCaBfcllsNp
 img: systems/archmage/assets/icons/tokens/monsters/token-neutral.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Elemental_Beast_Template__Water_5TdeF9aaOt6uB5K7.yml
+++ b/src/packs/src/srd-monsters/Elemental_Beast_Template__Water_5TdeF9aaOt6uB5K7.yml
@@ -1,6 +1,6 @@
 name: 'Elemental Beast Template: Water'
 type: npc
-_id: dPromlCaBfcllsNq
+_id: 5TdeF9aaOt6uB5K7
 img: systems/archmage/assets/icons/tokens/monsters/token-neutral.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Elemental_Beast_Template__Water_5TdeF9aaOt6uB5K7.yml
+++ b/src/packs/src/srd-monsters/Elemental_Beast_Template__Water_5TdeF9aaOt6uB5K7.yml
@@ -1,5 +1,6 @@
 name: 'Elemental Beast Template: Water'
 type: npc
+_id: dPromlCaBfcllsNq
 img: systems/archmage/assets/icons/tokens/monsters/token-neutral.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Epic_Flux_Elemental_YV2YxlxTm5J2F7hS.yml
+++ b/src/packs/src/srd-monsters/Epic_Flux_Elemental_YV2YxlxTm5J2F7hS.yml
@@ -1,5 +1,6 @@
 name: Epic Flux Elemental
 type: npc
+_id: YV2YxlxTm5J2F7hS
 img: systems/archmage/assets/icons/tokens/monsters/elemental.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Great_Horned_Owlbear_J4f9G9GgZjWAw6jC.yml
+++ b/src/packs/src/srd-monsters/Great_Horned_Owlbear_J4f9G9GgZjWAw6jC.yml
@@ -1,5 +1,6 @@
 name: Great Horned Owlbear
 type: npc
+_id: J4f9G9GgZjWAw6jC
 img: systems/archmage/assets/icons/tokens/monsters/beast.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Greater_Flux_Elemental_QBe6bc5EOVvLAobX.yml
+++ b/src/packs/src/srd-monsters/Greater_Flux_Elemental_QBe6bc5EOVvLAobX.yml
@@ -1,5 +1,6 @@
 name: Greater Flux Elemental
 type: npc
+_id: QBe6bc5EOVvLAobX
 img: systems/archmage/assets/icons/tokens/monsters/elemental.webp
 system:
   attributes:

--- a/src/packs/src/srd-monsters/Jackpot_Zombie_1F9umoT78QHO2idd.yml
+++ b/src/packs/src/srd-monsters/Jackpot_Zombie_1F9umoT78QHO2idd.yml
@@ -1,5 +1,6 @@
 name: Jackpot Zombie
 type: npc
+_id: 1F9umoT78QHO2idd
 img: systems/archmage/assets/icons/tokens/monsters/undead.webp
 system:
   attributes:


### PR DESCRIPTION
Fixes #445. We've got YAML for them, but they don't have `_id` fields at the top level for whatever reason. Here's a list of things to fix that I found by running `npm run build | grep undefined`:

- [x] Elemental beast template: earth
- [x] Elemental beast template: fire
- [x] Elemental beast template: water
- [x] Barbed Vines
- [x] Big Flux Elemental
- [x] Bone Imp Archer
- [x] Bone Imp Mage-Eater
- [x] Bone Imp Skullbiter
- [x] Bone Imp Tormentor
- [x] Briar Elf Assassin
- [x] Briar Elf Slayer
- [x] Briar Elf Sorcerer
- [x] Briar Elf Sovereign
- [x] Briar Elf Stalker
- [x] Briar Elf Warrior
- [x] Briar Tree
- [x] Coin Collector Zombie
- [x] Coin Zombie
- [x] Derro Berserker
- [x] Epic Flux Elemental
- [x] Great Horned Owlbear
- [x] Greater Flux Elemental
- [x] Jackpot Zombie