### PR TITLE
Bugfix for token resource updates on v12

### DIFF
--- a/src/module/Triggers/CritTrigger.mjs
+++ b/src/module/Triggers/CritTrigger.mjs
@@ -2,7 +2,6 @@ import ITrigger from "./ITrigger.mjs";
 
 export default class CritTrigger extends ITrigger{
     isActive(triggerText, rollResult, hitEvaluationResults) {
-        // console.log(rollResult);
         let active = undefined;
 
         if (rollResult == undefined) return active;

--- a/src/module/actor/actor-sheet-v2.js
+++ b/src/module/actor/actor-sheet-v2.js
@@ -1087,7 +1087,7 @@ export class ActorArchmageSheetV2 extends ActorSheet {
   /** @override */
   _getSubmitData(updateData={}) {
     // Bugfix for Foundry v12.
-    if (foundry.utils.isNewerVersion(game.version, '12')) {
+    if (game.release.version >= 12) {
       // Retrieve the data from the upstream method.
       let newData = super._getSubmitData(updateData);
       // Retrieve a copy of the existing actor data.

--- a/src/module/actor/actor-sheet-v2.js
+++ b/src/module/actor/actor-sheet-v2.js
@@ -500,7 +500,7 @@ export class ActorArchmageSheetV2 extends ActorSheet {
    */
   async _onFormulaRoll(formula) {
     let roll = new Roll(formula, this.actor.getRollData());
-    await roll.roll({async: true});
+    await roll.roll();
     roll.toMessage();
   }
 
@@ -590,7 +590,7 @@ export class ActorArchmageSheetV2 extends ActorSheet {
     if (actorData.icons[iconIndex]) {
       let icon = actorData.icons[iconIndex];
       let roll = new Roll(`${icon.bonus.value}d6`);
-      let result = await roll.roll({async: true});
+      let result = await roll.roll();
 
       let fives = 0;
       let sixes = 0;
@@ -643,7 +643,7 @@ export class ActorArchmageSheetV2 extends ActorSheet {
 
       // Update actor.
       let updateData = {};
-      updateData[`data.icons.${iconIndex}.results`] = actorIconResults;
+      updateData[`system.icons.${iconIndex}.results`] = actorIconResults;
       await this.actor.update(updateData);
 
       // Card support
@@ -704,7 +704,7 @@ export class ActorArchmageSheetV2 extends ActorSheet {
   async _onCommandRoll(dice) {
     let actor = this.actor;
     let roll = new Roll(dice, this.actor.getRollData());
-    await roll.roll({async: true});
+    await roll.roll();
 
     let pointsOld = actor.system.resources.perCombat.commandPoints.current;
     let pointsNew = roll.total;
@@ -807,7 +807,7 @@ export class ActorArchmageSheetV2 extends ActorSheet {
         count = Math.max(0, count - 1);
       }
       let updateData = {};
-      let path = `data.attributes.saves.${saveType}.value`;
+      let path = `system.attributes.saves.${saveType}.value`;
       updateData[path] = count;
       let update = await this.actor.update(updateData);
     }

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -1699,6 +1699,14 @@ export class ActorArchmage extends Actor {
     await super._preUpdate(data, options, userId);
     if (!options.diff || data === undefined) return; // Nothing to do
 
+    // @todo Bizarre bug in v12 where token updates come through as data.data
+    // instead of data.system.
+    if (game.release.generation >= 12) {
+      if (data?.data && !data?.system) {
+        data.system = data.data;
+      }
+    }
+
     // Update default images on npc type change
     if (data.system?.details?.type?.value
       && this.type == "npc"

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -772,7 +772,7 @@ export class ActorArchmage extends Actor {
     let bonus = this.system.attributes.saves.bonus;
     if (bonus != 0) formula = formula + "+" + bonus.toString();
     let roll = new Roll(formula);
-    let result = await roll.roll({async: true});
+    let result = await roll.roll();
 
     // Create the chat message title.
     let label = game.i18n.localize(`ARCHMAGE.SAVE.${difficulty}`);
@@ -873,7 +873,7 @@ export class ActorArchmage extends Actor {
 
       // Execute the roll
       let roll = new Roll(terms.join('+'), data);
-      await roll.evaluate({async: true});
+      await roll.evaluate();
 
       // Determine the roll result.
       let rollResult = roll.total;
@@ -1147,7 +1147,7 @@ export class ActorArchmage extends Actor {
 
       // Render the template
       chatData.content = await renderTemplate(template, templateData);
-      chatData.content = await TextEditor.enrichHTML(chatData.content, { rollData: this.getRollData(), async: true });
+      chatData.content = await TextEditor.enrichHTML(chatData.content, { rollData: this.getRollData() });
       // Create the chat message
       msg = await game.archmage.ArchmageUtility.createChatMessage(chatData);
       // Get the roll from the chat message
@@ -1157,7 +1157,7 @@ export class ActorArchmage extends Actor {
       roll = Roll.fromJSON(unescape(roll_html.data('roll')));
     } else {
       // Perform the roll ourselves
-      await roll.roll({async: true});
+      await roll.roll();
     }
 
     // If 3d dice are enabled, handle them
@@ -1604,7 +1604,7 @@ export class ActorArchmage extends Actor {
         value = Number(current.value) + value;
         if ( current.value < 0 ) value -= current.value;
       }
-      let updates = {[`data.${attribute}.value`]: value};
+      let updates = {[`system.${attribute}.value`]: value};
       const allowed = Hooks.call("modifyTokenAttribute", {attribute, value, isDelta, isBar}, updates);
       return allowed !== false ? this.update(updates) : this;
     } else {
@@ -1698,14 +1698,6 @@ export class ActorArchmage extends Actor {
   async _preUpdate(data, options, userId) {
     await super._preUpdate(data, options, userId);
     if (!options.diff || data === undefined) return; // Nothing to do
-
-    // @todo Bizarre bug in v12 where token updates come through as data.data
-    // instead of data.system.
-    if (game.release.generation >= 12) {
-      if (data?.data && !data?.system) {
-        data.system = data.data;
-      }
-    }
 
     // Update default images on npc type change
     if (data.system?.details?.type?.value
@@ -1915,10 +1907,10 @@ export class ActorArchmage extends Actor {
         const effectData = {
           label: negRecoveryLabel,
           changes: [
-            {key: "data.attributes.ac.value",value: newRec, mode: CONST.ACTIVE_EFFECT_MODES.ADD},
-            {key: "data.attributes.pd.value", value: newRec, mode: CONST.ACTIVE_EFFECT_MODES.ADD},
-            {key: "data.attributes.md.value", value: newRec, mode: CONST.ACTIVE_EFFECT_MODES.ADD},
-            {key: "data.attributes.attackMod.value", value: newRec, mode: CONST.ACTIVE_EFFECT_MODES.ADD}
+            {key: "system.attributes.ac.value",value: newRec, mode: CONST.ACTIVE_EFFECT_MODES.ADD},
+            {key: "system.attributes.pd.value", value: newRec, mode: CONST.ACTIVE_EFFECT_MODES.ADD},
+            {key: "system.attributes.md.value", value: newRec, mode: CONST.ACTIVE_EFFECT_MODES.ADD},
+            {key: "system.attributes.attackMod.value", value: newRec, mode: CONST.ACTIVE_EFFECT_MODES.ADD}
           ]
         };
         this.createEmbeddedDocuments("ActiveEffect", [effectData]);

--- a/src/module/actor/dice.js
+++ b/src/module/actor/dice.js
@@ -87,7 +87,7 @@ export class DiceArchmage {
 
       // Execute the roll
       let roll = new Roll(terms.join('+'), data);
-      await roll.evaluate({async: true});
+      await roll.evaluate();
 
       // Grab the template.
       const template = `systems/archmage/templates/chat/skill-check-card.html`;

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -1298,8 +1298,6 @@ Hooks.on('renderChatMessage', (chatMessage, html, options) => {
         const value = parent.dataset.value;
         // Healing always starts from 0 HP
         const base = value >= 0 ? actor.system.attributes.hp.value : Math.max(actor.system.attributes.hp.value, 0);
-        console.log(base);
-        console.log(actor);
         await actor.update({ "system.attributes.hp.value": base - value });
         if (chatMessage.isAuthor || game.user.isGM) await chatMessage.setFlag('archmage', `effectApplied.${effectId}`, true);
         else game.socket.emit('system.archmage', {type: 'condButton', msg: chatMessage.id, flg: `effectApplied.${effectId}`});

--- a/src/module/hooks/combat.mjs
+++ b/src/module/hooks/combat.mjs
@@ -1,6 +1,4 @@
 export async function combatTurn(combat, context, options) {
-    console.log("Combat Turn", combat.combatant.name, combat, context, options);
-
     // Exit early if the feature is disabled.
     if (!game.settings.get('archmage', 'enableOngoingEffectsMessages')) return;
 
@@ -16,8 +14,6 @@ export async function combatTurn(combat, context, options) {
 export async function handleTurnEffects(prefix, combat, combatant, context, options) {
 
     const saveEndsEffects = ["EasySaveEnds", "NormalSaveEnds", "HardSaveEnds"];
-    console.log(`Handling ${prefix} of Turn for combatant`, combatant.name, combatant, combat);
-
     const hasImplacable = combatant.actor.flags.archmage?.implacable ?? false;
     const currentCombatantEffectData = {
         selfEnded: [],
@@ -34,11 +30,9 @@ export async function handleTurnEffects(prefix, combat, combatant, context, opti
         if (effect.name === game.i18n.localize("ARCHMAGE.EFFECT.StatusDead")) isDead = true;
         const duration = effect.flags.archmage?.duration || "Unknown";
         if (duration === `${prefix}OfNextTurn`) {
-            console.log(`${prefix}OfNextTurn effect found`, effect);
             currentCombatantEffectData.selfEnded.push(effect);
             effectsToDelete.push(effect.id);
         } else if (saveEndsEffects.includes(duration) && (prefix == "End" || (prefix == "Start" && hasImplacable))) {
-            // console.log("SaveEnds effect found", effect, combatant);
             const isOngoing = effect.flags.archmage?.ongoingDamage != 0;
             effect.isOngoing = isOngoing;
             currentCombatantEffectData.savesEnds.push(effect);
@@ -57,7 +51,6 @@ export async function handleTurnEffects(prefix, combat, combatant, context, opti
         for (const effect of otherCombatant.actor.effects) {
             const duration = effect.flags.archmage?.duration || "Unknown";
             if (duration === `${prefix}OfNextSourceTurn` && effect.origin === combatant.actor.uuid) {
-                // console.log(`${prefix}OfNextSourceTurn effect found`, effect);
                 effect.otherName = otherCombatant.actor.name;
                 currentCombatantEffectData.otherEnded.push(effect);
                 effectsToDelete.push(effect.id);
@@ -67,7 +60,6 @@ export async function handleTurnEffects(prefix, combat, combatant, context, opti
         await otherCombatant.actor.deleteEmbeddedDocuments("ActiveEffect", effectsToDelete);
     }
 
-    // console.log("Current Combatant Effect Data", currentCombatantEffectData);
     if (!isDead) {
         await renderOngoingEffectsCard(`${prefix} of Turn Effects`, combatant, currentCombatantEffectData);
     }
@@ -176,7 +168,6 @@ async function renderOngoingEffectsCard(title, combatant, effectData) {
         unknown: effectData.unknown,
         hasUnknown: effectData.unknown.length > 0,
     };
-    // console.log("Render Data", renderData);
     const html = await renderTemplate(template, renderData);
 
     // Create a chat card

--- a/src/module/hooks/preCreateChatMessageHandler.mjs
+++ b/src/module/hooks/preCreateChatMessageHandler.mjs
@@ -187,7 +187,6 @@ export default class preCreateChatMessageHandler {
 
                 // Determine if this line is a "Trigger" - something like "Natural 16+:" or "Even Miss:"
                 var triggerText = row_text.toLowerCase();
-                //console.log(triggerText);
                 if (triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.natural").toLowerCase()) ||
                     triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.miss").toLowerCase() + ':') ||
                     triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.hit").toLowerCase() + ':') ||

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -67,11 +67,8 @@ export class ItemArchmage extends Item {
     // Get token.
     let token = this._rollGetToken(itemToRender);
 
-    console.log('Current:', itemToRender.toObject());
-
     // Render the chat card.
     let chatData = await this._rollRender(itemUpdateData, actorUpdateData, itemToRender, rollData, token);
-    console.log('Chat Data:', chatData);
 
     // Evaluate outcomes and prepare animations.
     let [ sequencerAnim, hitEvalRes ] = preCreateChatMessageHandler.handle(chatData, {
@@ -163,7 +160,7 @@ export class ItemArchmage extends Item {
 
     // Enrich the message to parse inline rolls.
     let rollData = this.actor.getRollData(this);
-    chatData.content = await TextEditor.enrichHTML(chatData.content, { rolls: true, rollData: rollData, async: true });
+    chatData.content = await TextEditor.enrichHTML(chatData.content, { rolls: true, rollData: rollData });
 
     // Perform updates.
     if (!foundry.utils.isEmpty(updateData)) this.update(updateData, {});
@@ -524,7 +521,7 @@ export class ItemArchmage extends Item {
     chatData["content"] = await renderTemplate(template, templateData);
 
     // Enrich the message to parse inline rolls.
-    chatData.content = await TextEditor.enrichHTML(chatData.content, { rolls: true, rollData: rollData, async: true });
+    chatData.content = await TextEditor.enrichHTML(chatData.content, { rolls: true, rollData: rollData });
 
     return chatData;
   }
@@ -629,7 +626,7 @@ export class ItemArchmage extends Item {
       name: game.i18n.localize("ARCHMAGE.MONKFORMS.aelabel"),
       img: "icons/svg/shield.svg",
       changes: [{
-        key: "data.attributes.ac.value",
+        key: "system.attributes.ac.value",
         value: bonusMagnitude,
         mode: CONST.ACTIVE_EFFECT_MODES.ADD
       }]

--- a/src/module/rolls/Targeting.mjs
+++ b/src/module/rolls/Targeting.mjs
@@ -21,8 +21,6 @@ export default class Targeting {
 
         if (numberOfTargets && numberOfTargets.length == 1) {
             let maxTargets = parseInt(numberOfTargets[0]);
-            //console.log("MaxTargets " + maxTargets);
-
             targets = targets.slice(0, maxTargets);
         }
 

--- a/src/module/setup/macros.js
+++ b/src/module/setup/macros.js
@@ -12,9 +12,9 @@ export class ArchmageMacros {
   static async aasimarHalo(speaker, actor, token, character, archmage) {
     const label = archmage.item.name;
     const effects = [
-      { key: "data.attributes.ac.value", value: 2, mode: CONST.ACTIVE_EFFECT_MODES.ADD },
-      { key: "data.attributes.pd.value", value: 2, mode: CONST.ACTIVE_EFFECT_MODES.ADD },
-      { key: "data.attributes.md.value", value: 2, mode: CONST.ACTIVE_EFFECT_MODES.ADD }
+      { key: "system.attributes.ac.value", value: 2, mode: CONST.ACTIVE_EFFECT_MODES.ADD },
+      { key: "system.attributes.pd.value", value: 2, mode: CONST.ACTIVE_EFFECT_MODES.ADD },
+      { key: "system.attributes.md.value", value: 2, mode: CONST.ACTIVE_EFFECT_MODES.ADD }
     ];
 
     // Check for previous effects
@@ -57,8 +57,8 @@ export class ArchmageMacros {
       label: archmage.item.name,
       icon: archmage.item.img,
       changes: [
-        { key: "data.attributes.ac.value", value: penalty, mode: CONST.ACTIVE_EFFECT_MODES.ADD },
-        { key: "data.attributes.pd.value", value: penalty, mode: CONST.ACTIVE_EFFECT_MODES.ADD }
+        { key: "system.attributes.ac.value", value: penalty, mode: CONST.ACTIVE_EFFECT_MODES.ADD },
+        { key: "system.attributes.pd.value", value: penalty, mode: CONST.ACTIVE_EFFECT_MODES.ADD }
       ]
     }
     game.archmage.MacroUtils.setDuration(effectData, CONFIG.ARCHMAGE.effectDurationTypes.StartOfNextTurn);
@@ -264,15 +264,15 @@ export class ArchmageMacros {
     // If the champion feat in active increase the bonus
     if (game.archmage.MacroUtils.getFeatsByTier(archmage.item, 'champion')[0].isActive.value) bonus = 3;
     let effects = [
-      { key: "data.attributes.ac.value", value: bonus, mode: CONST.ACTIVE_EFFECT_MODES.ADD }
+      { key: "system.attributes.ac.value", value: bonus, mode: CONST.ACTIVE_EFFECT_MODES.ADD }
     ];
     // If the adventurer feat in active apply to PD
     if (game.archmage.MacroUtils.getFeatsByTier(archmage.item, 'adventurer')[0].isActive.value) {
-      effects.push({ key: "data.attributes.pd.value", value: bonus, mode: CONST.ACTIVE_EFFECT_MODES.ADD });
+      effects.push({ key: "system.attributes.pd.value", value: bonus, mode: CONST.ACTIVE_EFFECT_MODES.ADD });
     }
     // If the epic feat in active apply to MD
     if (game.archmage.MacroUtils.getFeatsByTier(archmage.item, 'epic')[0].isActive.value) {
-      effects.push({ key: "data.attributes.md.value", value: bonus, mode: CONST.ACTIVE_EFFECT_MODES.ADD });
+      effects.push({ key: "system.attributes.md.value", value: bonus, mode: CONST.ACTIVE_EFFECT_MODES.ADD });
     }
 
     let effectData = { label: archmage.item.name, icon: archmage.item.img, changes: effects };


### PR DESCRIPTION
- Fixed remaining calls to `"data."` in actor and item update methods, which should hopefully be the last of the breaking v12 bugs.
- Fixed references to `{async: true}` in rolls. These were already being handled as async, but including the option caused a deprecation warning to appear.
- Removed a bunch of unnecessary `console.log()` calls.