### PR TITLE
Release 1.30.2

### DIFF
--- a/release-notes/1.30.2.md
+++ b/release-notes/1.30.2.md
@@ -1,0 +1,21 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.30.2/system.json
+
+## Compatible Foundry versions
+
+![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12.327](https://img.shields.io/badge/Foundry-v12.327-green)
+
+**Note**: This system update includes both support for Foundry v12 and the 13th Age 2e beta packet rules. Backup before updating!
+
+## Bug Fixes
+- Fixed several bugs related to Foundry v12:
+    - Disegage checks now take into account bonuses, modifiers and Active Effects modifying them.
+    - Skill checks now work again.
+- Fixed powers not being rollable to chat from npcs (for the rare ones that use them).
+- Added missing `_id` to several SRD monster entries, which can no longer hide from the gaze of our compendium browser.
+    
+
+## Credits
+
+Thanks go out to @ben and @LegoFed3 for their contributions in this release!

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -1,7 +1,7 @@
 name: archmage
 id: archmage
 title: 13th Age
-version: "1.30.1"
+version: "1.30.2"
 authors:
   - name: Matt Smith
     discord: asacolips#1867


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.30.2/system.json

## Compatible Foundry versions

![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12.327](https://img.shields.io/badge/Foundry-v12.327-green)

**Note**: This system update includes both support for Foundry v12 and the 13th Age 2e beta packet rules. Backup before updating!

## Bug Fixes
- Fixed several bugs related to Foundry v12:
    - Disegage checks now take into account bonuses, modifiers and Active Effects modifying them.
    - Skill checks now work again.
- Fixed powers not being rollable to chat from npcs (for the rare ones that use them).
- Added missing `_id` to several SRD monster entries, which can no longer hide from the gaze of our compendium browser.


## Credits

Thanks go out to @ben and @LegoFed3 for their contributions in this release!