### PR TITLE
Release 1.31.0

### DIFF
--- a/release-notes/1.31.0.md
+++ b/release-notes/1.31.0.md
@@ -10,14 +10,12 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.31.0/syste
 
 ## Token Action HUD Integration
 While not part of the system itself, we've also developed a new [Token Action HUD 13th Age](https://foundryvtt.com/packages/token-action-hud-13th-age) module that provides a 13th Age integration for Token Action HUD. The new module is only available for Foundry v12 or higher, but it adds a ton of convenience actions when you've selected a token! Install it now via the package manager, and be sure to report any bugs or feature requests to its [Github issues page](https://github.com/asacolips-projects/token-action-hud-13th-age/issues)!
-- [mp4 here]
 
 ## Active Effects Improvements
 - Added new dialog when dropping a condition/effect on a character sheet or token to select its duration. If the shift key is held down while droping, this dialog will be skipped.
 - Updated our chat message handler to turn content-link elements rendered by Foundry core into effect-link elements so that we can include them in our duration dialog events.
 - Update character/NPC sheet to also render content-link elements as effect-link elements.
 - Add effects tab to items and render any effects the item owns in the footer of their chat cards. Once an effect has been rendered in the footer of a chat card, it can then be dragged and dropped onto any actor, which allows for a very powerful form of automating buffs and debuffs created by powers without having to code a macro.
-- [screenshots here]
 
 ## Damage Menu Improvements
 - Added a new setting to allow users to apply damage to targeted tokens or selected tokens (disabled by default). If enabled, users can choose on the damage applicator menu whether to apply damage to selected tokens (which was the previous behavior, and requires permission to select the token) or targeted tokens (which does not require any special permissions).
@@ -25,13 +23,11 @@ While not part of the system itself, we've also developed a new [Token Action HU
 - Added a subtle border between form groups on the new dialog for applying active effects.
 - Added new toggles to adjust damage modifiers prior to applying damage or healing. Previously, this was setup as individual actions for 1x damage, 2x damage, 3x damage, 1x healing, 0.5x healing, and 1x temp healing. With the new setup, you can use 0.5x, 1x, 1.5x, 2x, 3x, or 4x on damage, healing, and temp healing.
 - Added new setting to allow players and GMs to reroll inline dice rolls and standard Foundry dice rolls (meaning rolls from chat, ability checks, and deferred inline rolls).
-- [screenshots here]
 
 ## Other Improvements
 - Updated wording for `hindered`, `stuck`, and `vulnerable` when 2e is enabled to reflect the latest Gamma packet rules.
 - Tweaked the rogue pregen actor's ability scores to make its Deadly Thrust power more viable.
 - Added a new per-user setting to zoom sheets to a smaller size. The sheet layout will be the same, but both character and NPC sheets will be roughly 86% of their original size.
-- [screenshots here]
 
 ## Bug Fixes
 - [v12] Removed obsolete references to effect.data.changes, which was causing a fatal error when trying to use monk forms.
@@ -49,6 +45,10 @@ While not part of the system itself, we've also developed a new [Token Action HU
 - Updated Defensive Fighting macro for 2e.
 - Added support for drag sorting on active effects on the sheet.
 - Updated items (characters: powers and inventory, npcs: actions) to always be sortable, even when using sort modes such as Name or Level. While their display won't change in these modes, they do need to be draggable in order for macro drops to work.
+
+## Changelog
+
+Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.30.4...1.31.0
 
 ## Contributors
 

--- a/release-notes/1.31.0.md
+++ b/release-notes/1.31.0.md
@@ -1,0 +1,55 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.31.0/system.json
+
+## Compatible Foundry versions
+
+![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12.331](https://img.shields.io/badge/Foundry-v12.328-green)
+
+**Note**: This will be the final release of the system for Foundry v11. Future versions will be for v12 or higher.
+
+## Token Action HUD Integration
+While not part of the system itself, we've also developed a new [Token Action HUD 13th Age](https://foundryvtt.com/packages/token-action-hud-13th-age) module that provides a 13th Age integration for Token Action HUD. The new module is only available for Foundry v12 or higher, but it adds a ton of convenience actions when you've selected a token! Install it now via the package manager, and be sure to report any bugs or feature requests to its [Github issues page](https://github.com/asacolips-projects/token-action-hud-13th-age/issues)!
+- [mp4 here]
+
+## Active Effects Improvements
+- Added new dialog when dropping a condition/effect on a character sheet or token to select its duration. If the shift key is held down while droping, this dialog will be skipped.
+- Updated our chat message handler to turn content-link elements rendered by Foundry core into effect-link elements so that we can include them in our duration dialog events.
+- Update character/NPC sheet to also render content-link elements as effect-link elements.
+- Add effects tab to items and render any effects the item owns in the footer of their chat cards. Once an effect has been rendered in the footer of a chat card, it can then be dragged and dropped onto any actor, which allows for a very powerful form of automating buffs and debuffs created by powers without having to code a macro.
+- [screenshots here]
+
+## Damage Menu Improvements
+- Added a new setting to allow users to apply damage to targeted tokens or selected tokens (disabled by default). If enabled, users can choose on the damage applicator menu whether to apply damage to selected tokens (which was the previous behavior, and requires permission to select the token) or targeted tokens (which does not require any special permissions).
+- Updated the damage applicator context menu to hide any tooltips when it's initially opened.
+- Added a subtle border between form groups on the new dialog for applying active effects.
+- Added new toggles to adjust damage modifiers prior to applying damage or healing. Previously, this was setup as individual actions for 1x damage, 2x damage, 3x damage, 1x healing, 0.5x healing, and 1x temp healing. With the new setup, you can use 0.5x, 1x, 1.5x, 2x, 3x, or 4x on damage, healing, and temp healing.
+- Added new setting to allow players and GMs to reroll inline dice rolls and standard Foundry dice rolls (meaning rolls from chat, ability checks, and deferred inline rolls).
+- [screenshots here]
+
+## Other Improvements
+- Updated wording for `hindered`, `stuck`, and `vulnerable` when 2e is enabled to reflect the latest Gamma packet rules.
+- Tweaked the rogue pregen actor's ability scores to make its Deadly Thrust power more viable.
+- Added a new per-user setting to zoom sheets to a smaller size. The sheet layout will be the same, but both character and NPC sheets will be roughly 86% of their original size.
+- [screenshots here]
+
+## Bug Fixes
+- [v12] Removed obsolete references to effect.data.changes, which was causing a fatal error when trying to use monk forms.
+- [v12] Updated compendium image mapping (such as for the Pathfinder Bestiary Token pack) to work with v12.
+- Updated inventory tab on character sheets to enrich text (including secrets, dice rolls, and links).
+- Fixed rendering of condition links on power previews.
+- Fixed ongoing damage and system macro created AEs not appearing on tokens.
+- Fixed a bug with rolling NPC attacks that caused an exception in some cases.
+- Fixed the cover image for the system not appearing on the setup screen's systems tab.
+- Fixed reroll bonuses not localizing correctly on the character sheet.
+- Fix missing duration and icon for negative recovery AE.
+- Fix monk's AC bonus AE missing icon.
+- Refactored how macros are created on drop events to prevent some scenarios where it could silently fail. Also adjusted it to use UUID when creating the macro rather than name.
+- Fixed a bug with the ActiveEffect sheet that prevented changes to their images from saving.
+- Updated Defensive Fighting macro for 2e.
+- Added support for drag sorting on active effects on the sheet.
+- Updated items (characters: powers and inventory, npcs: actions) to always be sortable, even when using sort modes such as Name or Level. While their display won't change in these modes, they do need to be draggable in order for macro drops to work.
+
+## Contributors
+
+legofed3, ben, and asacolips

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -1,20 +1,22 @@
 name: archmage
 id: archmage
 title: 13th Age
-version: "1.30.4"
+version: "1.31.0"
 authors:
   - name: Matt Smith
-    discord: asacolips#1867
+    discord: asacolips
   - name: Cody Swendrowski
-    discord: cswendrowski#9701
+    discord: cswendrowski
   - name: Federico Pederzolli
-    discord: Legofed3#6471
+    discord: legofed3
+  - name: Ben Straub
+    discord: benstraub
 
 description: The official 13th Age system for Foundry Virtual Tabletop.
 
 compatibility:
   minimum: "11"
-  verified: "12.327"
+  verified: "12.331"
   maximum: "12"
 
 esmodules:
@@ -277,7 +279,7 @@ languages:
 socket: true
 url: https://github.com/asacolips-projects/13th-age
 manifest: https://asacolips-artifacts.s3.amazonaws.com/archmage/latest/system.json
-download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.30.4/archmage.zip
+download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.31.0/archmage.zip
 changelog: https://github.com/asacolips-projects/13th-age/releases
 initiative: 1d20 + (@abilities?.dex.mod || 0) + @attributes.init.value + @attributes.level.value
 gridDistance: "1"


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.31.0/system.json

## Compatible Foundry versions

![Foundry v11.315](https://img.shields.io/badge/Foundry-v11.315-green) ![Foundry v12.331](https://img.shields.io/badge/Foundry-v12.328-green)

**Note**: This will be the final release of the system for Foundry v11. Future versions will be for v12 or higher.

## Token Action HUD Integration
While not part of the system itself, we've also developed a new [Token Action HUD 13th Age](https://foundryvtt.com/packages/token-action-hud-13th-age) module that provides a 13th Age integration for Token Action HUD. The new module is only available for Foundry v12 or higher, but it adds a ton of convenience actions when you've selected a token! Install it now via the package manager, and be sure to report any bugs or feature requests to its [Github issues page](https://github.com/asacolips-projects/token-action-hud-13th-age/issues)!
- [mp4 here]

## Active Effects Improvements
- Added new dialog when dropping a condition/effect on a character sheet or token to select its duration. If the shift key is held down while droping, this dialog will be skipped.
- Updated our chat message handler to turn content-link elements rendered by Foundry core into effect-link elements so that we can include them in our duration dialog events.
- Update character/NPC sheet to also render content-link elements as effect-link elements.
- Add effects tab to items and render any effects the item owns in the footer of their chat cards. Once an effect has been rendered in the footer of a chat card, it can then be dragged and dropped onto any actor, which allows for a very powerful form of automating buffs and debuffs created by powers without having to code a macro.
- [screenshots here]

## Damage Menu Improvements
- Added a new setting to allow users to apply damage to targeted tokens or selected tokens (disabled by default). If enabled, users can choose on the damage applicator menu whether to apply damage to selected tokens (which was the previous behavior, and requires permission to select the token) or targeted tokens (which does not require any special permissions).
- Updated the damage applicator context menu to hide any tooltips when it's initially opened.
- Added a subtle border between form groups on the new dialog for applying active effects.
- Added new toggles to adjust damage modifiers prior to applying damage or healing. Previously, this was setup as individual actions for 1x damage, 2x damage, 3x damage, 1x healing, 0.5x healing, and 1x temp healing. With the new setup, you can use 0.5x, 1x, 1.5x, 2x, 3x, or 4x on damage, healing, and temp healing.
- Added new setting to allow players and GMs to reroll inline dice rolls and standard Foundry dice rolls (meaning rolls from chat, ability checks, and deferred inline rolls).
- [screenshots here]

## Other Improvements
- Updated wording for `hindered`, `stuck`, and `vulnerable` when 2e is enabled to reflect the latest Gamma packet rules.
- Tweaked the rogue pregen actor's ability scores to make its Deadly Thrust power more viable.
- Added a new per-user setting to zoom sheets to a smaller size. The sheet layout will be the same, but both character and NPC sheets will be roughly 86% of their original size.
- [screenshots here]

## Bug Fixes
- [v12] Removed obsolete references to effect.data.changes, which was causing a fatal error when trying to use monk forms.
- [v12] Updated compendium image mapping (such as for the Pathfinder Bestiary Token pack) to work with v12.
- Updated inventory tab on character sheets to enrich text (including secrets, dice rolls, and links).
- Fixed rendering of condition links on power previews.
- Fixed ongoing damage and system macro created AEs not appearing on tokens.
- Fixed a bug with rolling NPC attacks that caused an exception in some cases.
- Fixed the cover image for the system not appearing on the setup screen's systems tab.
- Fixed reroll bonuses not localizing correctly on the character sheet.
- Fix missing duration and icon for negative recovery AE.
- Fix monk's AC bonus AE missing icon.
- Refactored how macros are created on drop events to prevent some scenarios where it could silently fail. Also adjusted it to use UUID when creating the macro rather than name.
- Fixed a bug with the ActiveEffect sheet that prevented changes to their images from saving.
- Updated Defensive Fighting macro for 2e.
- Added support for drag sorting on active effects on the sheet.
- Updated items (characters: powers and inventory, npcs: actions) to always be sortable, even when using sort modes such as Name or Level. While their display won't change in these modes, they do need to be draggable in order for macro drops to work.

## Contributors

legofed3, ben, and asacolips