### PR TITLE
Release 1.30.4

### DIFF
--- a/release-notes/1.30.4.md
+++ b/release-notes/1.30.4.md
@@ -1,0 +1,10 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.30.4/system.json
+
+## Compatible Foundry versions
+
+![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12.328](https://img.shields.io/badge/Foundry-v12.328-green)
+
+## Bug Fixes
+- [v12] Fixed a bug where too much data was being passed when using the damage applicator context menu, causing token HP to be wildly incorrect after applying damage.

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -1,7 +1,7 @@
 name: archmage
 id: archmage
 title: 13th Age
-version: "1.30.3"
+version: "1.30.4"
 authors:
   - name: Matt Smith
     discord: asacolips#1867
@@ -277,7 +277,7 @@ languages:
 socket: true
 url: https://github.com/asacolips-projects/13th-age
 manifest: https://asacolips-artifacts.s3.amazonaws.com/archmage/latest/system.json
-download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.30.3/archmage.zip
+download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.30.4/archmage.zip
 changelog: https://github.com/asacolips-projects/13th-age/releases
 initiative: 1d20 + (@abilities?.dex.mod || 0) + @attributes.init.value + @attributes.level.value
 gridDistance: "1"


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.30.4/system.json

## Compatible Foundry versions

![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12.328](https://img.shields.io/badge/Foundry-v12.328-green)

## Bug Fixes
- [v12] Fixed a bug where too much data was being passed when using the damage applicator context menu, causing token HP to be wildly incorrect after applying damage.