### PR TITLE
feature/conditionDialog

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -51,7 +51,6 @@ ARCHMAGE:
   disengageShort: Disengage
   disengageAdjustment: Disengage Adjustment
   divine: Divine
-  duration: Duration
   edit: Edit
   effects: Effects
   equipment: Equipment
@@ -541,6 +540,7 @@ ARCHMAGE:
     DeleteConfirmTitle: Confirm deletion
     desperateRecharge: Desperate Recharge
     disengage: Disengage Check
+    duration: Duration
     effect: Effect
     epic: Epic Feat
     even: even
@@ -624,6 +624,7 @@ ARCHMAGE:
     sequencerRay: Sequencer File (Ray)
     sequencerSelf: Sequencer File (Self)
     sequencerReverse: Reverse Sequence
+    source: Source
     special: Special
     spellChain: Chain Spell
     spellLevel2: 2nd Level

--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -51,6 +51,7 @@ ARCHMAGE:
   disengageShort: Disengage
   disengageAdjustment: Disengage Adjustment
   divine: Divine
+  duration: Duration
   edit: Edit
   effects: Effects
   equipment: Equipment
@@ -523,6 +524,8 @@ ARCHMAGE:
     attack: Attack
     attackPlaceholder: "[[d20+@str.mod+@std]] vs. AC"
     attackTitle: Attack formula, such as "[[d20+@str.mod+@std]] vs. AC"
+    Apply: Apply
+    applyAETitle: Apply Active Effect?
     applyDamage: Apply Damage
     breathWeapon: Breath Weapon
     Cancel: Cancel

--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -764,6 +764,7 @@ ARCHMAGE:
     errNotInteger: must be an integer number
     errNoInitiativeOutsideCombat: Can't roll initiative without an encounter in the combat tracker.
     errOnlyTextRolltables: Only text Roll Tables are supported for now.
+    warnStatusEffect: Effect data empty, can't apply this effect.
     warnMacroOnlyOwnedItems: You can only create macro buttons for owned Items.
     warnMacroItemNotFound: Could not find item {item}. You may need to delete and recreate this macro.
     warnMacroItemNotOnActor: Your controlled Actor does not have an item named {item}.

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -925,7 +925,6 @@ export class ActorArchmage extends Actor {
       formula: terms.join(' + '),
       data: data,
       defaultRollMode: rollMode,
-      // abilities: abilities ?? {},
       rollModes: CONFIG.Dice.rollModes
     };
 

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -1134,12 +1134,14 @@ async function _applyAEDurationDialog(actor, effectData, duration, source, token
   }
   // Render modal dialog
   const sourceActor = await fromUuid(source);
+  let durations = foundry.utils.duplicate(CONFIG.ARCHMAGE.effectDurationTypes);
+  delete durations['Unknown'];
   const template = 'systems/archmage/templates/chat/apply-AE.html';
   let dialogData = {
     effectName: effectData.name,
     sourceName: sourceActor?.name ?? "",
-    defaultDuration: duration,
-    durations: CONFIG.ARCHMAGE.effectDurationTypes
+    defaultDuration: duration != 'Unknown' ? duration : "",
+    durations: durations
   };
   let do_apply = false;
 
@@ -1161,6 +1163,7 @@ async function _applyAEDurationDialog(actor, effectData, duration, source, token
       close: html => {
         if (do_apply) {
           duration = html.find('[name="duration"]:checked').val();
+          if ( !duration ) duration = "Unknown";
           let options = []
           if (['StartOfNextSourceTurn', 'EndOfNextSourceTurn'].includes(duration)) {
             options = {sourceTurnUuid: source};

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -1160,7 +1160,7 @@ async function _applyAEDurationDialog(actor, effectData, duration, source, token
       default: 'apply',
       close: html => {
         if (do_apply) {
-          duration = html.find('[name="duration"]').val();
+          duration = html.find('[name="duration"]:checked').val();
           let options = []
           if (['StartOfNextSourceTurn', 'EndOfNextSourceTurn'].includes(duration)) {
             options = {sourceTurnUuid: source};

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -1135,10 +1135,7 @@ async function _applyAEDurationDialog(actor, effectData, duration, source, token
   }
 
   if (event.shiftKey) {
-    if ( token ) {
-      if (game.release.version >= 12) return actor.toggleStatusEffect(effectData.id, {active: true});
-      else return token._object.toggleEffect(effectData, {active: true});
-    }
+    if ( token && game.release.version < 12 ) return token._object.toggleEffect(effectData, {active: true});
     else return actor.createEmbeddedDocuments("ActiveEffect", [effectData]);
   }
   // Render modal dialog
@@ -1168,10 +1165,7 @@ async function _applyAEDurationDialog(actor, effectData, duration, source, token
               options = {sourceTurnUuid: source};
             }
             game.archmage.MacroUtils.setDuration(effectData, duration, options);
-            if ( token ) {
-              if (game.release.version >= 12) return actor.toggleStatusEffect(effectData.id, {active: true});
-              else return token._object.toggleEffect(effectData, {active: true});
-            }
+            if ( token && game.release.version < 12 ) return token._object.toggleEffect(effectData, {active: true});
             else return actor.createEmbeddedDocuments("ActiveEffect", [effectData]);
           }
         },

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -1089,14 +1089,14 @@ async function _applyAE(actor, data, token=undefined) {
       return await _applyAEDurationDialog(actor, statusEffect, "Unknown", data.source);
     }
   }
-  // else if ( data.type === "effect" ) {
-    // const actorId = data.actorId;
-    // const sourceActor = game.actors.get(actorId);
-    // const effect = sourceActor.effects.get(data.id);
-    // let effectData = foundry.utils.duplicate(effect);
+  else if ( data.type === "effect" ) {
+    const actorId = data.actorId;
+    const sourceActor = game.actors.get(actorId);
+    const effect = sourceActor.effects.get(data.id);
+    let effectData = foundry.utils.duplicate(effect);
     // console.dir(effectData);
-    // return _applyAEDurationDialog(actor, effectData, "Unknown", data.source);
-  // }
+    return _applyAEDurationDialog(actor, effectData, "Unknown", data.source);
+  }
   else if ( data.type == "ongoing-damage" ) {
 
     // Load the source actor and grab its image if possible
@@ -1128,6 +1128,12 @@ async function _applyAE(actor, data, token=undefined) {
 }
 
 async function _applyAEDurationDialog(actor, effectData, duration, source, token=undefined) {
+  // If no effectData something went wrong, stop gracefully
+  if ( effectData == undefined ) {
+    ui.notifications.warn(game.i18n.localize("ARCHMAGE.UI.warnStatusEffect"));
+    return;
+  }
+  
   if (event.shiftKey) {
     if ( token ) return token._object.toggleEffect(effectData, {active: true});
     else return actor.createEmbeddedDocuments("ActiveEffect", [effectData]);

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -1135,7 +1135,10 @@ async function _applyAEDurationDialog(actor, effectData, duration, source, token
   }
   
   if (event.shiftKey) {
-    if ( token ) return token._object.toggleEffect(effectData, {active: true});
+    if ( token ) {
+      if (game.release.version >= 12) return actor.toggleStatusEffect(effectData, {active: true});
+      else return token._object.toggleEffect(effectData, {active: true});
+    }
     else return actor.createEmbeddedDocuments("ActiveEffect", [effectData]);
   }
   // Render modal dialog
@@ -1165,7 +1168,10 @@ async function _applyAEDurationDialog(actor, effectData, duration, source, token
               options = {sourceTurnUuid: source};
             }
             game.archmage.MacroUtils.setDuration(effectData, duration, options);
-            if ( token ) return token._object.toggleEffect(effectData, {active: true});
+            if ( token ) {
+              if (game.release.version >= 12) return actor.toggleStatusEffect(effectData, {active: true});
+              else return token._object.toggleEffect(effectData, {active: true});
+            }
             else return actor.createEmbeddedDocuments("ActiveEffect", [effectData]);
           }
         },

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -1129,7 +1129,7 @@ async function _applyAE(actor, data, token=undefined) {
 
 async function _applyAEDurationDialog(actor, effectData, duration, source, token=undefined) {
   if (event.shiftKey) {
-    if ( token ) return token.toggleEffect(effectData, {active: true});
+    if ( token ) return token._object.toggleEffect(effectData, {active: true});
     else return actor.createEmbeddedDocuments("ActiveEffect", [effectData]);
   }
   // Render modal dialog

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -869,7 +869,7 @@ Hooks.on('renderSettingsConfig', (app, html, data) => {
         preview.classList.remove('colorBlindRG');
         preview.classList.add('colorBlindBY');
         break;
-    
+
       default:
         preview.classList.remove('colorBlindBY');
         preview.classList.remove('colorBlindRG');
@@ -1133,10 +1133,10 @@ async function _applyAEDurationDialog(actor, effectData, duration, source, token
     ui.notifications.warn(game.i18n.localize("ARCHMAGE.UI.warnStatusEffect"));
     return;
   }
-  
+
   if (event.shiftKey) {
     if ( token ) {
-      if (game.release.version >= 12) return actor.toggleStatusEffect(effectData, {active: true});
+      if (game.release.version >= 12) return actor.toggleStatusEffect(effectData.id, {active: true});
       else return token._object.toggleEffect(effectData, {active: true});
     }
     else return actor.createEmbeddedDocuments("ActiveEffect", [effectData]);
@@ -1169,7 +1169,7 @@ async function _applyAEDurationDialog(actor, effectData, duration, source, token
             }
             game.archmage.MacroUtils.setDuration(effectData, duration, options);
             if ( token ) {
-              if (game.release.version >= 12) return actor.toggleStatusEffect(effectData, {active: true});
+              if (game.release.version >= 12) return actor.toggleStatusEffect(effectData.id, {active: true});
               else return token._object.toggleEffect(effectData, {active: true});
             }
             else return actor.createEmbeddedDocuments("ActiveEffect", [effectData]);

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -1135,8 +1135,7 @@ async function _applyAEDurationDialog(actor, effectData, duration, source, token
   }
 
   if (event.shiftKey) {
-    if ( token && game.release.version < 12 ) return token._object.toggleEffect(effectData, {active: true});
-    else return actor.createEmbeddedDocuments("ActiveEffect", [effectData]);
+    return actor.createEmbeddedDocuments("ActiveEffect", [effectData]);
   }
   // Render modal dialog
   const sourceActor = await fromUuid(source);
@@ -1165,8 +1164,7 @@ async function _applyAEDurationDialog(actor, effectData, duration, source, token
               options = {sourceTurnUuid: source};
             }
             game.archmage.MacroUtils.setDuration(effectData, duration, options);
-            if ( token && game.release.version < 12 ) return token._object.toggleEffect(effectData, {active: true});
-            else return actor.createEmbeddedDocuments("ActiveEffect", [effectData]);
+            return actor.createEmbeddedDocuments("ActiveEffect", [effectData]);
           }
         },
         pen1: {

--- a/src/module/hooks/combat.mjs
+++ b/src/module/hooks/combat.mjs
@@ -91,13 +91,13 @@ export async function preDeleteCombat(combat, context, options) {
 
             for (const effect of combatant.actor.effects) {
                 if (!effect.active) continue;
+                const isOngoing = effect.flags.archmage?.ongoingDamage != 0;
+                effect.isOngoing = isOngoing;
                 const duration = effect.flags.archmage?.duration || "Unknown";
                 // If duration is "Infinite" skip
                 if (duration === "Infinite") continue;
                 // If it's a save-ends effect store it as such
                 else if (saveEndsEffects.includes(duration)) {
-                    const isOngoing = effect.flags.archmage?.ongoingDamage != 0;
-                    effect.isOngoing = isOngoing;
                     currentCombatantEffectData.savesEnds.push(effect);
                 }
                 // If it's unknown also store it as such

--- a/src/module/hooks/preCreateChatMessageHandler.mjs
+++ b/src/module/hooks/preCreateChatMessageHandler.mjs
@@ -5,13 +5,15 @@ import Triggers from "../Triggers/Triggers.mjs";
 
 export default class preCreateChatMessageHandler {
 
-    static replaceEffectAndConditionReferences(actorDocument, $rows) {
+    static replaceEffectAndConditionReferences(uuid, $rows) {
         let conditions = CONFIG.ARCHMAGE.statusEffects.filter(x => x.journal);
         const conditionNames = new Set(conditions.map(x => game.i18n.localize(x.name)));
 
         function generateConditionLink(name) {
             const condition = conditions.find(x => game.i18n.localize(x.name) === name);
-            return `<a class="effect-link" draggable="true" data-type="condition" data-id="${condition.id}" title="">
+            const source = uuid;
+            return `<a class="effect-link" draggable="true" data-type="condition" data-id="${condition.id}" title="" 
+                    data-source="${source}">
                     <img class="effects-icon" src="${condition.icon}" />
                     ${name}</a>`;
         }
@@ -118,12 +120,12 @@ export default class preCreateChatMessageHandler {
         let $rows = $content.find('.card-prop');  // Updated later
 
         preCreateChatMessageHandler.replaceOngoingEffectReferences(uuid, $rows, options);
-        preCreateChatMessageHandler.replaceEffectAndConditionReferences(actorDocument, $rows);
+        preCreateChatMessageHandler.replaceEffectAndConditionReferences(uuid, $rows);
 
         // Handle conditions in feats as well as traits & nastier specials
         let $otherRows = $content.find('.tag--feat .description, .card-row-description');
         preCreateChatMessageHandler.replaceOngoingEffectReferences(uuid, $otherRows, options);
-        preCreateChatMessageHandler.replaceEffectAndConditionReferences(actorDocument, $otherRows);
+        preCreateChatMessageHandler.replaceEffectAndConditionReferences(uuid, $otherRows);
         $content.find('.tag--feat .description, .card-row-description').replaceWith($otherRows);
 
         let sequence = undefined;

--- a/src/module/setup/utility-classes.js
+++ b/src/module/setup/utility-classes.js
@@ -562,7 +562,8 @@ export class MacroUtils {
       default:
         // console.warn("Unknown duration ", duration);
         // Condition drag and drop passes the correct data already
-        data['flags.archmage.duration'] = duration;
+        if (data.flags?.archmage?.duration) data.flags.archmage.duration = duration;
+        else data['flags.archmage.duration'] = duration;
     }
 
     return data;

--- a/src/module/setup/utility-classes.js
+++ b/src/module/setup/utility-classes.js
@@ -565,6 +565,11 @@ export class MacroUtils {
         if (data.flags?.archmage?.duration) data.flags.archmage.duration = duration;
         else data['flags.archmage.duration'] = duration;
     }
+    // Set Foundry core duration to make the thing appear on tokens
+    data['duration'] = {
+      rounds: 999,
+      turns: 999
+    }
 
     return data;
   }

--- a/src/module/setup/utility-classes.js
+++ b/src/module/setup/utility-classes.js
@@ -560,7 +560,8 @@ export class MacroUtils {
         data['flags.archmage.duration'] = "StartOfEachTurn";
         break;
       default:
-        console.warn("Unknown duration ", duration);
+        // console.warn("Unknown duration ", duration);
+        data['flags.archmage.duration'] = duration;
     }
 
     return data;

--- a/src/module/setup/utility-classes.js
+++ b/src/module/setup/utility-classes.js
@@ -561,6 +561,7 @@ export class MacroUtils {
         break;
       default:
         // console.warn("Unknown duration ", duration);
+        // Condition drag and drop passes the correct data already
         data['flags.archmage.duration'] = duration;
     }
 

--- a/src/templates/chat/apply-AE.html
+++ b/src/templates/chat/apply-AE.html
@@ -1,0 +1,13 @@
+<form>
+
+  <div class="form-group">
+    <label>{{localize 'ARCHMAGE.duration'}}</label>
+    <select name="duration">
+      {{#select defaultDuration}}
+      {{#each durations as |label duration|}}
+        <option value="{{duration}}">{{localize label}}</option>
+      {{/each}}
+      {{/select}}
+    </select>
+  </div>
+</form>

--- a/src/templates/chat/apply-AE.html
+++ b/src/templates/chat/apply-AE.html
@@ -8,13 +8,10 @@
     <span>{{sourceName}}</span>
   </div>
   <div class="form-group">
-    <label>{{localize 'ARCHMAGE.CHAT.duration'}}</label>
-    <select name="duration">
-      {{#select defaultDuration}}
-      {{#each durations as |label duration|}}
-        <option value="{{duration}}">{{localize label}}</option>
-      {{/each}}
-      {{/select}}
-    </select>
+    <label style="align-self: start;">{{localize 'ARCHMAGE.CHAT.duration'}}</label>
+    <div class="form-fields" style="flex-direction: column; align-items: start;">
+      {{radioBoxes 'duration' durations checked=defaultDuration localize=true}}
+    </div>
+
   </div>
 </form>

--- a/src/templates/chat/apply-AE.html
+++ b/src/templates/chat/apply-AE.html
@@ -1,7 +1,14 @@
 <form>
-
   <div class="form-group">
-    <label>{{localize 'ARCHMAGE.duration'}}</label>
+    <label>{{localize 'ARCHMAGE.CHAT.effect'}}</label>
+    <span>{{effectName}}</span>
+  </div>
+  <div class="form-group">
+    <label>{{localize 'ARCHMAGE.CHAT.source'}}</label>
+    <span>{{sourceName}}</span>
+  </div>
+  <div class="form-group">
+    <label>{{localize 'ARCHMAGE.CHAT.duration'}}</label>
     <select name="duration">
       {{#select defaultDuration}}
       {{#each durations as |label duration|}}

--- a/src/templates/chat/apply-AE.html
+++ b/src/templates/chat/apply-AE.html
@@ -10,8 +10,11 @@
   <div class="form-group">
     <label style="align-self: start;">{{localize 'ARCHMAGE.CHAT.duration'}}</label>
     <div class="form-fields" style="flex-direction: column; align-items: start;">
+      {{#if defaultDuration}}
       {{radioBoxes 'duration' durations checked=defaultDuration localize=true}}
+      {{else}}
+      {{radioBoxes 'duration' durations localize=true}}
+      {{/if}}
     </div>
-
   </div>
 </form>

--- a/src/templates/chat/ongoing-effects-card.html
+++ b/src/templates/chat/ongoing-effects-card.html
@@ -11,7 +11,7 @@
 {{!-- Condition row partial. --}}
 {{#*inline "condition"}}
 <div class="grid grid-7col effect" data-effect-id="{{effect._id}}" data-uuid="{{effect.parent.uuid}}">
-    <a class="effect-link {{#if effect.otherName}}grid-span-4{{else}}grid-span-7{{/if}}" draggable="true" data-type="condition" data-id="{{effect.id}}" title="" data-name="{{effect.name}}">
+    <a class="effect-link {{#if effect.otherName}}grid-span-4{{else}}grid-span-7{{/if}}" draggable="true" data-type="condition" data-id="{{effect.id}}" title="" data-name="{{effect.name}}" data-source="{{effect.origin}}"s>
         <img class="effects-icon" src="{{effect.icon}}" /> <span class="effect-name">{{effect.name}}</span>
     </a>
     {{#if effect.otherName}}

--- a/src/vue/methods/Helpers.js
+++ b/src/vue/methods/Helpers.js
@@ -101,8 +101,7 @@ export async function wrapRolls(text, replacements = [], diceFormulaMode = 'shor
   // Remove whitespace from inline rolls.
   let clean = text ? text?.toString() ?? '' : '';  // cast to string, could be e.g. number
 
-  // TODO: get the actor's uuid somehow
-  clean = replaceEffectAndConditionReferences("", clean)
+  clean = replaceEffectAndConditionReferences(clean)
 
   // Handle replacements for the 'short' syntax. Ex: WPN+DEX+LVL
   if (diceFormulaMode == 'short') {
@@ -165,14 +164,13 @@ export async function wrapRolls(text, replacements = [], diceFormulaMode = 'shor
   return parseMarkdown(clean);
 }
 
-function replaceEffectAndConditionReferences(uuid, text) {
+function replaceEffectAndConditionReferences(text) {
     let conditions = CONFIG.ARCHMAGE.statusEffects.filter(x => x.journal);
     const conditionNames = new Set(conditions.map(x => game.i18n.localize(x.name)));
 
     function generateConditionLink(name) {
         const condition = conditions.find(x => game.i18n.localize(x.name) === name);
-        return `<a class="effect-link" draggable="true" data-type="condition" data-id="${condition.id}" title="" 
-                data-source="${uuid}">
+        return `<a class="effect-link" data-type="condition" data-id="${condition.id}" title="">
                 <img class="effects-icon" src="${condition.icon}" />
                 ${name}</a>`;
     }

--- a/src/vue/methods/Helpers.js
+++ b/src/vue/methods/Helpers.js
@@ -101,7 +101,8 @@ export async function wrapRolls(text, replacements = [], diceFormulaMode = 'shor
   // Remove whitespace from inline rolls.
   let clean = text ? text?.toString() ?? '' : '';  // cast to string, could be e.g. number
 
-  // TODO: process condition links
+  // TODO: get the actor's uuid somehow
+  clean = replaceEffectAndConditionReferences("", clean)
 
   // Handle replacements for the 'short' syntax. Ex: WPN+DEX+LVL
   if (diceFormulaMode == 'short') {
@@ -162,6 +163,27 @@ export async function wrapRolls(text, replacements = [], diceFormulaMode = 'shor
 
   // Return the revised text and convert markdown to HTML.
   return parseMarkdown(clean);
+}
+
+function replaceEffectAndConditionReferences(uuid, text) {
+    let conditions = CONFIG.ARCHMAGE.statusEffects.filter(x => x.journal);
+    const conditionNames = new Set(conditions.map(x => game.i18n.localize(x.name)));
+
+    function generateConditionLink(name) {
+        const condition = conditions.find(x => game.i18n.localize(x.name) === name);
+        return `<a class="effect-link" draggable="true" data-type="condition" data-id="${condition.id}" title="" 
+                data-source="${uuid}">
+                <img class="effects-icon" src="${condition.icon}" />
+                ${name}</a>`;
+    }
+
+    for (const name of conditionNames) {
+        const link = generateConditionLink(name);
+        const regex = new RegExp(`\\*${name}\\*`, "ig");
+        text = text.replace(regex, link);
+    }
+
+    return text;
 }
 
 /**


### PR DESCRIPTION
- Add dialog on condition drop on sheet/token to select its duration (SHIFT-skippable as usual)
- Fix rendering of condition links in power previews
- Fix ongoing damage and system macro created AEs not appearing on tokens

TODOs:
- [x] Condition duration dialog on drag
- [x] shift bypass
- [x] handle token toggle
- [x] handle *sourceTurn
- [x] fix start/end-of-turn ongoing draggables not producing an ongoing AE
- [x] store source combat round to properly support *next* turn