### PR TITLE
Fix rolling NPC attacks

### DIFF
--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -231,8 +231,9 @@ export class ItemArchmage extends Item {
 
   async _rollTemporaryOverrides() {
     let overrides = {};
+    if (this.type != 'power') return overrides;
     let lvl = this.system.powerLevel?.value ?? 0;
-    if (this.actor.getFlag("archmage", "overridePowerLevel") && this.type == 'power') {
+    if (this.actor.getFlag("archmage", "overridePowerLevel")) {
       lvl = Math.max(this.actor.system.attributes.level.value, lvl);
     }
     if (event.altKey && this.system.powerLevel?.value != undefined) {

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -231,7 +231,7 @@ export class ItemArchmage extends Item {
 
   async _rollTemporaryOverrides() {
     let overrides = {};
-    let lvl = this.system.powerLevel.value;
+    let lvl = this.system.powerLevel?.value ?? 0;
     if (this.actor.getFlag("archmage", "overridePowerLevel") && this.type == 'power') {
       lvl = Math.max(this.actor.system.attributes.level.value, lvl);
     }


### PR DESCRIPTION
Looks like this was introduced as [part of #456](https://github.com/asacolips-projects/13th-age/pull/456/files#diff-09d8976f016be8f48693bcc5b4abcab8c58b5f9d120c71122e676fe4827d9e8cR233-R243). Without this patch, rolling NPC attacks fails with an exception, and after it looks to work just fine. (v11 and v12)