### PR TITLE
Fix effect sheet fields, effect durations

### DIFF
--- a/src/module/active-effects/effect-sheet.js
+++ b/src/module/active-effects/effect-sheet.js
@@ -9,7 +9,8 @@ export class EffectArchmageSheet extends ActiveEffectConfig {
       height: 550,
       tabs: [{navSelector: ".tabs", contentSelector: "form", initial: "effects"}],
       submitOnClose: true,
-      submitOnChange: false
+      submitOnChange: true,
+      closeOnSubmit: false,
     });
   }
 
@@ -149,6 +150,9 @@ export class EffectArchmageSheet extends ActiveEffectConfig {
 
     // Filter changes for empty form fields.
     ae.changes = ae.changes.filter(c => c.value !== null);
+
+    // Handle details fields.
+    ae.disabled = !!formData?.effect?.disabled;
 
     return this.object.update(ae);
   }

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -1152,8 +1152,8 @@ async function _applyAE(actor, data) {
       }
     }
     let effectData = foundry.utils.duplicate(effect);
-    // console.dir(effectData);
-    return await _applyAEDurationDialog(actor, effectData, "Unknown", sourceDocument?.uuid, data.type);
+    const ends = effectData.flags?.archmage?.duration ?? "Unknown";
+    return await _applyAEDurationDialog(actor, effectData, ends, sourceDocument?.uuid, data.type);
   }
   else if ( data.type == "ongoing-damage" ) {
 

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -895,6 +895,8 @@ export class ItemArchmage extends Item {
         img: effect.img,
         name: effect.name,
         id: effect.id,
+        flags: effect.flags,
+        description: effect?.description,
       }
     });
   }

--- a/src/scss/global/_archmage-global.scss
+++ b/src/scss/global/_archmage-global.scss
@@ -548,8 +548,28 @@ option[selected] {
   }
 
   &.effect-sheet {
-    .description {
-      height: 50%;
+    .tab.active {
+      display: flex;
+      flex-direction: column;
+
+      > * {
+        flex: 0 auto;
+      }
+
+      .description {
+        flex: 1;
+      }
+
+      .prosemirror {
+        .editor-container {
+          margin: 0;
+        }
+
+        .editor-content {
+          background: transparent;
+          border: none;
+        }
+      }
     }
   }
 

--- a/src/templates/active-effects/effect.html
+++ b/src/templates/active-effects/effect.html
@@ -18,13 +18,6 @@
             <div class="sheet-tabs-content">
                 <!-- Details Tab -->
                 <section class="tab" data-tab="details">
-                    <div class="form-group">
-                        <label>{{ localize "EFFECT.Icon" }}</label>
-                        <div class="form-fields">
-                            {{filePicker target="icon" type="image"}}
-                            <input class="image" type="text" name="icon" placeholder="path/image.png" value="{{effect.icon}}"/>
-                        </div>
-                    </div>
 
                     <div class="form-group">
                         <label>{{ localize "EFFECT.Disabled" }}</label>
@@ -38,7 +31,8 @@
                             <input type="text" name="origin" value="{{ effect.origin }}" />
                         </div>
                     </div>
-
+                    {{/if}}
+                    
                     <div class="form-group">
                         <label>{{ localize "EFFECT.TabDuration" }}</label>
                         <div class="form-fields">
@@ -47,16 +41,16 @@
                             </select>
                         </div>
                     </div>
-                    {{/if}}
 
-                    {{#if isItemEffect}}
+                    {{!-- We may enable this later, but for now, disable it. --}}
+                    {{!-- {{#if isItemEffect}}
                     <div class="form-group">
                         <label>{{ localize "EFFECT.Transfer" }}</label>
                         <div class="form-fields">
                             <input type="checkbox" name="effect.transfer" {{checked effect.transfer}}/>
                         </div>
                     </div>
-                    {{/if}}
+                    {{/if}} --}}
 
                     {{#if supportsDescription}}
                     <div class="form-group stacked description">

--- a/src/templates/chat/_chat-effect-part.html
+++ b/src/templates/chat/_chat-effect-part.html
@@ -3,7 +3,7 @@
     <strong class="card-label">Effects:</strong>
     <div class="card-effects-row">
         {{#each data.activeEffects as |effect index|}}
-        <a class="content-link effect-link" data-link data-type="ActiveEffect" data-uuid="{{effect.uuid}}" data-id="{{effect.id}}" draggable="true">
+        <a class="content-link effect-link" data-link data-type="ActiveEffect" data-uuid="{{effect.uuid}}" {{#if effect.duration}}data-duration="{{effect.duration}}"{{/if}} data-id="{{effect.id}}" draggable="true">
             <img class="effects-icon" src="{{effect.img}}"/>
             {{effect.name}}
         </a>


### PR DESCRIPTION
- Updated active effect sheet to not close when changes are submitted, which had caused some UX annoyances. Also updated it to submit on change.
- Updated active effect sheet to save durations.
- Minor styling improvements for the description field on the effect sheet.
- Added support for durations to effects rendered in chat.