### PR TITLE
Fix monk form AC bug on v12

### DIFF
--- a/src/module/active-effects/effect-sheet.js
+++ b/src/module/active-effects/effect-sheet.js
@@ -93,7 +93,7 @@ export class EffectArchmageSheet extends ActiveEffectConfig {
 
     // Retrieve the existing effects.
     const effectData = await this.getData();
-    let changes = effectData?.data?.changes ? effectData.data.changes : [];
+    let changes = effectData?.changes ? effectData.changes : [];
 
     // Build an array of effects from the form data
     let newChanges = [];

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -1332,6 +1332,7 @@ Hooks.on('renderChatMessage', (chatMessage, html, options) => {
           <div class="damage-modifiers flex flexrow">
             <button type="button" data-mod="0.5">0.5x</button>
             <button type="button" data-mod="1" class="active">1x</button>
+            <button type="button" data-mod="1.5">1.5x</button>
             <button type="button" data-mod="2">2x</button>
             <button type="button" data-mod="3">3x</button>
             <button type="button" data-mod="4">4x</button>

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -630,7 +630,7 @@ export class ItemArchmage extends Item {
     let alreadyHasBetterBonus = false;
     effects.forEach(e => {
       if (e.name == game.i18n.localize("ARCHMAGE.MONKFORMS.aelabel")) {
-        if (Number(e.data.changes[0].value) <= bonusMagnitude) {
+        if (Number(e.changes[0].value) <= bonusMagnitude) {
           effectsToDelete.push(e.id);
         }
         else alreadyHasBetterBonus = true;


### PR DESCRIPTION
- Removed obsolete references to `effect.data.changes`
- Added 1.5x damage modifier button to the damage applicator for when damage is tripled (such as with Carve an Opening) and also halved (such as with a Combat Rhythm defensive maneuver)