### PR TITLE
Token artwork with mapped modules in Foundry v12

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -19,14 +19,14 @@ export class ActorArchmage extends Actor {
         // Module art was found. Replace the actor image.
         data.img = art.actor;
         // Replace the token art as well.
-        const tokenArt =
-          typeof art.token === "string"
-            // If it's a string, we only need to set the image.
-            ? { img: art.token }
-            // If it's an object, that will also include the image scale.
-            : { ...art.token };
-        // Update the prototype token for the actor.
-        data.prototypeToken = foundry.utils.mergeObject(data.prototypeToken ?? {}, tokenArt);
+        const tokenData = {
+          texture: {
+            src: typeof art.token === "string" ? art.token : art.token.img,
+            scaleX: art.token.scale,
+            scaleY: art.token.scale
+          }
+        };
+        data.prototypeToken = foundry.utils.mergeObject(data.prototypeToken ?? {}, tokenData);
       }
     }
 
@@ -1706,7 +1706,7 @@ export class ActorArchmage extends Actor {
       // Retrieve a copy of the existing actor data.
       let newData = foundry.utils.flattenObject(data);
       let oldData = foundry.utils.flattenObject(this);
-  
+
       // Limit data to just the new data.
       const diffData = foundry.utils.diffObject(oldData, newData);
       changes = foundry.utils.expandObject(diffData);

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -1721,6 +1721,7 @@ export class ActorArchmage extends Actor {
       && Object.values(CONFIG.ARCHMAGE.defaultMonsterTokens).includes(this.img)
       && CONFIG.ARCHMAGE.defaultMonsterTokens[data.system.details.type.value]) {
       data.img = CONFIG.ARCHMAGE.defaultMonsterTokens[data.system.details.type.value];
+      changes.img = data.img;
     }
     // Update the prototype token.
     if (changes.img || changes.name) {


### PR DESCRIPTION
Foundry v12 dropped support for setting the `img` and `scale` fields on a token, instead these are now in the `texture` sub-field. Looks like this was introduced [in v11](https://foundryvtt.com/api/v11/classes/foundry.data.PrototypeToken.html), but v12 deprecated the old method. 

- [x] Update to the new method of setting token image and scale
- [x] Verify this works in v11
- [x] Verify this works in v12

## Validation

Gonna just drag in a [Bugbear Scout](https://github.com/asacolips-projects/13th-age/blob/88e9adae67cb61cf8ad57d7cd561cdd1d8dd1ef6/src/map-archmage.yaml#L103-L105) (`token` is a string) and a [Giant Scorpion](https://github.com/asacolips-projects/13th-age/blob/88e9adae67cb61cf8ad57d7cd561cdd1d8dd1ef6/src/map-archmage.yaml#L27-L31) (`token` is an object with `img` and `scale`) onto the map.

v11:

https://github.com/user-attachments/assets/3249fe41-dadb-47b7-a0a5-0f3f82344736

v12:


https://github.com/user-attachments/assets/71001735-fa9c-4651-8ee7-1bdb319eb400

