### PR TITLE
Inventory tab text rendering

### DIFF
--- a/src/vue/components/parts/Equipment.vue
+++ b/src/vue/components/parts/Equipment.vue
@@ -14,7 +14,9 @@
     <!-- Primary properties (attack, hit, effect, etc.). -->
     <section class="equipment-details flexcol">
       <div class="equipment-detail">
-        <span class="equipment-detail-value" v-html="equipment.system.description.value"></span>
+        <Suspense>
+          <Enriched tag="span" class="equipment-detail-value" :text="equipment.system.description.value" :diceFormulaMode="diceFormulaMode" />
+        </Suspense>
       </div>
     </section>
   </section>
@@ -22,9 +24,11 @@
 
 <script>
 import { concat, localize } from '@/methods/Helpers';
+import Enriched from '@/components/parts/Enriched.vue';
 export default {
   name: 'Equipment',
   props: ['equipment', 'bonuses'],
+  components: { Enriched },
   setup() {
     return {
       concat,
@@ -37,6 +41,9 @@ export default {
   computed: {
     constants() {
       return CONFIG.ARCHMAGE;
+    },
+    diceFormulaMode() {
+      return this.equipment?.actor?.flags?.archmage?.diceFormulaMode ?? 'short';
     },
   },
   methods: {},

--- a/src/vue/components/parts/Loot.vue
+++ b/src/vue/components/parts/Loot.vue
@@ -4,7 +4,7 @@
     <section class="equipment-details flexcol">
       <div class="equipment-detail">
         <Suspense>
-          <Enriched tag="span" :text="equipment.system.description.value" />
+          <Enriched tag="span" :text="equipment.system.description.value" :diceFormulaMode="diceFormulaMode" />
         </Suspense>
       </div>
     </section>
@@ -30,6 +30,9 @@ export default {
   computed: {
     constants() {
       return CONFIG.ARCHMAGE;
+    },
+    diceFormulaMode() {
+      return this.equipment?.actor?.flags?.archmage?.diceFormulaMode ?? 'short';
     },
   },
   methods: {},

--- a/src/vue/components/parts/Loot.vue
+++ b/src/vue/components/parts/Loot.vue
@@ -4,7 +4,7 @@
     <section class="equipment-details flexcol">
       <div class="equipment-detail">
         <Suspense>
-          <Enriched tag="span" :text="equipment.system.description.value" :diceFormulaMode="diceFormulaMode" />
+          <Enriched tag="span" class="equipment-detail-value" :text="equipment.system.description.value" :diceFormulaMode="diceFormulaMode" />
         </Suspense>
       </div>
     </section>

--- a/src/vue/components/parts/Loot.vue
+++ b/src/vue/components/parts/Loot.vue
@@ -3,7 +3,9 @@
     <!-- Primary properties (attack, hit, effect, etc.). -->
     <section class="equipment-details flexcol">
       <div class="equipment-detail">
-        <span class="equipment-detail-value" v-html="equipment.system.description.value"></span>
+        <Suspense>
+          <Enriched tag="span" :text="equipment.system.description.value" />
+        </Suspense>
       </div>
     </section>
   </section>
@@ -11,9 +13,11 @@
 
 <script>
 import { concat, localize } from '@/methods/Helpers';
+import Enriched from '@/components/parts/Enriched.vue';
 export default {
   name: 'Loot',
   props: ['equipment'],
+  components: {Enriched},
   setup() {
     return {
       concat,

--- a/src/vue/components/parts/Power.vue
+++ b/src/vue/components/parts/Power.vue
@@ -14,7 +14,9 @@
     <!-- Primary properties (attack, hit, effect, etc.). -->
     <section class="power-details flexcol">
       <div v-if="power.system.description.value" class="power-detail power-detail--description">
-        <span class="power-detail-value" v-html="power.system.description.value"></span>
+        <Suspense>
+          <Enriched tag="span" class="power-detail-value" :text="power.system.description.value" :diceFormulaMode="diceFormulaMode" />
+        </Suspense>
       </div>
       <div class="power-detail" :data-field="field" v-for="field in powerDetailFields" :key="field">
         <strong class="power-detail-label">{{localize(concat('ARCHMAGE.CHAT.', field))}}:</strong>


### PR DESCRIPTION
This patch updates the display of the inventory tab to run all the descriptions through `<Enriched>`. It started with me wanting to do the "mystery potion" thing with secret text, and finding out that was broken.

Before:

![CleanShot 2024-07-16 at 07 15 13](https://github.com/user-attachments/assets/617df4b0-85db-4f43-b5f7-02339324b29d)

After:

![CleanShot 2024-07-16 at 07 15 31](https://github.com/user-attachments/assets/52ec03ed-892e-47d9-9ba8-c1236cfe2c33)

- [x] Loot
- [x] Equipment
- [x] Power