### PR TITLE
Draft: Effect drag/drop improvements

### DIFF
--- a/src/module/hooks/preCreateChatMessageHandler.mjs
+++ b/src/module/hooks/preCreateChatMessageHandler.mjs
@@ -27,6 +27,17 @@ export default class preCreateChatMessageHandler {
         }
     }
 
+    static replaceActiveEffectLinkReferences(uuid, $content) {
+        const elements = $content[0].querySelectorAll('.content-link[data-type="ActiveEffect"]');
+        elements.forEach((element) => {
+            const effect = fromUuidSync(element.dataset.uuid);
+            element.classList.add('effect-link');
+            element.classList.remove('content-link');
+            element.dataset.source = uuid;
+            element.innerHTML = `<img class="effects-icon" src="${effect.img}"/>${element.innerText}`;
+        });
+    }
+
     static replaceOngoingEffectReferences(uuid, $rows, options) {
         // HTML looks like this
         // <div className="card-prop trigger-unknown"><strong>Hit:</strong> <a
@@ -121,6 +132,7 @@ export default class preCreateChatMessageHandler {
 
         preCreateChatMessageHandler.replaceOngoingEffectReferences(uuid, $rows, options);
         preCreateChatMessageHandler.replaceEffectAndConditionReferences(uuid, $rows);
+        preCreateChatMessageHandler.replaceActiveEffectLinkReferences(uuid, $content);
 
         // Handle conditions in feats as well as traits & nastier specials
         let $otherRows = $content.find('.tag--feat .description, .card-row-description');


### PR DESCRIPTION
**Note:** Marking this as a draft until the Vue sheet is also updated to render effects as effect links.

- Updated our chat message handler to turn `content-link` elements rendered by Foundry core into `effect-link` elements so that we can include them in our duration dialog events.
- Updated the duration dialog to update existing effects if the effect being dropped is not ongoing damage.