### PR TITLE
Add target damage application setting

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -211,6 +211,8 @@ ARCHMAGE:
     rechargeOncePerDayName: Recharge once per day only
     RoundUpDamageApplicationHint: When applying damage (or healing) via the right-click context menu, should it round up (true) or round down (false)? Default is true (round up). This will be applied the same way for both characters and NPCs.
     RoundUpDamageApplicationName: Round damage/healing up (true) or down (false)
+    allowTargetDamageApplicationHint: Whether or not to allow damage and healing on chat messages to be applied to targeted tokens in addition to selected tokens. Targeting does not require permissions, so this can allow players and GMs to apply damage to ANY token they can see.
+    allowTargetDamageApplicationName: Allow target damage application
     secondEditionHint: Turn this on to use the 13th Age second edition playtest rules, off if you'd prefer the regular rules.
     secondEditionName: Use 2e Gamma Playtest Rules
     ShowDebugLogsHint: Turn this on for bug reports
@@ -753,6 +755,9 @@ ARCHMAGE:
     StatusVulnerable: Vulnerable
     StatusWeakened: Weakened
   UI:
+    applyChanges: Apply changes
+    targeted: Targeted
+    selected: Selected
     errMacroSyntax: There was an error in your macro syntax. See the console (F12) for details.
     errNotEnoughCP: You don't have enough Command Points to use this command. Use anyway?
     errNotEnoughKi: You don't have enough Ki to use this power. Use anyway?
@@ -768,6 +773,7 @@ ARCHMAGE:
     warnMacroOnlyOwnedItems: You can only create macro buttons for owned Items.
     warnMacroItemNotFound: Could not find item {item}. You may need to delete and recreate this macro.
     warnMacroItemNotOnActor: Your controlled Actor does not have an item named {item}.
+    noTarget: No target selected.
     noToken: No token selected.
     tooManyLevels: Changing a monster by more than 6 levels is not recommended.
     levelLimits: Level can't increase above 15 or decrease below 0.

--- a/src/scss/archmage.scss
+++ b/src/scss/archmage.scss
@@ -42,11 +42,20 @@
   max-width: 360px;
   position: absolute;
   left: 0;
-  background: #23221d;
+  background: linear-gradient(180deg, #181714 0, #23221d 100%);
   border: 1px solid #000;
+  box-shadow: 0 0 20px -2px #000;
   border-radius: 5px;
   color: #EEE;
   z-index: 31;
+
+  h2 {
+    font-family: $font-stack-base;
+    line-height: 44px;
+    padding: 0 5px;
+    border-bottom: 1px solid $c-blue-dark;
+    text-shadow: none;
+  }
 }
 #context-menu2.expand-down {
   top: calc(100% + 2px);
@@ -73,4 +82,34 @@
 }
 .window-app #context-menu2 {
   z-index: 101;
+}
+
+#chat-log .card-row #context-menu2 {
+  button {
+    font-size: 12px;
+    background: transparent;
+    color: $c-white;
+    border: 1px dashed $c-blue;
+    box-shadow: none;
+    opacity: 0.5;
+
+    &.active,
+    &:hover {
+      border: 1px solid $c-blue;
+      color: $c-white;
+      opacity: 1;
+      box-shadow: inset 0 0 10px 0px $c-blue-dark;
+    }
+
+    &:hover {
+      border: 1px solid $c-blue-light;
+      box-shadow: inset 0 0 8px 2px $c-blue;
+    }
+  }
+}
+
+.archmage-apply-ae {
+  .form-group {
+    border-bottom: 1px solid $c-black--15;
+  }
 }

--- a/src/scss/global/_archmage-global.scss
+++ b/src/scss/global/_archmage-global.scss
@@ -1859,7 +1859,7 @@ option[selected] {
     }
 
     &:hover {
-      transform: scale(1.05);
+      // transform: scale(1.05);
       z-index: 90;
     }
 

--- a/src/templates/chat/apply-AE.html
+++ b/src/templates/chat/apply-AE.html
@@ -1,4 +1,4 @@
-<form>
+<form class="archmage archmage-apply-ae">
   <div class="form-group">
     <label>{{localize 'ARCHMAGE.CHAT.effect'}}</label>
     <span>{{effectName}}</span>


### PR DESCRIPTION
- Added a new setting to allow users to apply damage to targeted tokens or selected tokens (disabled by default). If enabled, users can choose on the damage applicator menu whether to apply damage to selected tokens (which was the previous behavior, and requires permission to select the token) or targeted tokens (which does _not_ require any special permissions).
- Updated the damage applicator context menu to hide any tooltips when it's initially opened.
- Added a subtle border between form groups on the new dialog for applying active effects.

## Screenshots

![image](https://github.com/user-attachments/assets/a03e9b50-d2eb-472b-a2e2-4d4eaa510257)
