### PR TITLE
Disengage fix for v12

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -858,7 +858,7 @@ export class ActorArchmage extends Actor {
     // Inner roll function
     let rollMode = game.settings.get("core", "rollMode");
     let rolled = false;
-    let roll = (html = null, data = {}) => {
+    let roll = async (html = null, data = {}) => {
       // Don't include situational bonus unless it is defined
       if (!data.bonus && terms.indexOf('@bonus') !== -1) {
         terms.pop();
@@ -872,7 +872,8 @@ export class ActorArchmage extends Actor {
       rollMode = form ? form.rollMode.value : rollMode;
 
       // Execute the roll
-      let roll = new Roll(terms.join('+'), data).roll({async: false});
+      let roll = new Roll(terms.join('+'), data);
+      await roll.evaluate({async: true});
 
       // Determine the roll result.
       let rollResult = roll.total;
@@ -887,6 +888,7 @@ export class ActorArchmage extends Actor {
         user: game.user.id,
         type: CONST.CHAT_MESSAGE_TYPES.ROLL,
         roll: roll,
+        rolls: [roll],
         speaker: game.archmage.ArchmageUtility.getSpeaker(this)
       };
 

--- a/src/module/actor/dice.js
+++ b/src/module/actor/dice.js
@@ -59,7 +59,7 @@ export class DiceArchmage {
     // Inner roll function
     let rollMode = game.settings.get("core", "rollMode");
     let rolled = false;
-    let roll = (html = null, data = {}) => {
+    let roll = async (html = null, data = {}) => {
       let flav = (flavor instanceof Function) ? flavor(terms, data) : title;
 
       // Don't include situational bonus unless it is defined
@@ -86,7 +86,8 @@ export class DiceArchmage {
       rollMode = form ? form.rollMode.value : rollMode;
 
       // Execute the roll
-      let roll = new Roll(terms.join('+'), data).roll({async: false});
+      let roll = new Roll(terms.join('+'), data);
+      await roll.evaluate({async: true});
 
       // Grab the template.
       const template = `systems/archmage/templates/chat/skill-check-card.html`;
@@ -97,6 +98,7 @@ export class DiceArchmage {
         user: game.user.id,
         type: CONST.CHAT_MESSAGE_TYPES.ROLL,
         roll: roll,
+        rolls: [roll],
         speaker: game.archmage.ArchmageUtility.getSpeaker(actor)
       };
 


### PR DESCRIPTION
This fixes the disengage rolls in Foundry v12, which had been throwing this warning:

```
Error: CONST.CHAT_MESSAGE_STYLES.ROLL is deprecated in favor of defining rolls directly in ChatMessage#rolls
Deprecated since Version 12
```

…and failing to roll and resolve in the chat message. I think the main thing here is that all rolling is async now, but I also included the v12-style `rolls: []` in the chat message payload.