### PR TITLE
Add stoke and custom resources to NPCs

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -459,6 +459,7 @@ ARCHMAGE:
     mdBonus: MD Bonus
     meleeBonus: Melee Attack Bonus
     ongoingDamage: Ongoing Damage
+    ongoingDamageCrit: Ongoing Damage is from a critical hit
     otherBonuses: Other Bonuses
     pdBonus: PD Bonus
     price: Price

--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -194,7 +194,7 @@ ARCHMAGE:
     automateHPConditionsName: Auto-manage Dead and Staggered
     ColorblindHint: Change the colors of the power cards to a more accessibile color palette.
     ColorblindName: Enable Colorblind Accessibility Mode
-    ColorblindIssuesMessage: We're always trying to improve our accessibility. Suggest accessibility improvements at <a href="https://gitlab.com/asacolips-projects/foundry-mods/archmage/-/issues/new" target="_blank">our issue tracker</a> and include the <strong>a11y</strong> label. 
+    ColorblindIssuesMessage: We're always trying to improve our accessibility. Suggest accessibility improvements at <a href="https://gitlab.com/asacolips-projects/foundry-mods/archmage/-/issues/new" target="_blank">our issue tracker</a> and include the <strong>a11y</strong> label.
     ColorblindOptioncolorBlindBY: Tritanopia (Blue/Yellow)
     ColorblindOptioncolorBlindRG: Protanopla / Deutanopla (Red/Green)
     ColorblindOptionDefault: Default Colors
@@ -596,6 +596,7 @@ ARCHMAGE:
     NoUsesMsg: No uses left, do you want to use this anyway?
     numbersOnly: Numbers only, such as '16'
     odd: odd
+    ongoingDamageTooltip: '{damage} ongoing {type} damage'
     ongoingDamage: '{target} takes [[{damage}]] ongoing {type}damage due to {source}'
     ongoingSelfEnded: The following Effects <strong>have ended on this</strong> Actor
     ongoingOtherEnded: The following Effects <strong>have ended on another</strong> Actor

--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -535,6 +535,7 @@ ARCHMAGE:
     applyAETitle: Apply Active Effect?
     applyDamage: Apply Damage
     breathWeapon: Breath Weapon
+    breath: 'Breath'
     Cancel: Cancel
     castBroadEffect: Cast for Broad Effect
     castPower: Cast for Power

--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -6,6 +6,8 @@ ARCHMAGE:
   action: Action
   actions: Actions
   add: Add
+  arc: Arc
+  arc-desparate: Arc/Desperate
   at-will: At-Will
   attack: Attack
   attackMod: Attack Modifier
@@ -44,7 +46,9 @@ ARCHMAGE:
   contextApplyTempHealth: Apply as Temp Health
   critModAtk: Crit Modifier (Attack)
   critModDef: Crit Modifier (Defense)
+  cyclic: Cyclic
   daily: Daily
+  daily-desperate: Arc/Desperate
   defenses: Defenses
   description: Description
   details: Details

--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -273,6 +273,7 @@ ARCHMAGE:
       rerollSave: Reroll Save
       rerollSaveDesc: Reroll a save
       rhythm: Combat Rhythm
+      stoke: Stoke
     RHYTHMCHOICES:
       none: None
       offense: Offense

--- a/src/module/active-effects/effect-sheet.js
+++ b/src/module/active-effects/effect-sheet.js
@@ -49,6 +49,7 @@ export class EffectArchmageSheet extends ActiveEffectConfig {
     context.duration = context.effect.flags.archmage?.duration || "Unknown";
     context.ongoingDamage = context.effect.flags.archmage?.ongoingDamage || 0;
     context.ongoingDamageType = context.effect.flags.archmage?.ongoingDamageType || "";
+    context.ongoingDamageCrit = context.effect.flags.archmage?.ongoingDamageCrit || false;
 
     return context;
   }
@@ -89,7 +90,8 @@ export class EffectArchmageSheet extends ActiveEffectConfig {
     ae.flags.archmage = {
       duration: formData.duration,
       ongoingDamage: formData.ongoingDamage,
-      ongoingDamageType: formData.ongoingDamageType
+      ongoingDamageType: formData.ongoingDamageType,
+      ongoingDamageCrit: formData.ongoingDamageCrit,
     };
 
     // Retrieve the existing effects.

--- a/src/module/actor/actor-npc-sheet-v2.js
+++ b/src/module/actor/actor-npc-sheet-v2.js
@@ -127,7 +127,7 @@ export class ActorArchmageNpcSheetV2 extends ActorArchmageSheetV2 {
       name: game.archmage.ArchmageUtility.formatNewItemName(itemType),
       type: itemType,
       img: img,
-      data: data
+      system: data
     };
     await this.actor.createEmbeddedDocuments('Item', [itemData]);
   }

--- a/src/module/actor/actor-sheet-v2.js
+++ b/src/module/actor/actor-sheet-v2.js
@@ -355,7 +355,7 @@ export class ActorArchmageSheetV2 extends ActorSheet {
       name: game.archmage.ArchmageUtility.formatNewItemName(itemType),
       type: itemType,
       img: img,
-      data: data
+      system: data
     };
     await this.actor.createEmbeddedDocuments('Item', [itemData]);
   }

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -1679,6 +1679,14 @@ export class ActorArchmage extends Actor {
           delta.signedString()+" "+suffix,
           foundry.utils.mergeObject(textOptions, overrideOptions)
         );
+        // Flash dynamic token rings.
+        if (token?.ring) {
+          const flashColor = delta < 0 ? Color.fromString('#ff0000') : Color.fromString('#00ff00');
+          token.ring.flashColor(flashColor, {
+            duration: 600,
+            easing: foundry.canvas.tokens.TokenRing.easeTwoPeaks,
+          });
+        }
       }
     }
   }

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -624,14 +624,6 @@ export class ActorArchmage extends Actor {
   _prepareNPCData(data, model, flags) {
     // init.mod is used for rolls, while value is used on the sheet.
     data.attributes.init.mod = data.attributes.init.value;
-
-    // Handle stoke.
-    if (data.details.type.value === 'dragon') {
-      data.resources.spendable.stoke.enabled = true;
-    }
-    else {
-      data.resources.spendable.stoke.enabled = false;
-    }
   }
 
   /** @inheritdoc */

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -1659,7 +1659,7 @@ export class ActorArchmage extends Actor {
    *
    * @return {undefined}
    */
-  _showScrollingText(delta, suffix="", overrideOptions={}) {
+  _showScrollingText(delta, suffix="", overrideOptions={}, ringColor = null) {
     // Show scrolling text of hp update
     const tokens = this.isToken ? [this.token?.object] : this.getActiveTokens(true);
     if (delta != 0 && tokens.length > 0) {
@@ -1681,7 +1681,8 @@ export class ActorArchmage extends Actor {
         );
         // Flash dynamic token rings.
         if (token?.ring) {
-          const flashColor = delta < 0 ? Color.fromString('#ff0000') : Color.fromString('#00ff00');
+          let flashColor = delta < 0 ? Color.fromString('#ff0000') : Color.fromString('#00ff00');
+          if (ringColor) flashColor = Color.fromString(ringColor);
           token.ring.flashColor(flashColor, {
             duration: 600,
             easing: foundry.canvas.tokens.TokenRing.easeTwoPeaks,

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -624,6 +624,14 @@ export class ActorArchmage extends Actor {
   _prepareNPCData(data, model, flags) {
     // init.mod is used for rolls, while value is used on the sheet.
     data.attributes.init.mod = data.attributes.init.value;
+
+    // Handle stoke.
+    if (data.details.type.value === 'dragon') {
+      data.resources.spendable.stoke.enabled = true;
+    }
+    else {
+      data.resources.spendable.stoke.enabled = false;
+    }
   }
 
   /** @inheritdoc */

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -186,6 +186,8 @@ Hooks.once('init', async function() {
   });
 
   CONFIG.ARCHMAGE = ARCHMAGE;
+  // Default the 2e constant to false, but the setting will be checked later in the 'ready' hook.
+  CONFIG.ARCHMAGE.is2e = false;
 
   // Update status effects.
   function _setArchmageStatusEffects(extended) {
@@ -690,6 +692,9 @@ Hooks.once('ready', () => {
   addEscalationDie();
   $('body').append('<div class="archmage-preload"></div>');
   renderSceneTerrains();
+
+  // Add a constant for whether or not we're on 2e.
+  CONFIG.ARCHMAGE.is2e = game.settings.get('archmage', 'secondEdition');
 
   // Add effect link drag data
   document.addEventListener("dragstart", event => {

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -1113,7 +1113,6 @@ Hooks.on('dropCanvasData', async (canvas, data) => {
     }
     return token;
   }
-
   const token = findToken();
   if (!token) return;
   return await _applyAE(token.actor, data);
@@ -1122,12 +1121,19 @@ Hooks.on('dropCanvasData', async (canvas, data) => {
 async function _applyAE(actor, data) {
 
   if ( data.type === "condition" ) {
+    // Handle hampered in 2e.
+    if (CONFIG.ARCHMAGE.is2e && data.id === 'hampered') {
+      data.id = 'hindered';
+    }
+    // Check for existing statuses.
     let statusEffect = CONFIG.statusEffects.find(x => x.id === data.id || x.id === data.name?.toLowerCase());
     if ( statusEffect ) {
       statusEffect = foundry.utils.duplicate(statusEffect);
       statusEffect.label = game.i18n.localize(statusEffect.name);
       statusEffect.name = statusEffect.label;
       statusEffect.origin = data.source;
+      // Add it as a status so that it can be toggled on the token.
+      statusEffect.statuses = [statusEffect.id];
 
       return await _applyAEDurationDialog(actor, statusEffect, "Unknown", data.source, data.type);
     }

--- a/src/module/hooks/combat.mjs
+++ b/src/module/hooks/combat.mjs
@@ -32,8 +32,20 @@ export async function handleTurnEffects(prefix, combat, combatant, context, opti
 
     for (const effect of combatant.actor.effects) {
         if (!effect.active) continue;
+        // Handle ongoing.
         const isOngoing = effect.flags.archmage?.ongoingDamage != 0;
         effect.isOngoing = isOngoing;
+        const isCrit = isOngoing && effect.flags.archmage?.ongoingDamageCrit === true;
+        effect.isCrit = isCrit;
+        effect.ongoingDamage = isOngoing ? Number(effect.flags.archmage.ongoingDamage) : 0;
+        effect.ongoingTooltip = game.i18n.format('ARCHMAGE.CHAT.ongoingDamageTooltip', {
+            damage: effect.ongoingDamage,
+            type: effect.flags.archmage?.ongoingDamageType ?? '',
+        });
+        if (isCrit) {
+            effect.ongoingDamage = effect.ongoingDamage * 2;
+        }
+        // Handle durations.
         if (effect.name === game.i18n.localize("ARCHMAGE.EFFECT.StatusDead")) isDead = true;
         const duration = effect.flags.archmage?.duration || "Unknown";
         if (duration === `${prefix}OfNextTurn`) {
@@ -61,6 +73,16 @@ export async function handleTurnEffects(prefix, combat, combatant, context, opti
             for (const effect of otherCombatant.actor.effects) {
                 const isOngoing = effect.flags.archmage?.ongoingDamage != 0;
                 effect.isOngoing = isOngoing;
+                const isCrit = isOngoing && effect.flags.archmage?.ongoingDamageCrit === true;
+                effect.isCrit = isCrit;
+                effect.ongoingDamage = isOngoing ? Number(effect.flags.archmage.ongoingDamage) : 0;
+                effect.ongoingTooltip = game.i18n.format('ARCHMAGE.CHAT.ongoingDamageTooltip', {
+                    damage: effect.ongoingDamage,
+                    type: effect.flags.archmage?.ongoingDamageType ?? '',
+                });
+                if (isCrit) {
+                    effect.ongoingDamage = effect.ongoingDamage * 2;
+                }
                 const duration = effect.flags.archmage?.duration || "Unknown";
                 if (duration === `${prefix}OfNextSourceTurn` && effect.origin === combatant.actor.uuid) {
                     // Ensure it's the *next* turn
@@ -110,6 +132,16 @@ export async function preDeleteCombat(combat, context, options) {
                 if (!effect.active) continue;
                 const isOngoing = effect.flags.archmage?.ongoingDamage != 0;
                 effect.isOngoing = isOngoing;
+                const isCrit = isOngoing && effect.flags.archmage?.ongoingDamageCrit === true;
+                effect.isCrit = isCrit;
+                effect.ongoingDamage = isOngoing ? Number(effect.flags.archmage.ongoingDamage) : 0;
+                effect.ongoingTooltip = game.i18n.format('ARCHMAGE.CHAT.ongoingDamageTooltip', {
+                    damage: effect.ongoingDamage,
+                    type: effect.flags.archmage?.ongoingDamageType ?? '',
+                });
+                if (isCrit) {
+                    effect.ongoingDamage = effect.ongoingDamage * 2;
+                }
                 const duration = effect.flags.archmage?.duration || "Unknown";
                 // If duration is "Infinite" skip
                 if (duration === "Infinite") continue;

--- a/src/module/hooks/combat.mjs
+++ b/src/module/hooks/combat.mjs
@@ -9,12 +9,17 @@ export async function combatTurn(combat, context, options) {
     const startCombatant = combat.nextCombatant;
     await handleTurnEffects("End", combat, endCombatant, context, options);
     await handleTurnEffects("Start", combat, startCombatant, context, options);
+    if (game.settings.get('archmage', 'secondEdition')) {
+        await handleStoke(combat, context, options);
+    }
 }
 
 export async function handleTurnEffects(prefix, combat, combatant, context, options) {
+    // Pseudo combatants may not have an actor.
+    if (!combatant?.actor) return;
 
     const saveEndsEffects = ["EasySaveEnds", "NormalSaveEnds", "HardSaveEnds"];
-    const hasImplacable = combatant.actor.flags.archmage?.implacable ?? false;
+    const hasImplacable = combatant?.actor?.flags.archmage?.implacable ?? false;
     const currentCombatantEffectData = {
         selfEnded: [],
         savesEnds: [],
@@ -52,22 +57,24 @@ export async function handleTurnEffects(prefix, combat, combatant, context, opti
     // For each other combatant, check if their EndOfNextSourceTurn effects reference this combatant's actor as the source
     for (const otherCombatant of combat.combatants) {
         effectsToDelete = [];
-        for (const effect of otherCombatant.actor.effects) {
-            const isOngoing = effect.flags.archmage?.ongoingDamage != 0;
-            effect.isOngoing = isOngoing;
-            const duration = effect.flags.archmage?.duration || "Unknown";
-            if (duration === `${prefix}OfNextSourceTurn` && effect.origin === combatant.actor.uuid) {
-                // Ensure it's the *next* turn
-                if (combat.round  > effect.duration.startRound
-                || (combat.round == effect.duration.startRound && combat.turn > effect.duration.startTurn)) {
-                    effect.otherName = otherCombatant.actor.name;
-                    currentCombatantEffectData.otherEnded.push(effect);
-                    effectsToDelete.push(effect.id);
+        if (otherCombatant?.actor?.effects) {
+            for (const effect of otherCombatant.actor.effects) {
+                const isOngoing = effect.flags.archmage?.ongoingDamage != 0;
+                effect.isOngoing = isOngoing;
+                const duration = effect.flags.archmage?.duration || "Unknown";
+                if (duration === `${prefix}OfNextSourceTurn` && effect.origin === combatant.actor.uuid) {
+                    // Ensure it's the *next* turn
+                    if (combat.round  > effect.duration.startRound
+                    || (combat.round == effect.duration.startRound && combat.turn > effect.duration.startTurn)) {
+                        effect.otherName = otherCombatant.actor.name;
+                        currentCombatantEffectData.otherEnded.push(effect);
+                        effectsToDelete.push(effect.id);
+                    }
                 }
             }
+            // Auto-delete AEs
+            await otherCombatant.actor.deleteEmbeddedDocuments("ActiveEffect", effectsToDelete);
         }
-        // Auto-delete AEs
-        await otherCombatant.actor.deleteEmbeddedDocuments("ActiveEffect", effectsToDelete);
     }
 
     if (!isDead) {
@@ -136,6 +143,17 @@ export async function preDeleteCombat(combat, context, options) {
 
         // Auto-delete AEs
         await combatant.actor.deleteEmbeddedDocuments("ActiveEffect", effectsToDelete);
+    }
+}
+
+async function handleStoke(combat, context, options) {
+    const endCombatant = combat.combatant;
+    if (endCombatant?.actor?.type === 'npc' && endCombatant.actor.system?.details?.type?.value === 'dragon') {
+        const stokeDelta = endCombatant.getFlag('archmage', 'breathUsed') ? -1 : 1;
+        await endCombatant.actor.update({
+            'system.resources.spendable.stoke.current': stokeDelta + (endCombatant.actor.system.resources.spendable.stoke.current ?? 0),
+        });
+        await endCombatant.setFlag('archmage', 'breathUsed', false);
     }
 }
 

--- a/src/module/hooks/combat.mjs
+++ b/src/module/hooks/combat.mjs
@@ -180,7 +180,7 @@ export async function preDeleteCombat(combat, context, options) {
 
 async function handleStoke(combat, context, options) {
     const endCombatant = combat.combatant;
-    if (endCombatant?.actor?.type === 'npc' && endCombatant.actor.system?.details?.type?.value === 'dragon') {
+    if (endCombatant?.actor?.type === 'npc' && endCombatant.actor.system?.resources?.spendable?.stoke?.enabled) {
         const stokeDelta = endCombatant.getFlag('archmage', 'breathUsed') ? -1 : 1;
         await endCombatant.actor.update({
             'system.resources.spendable.stoke.current': stokeDelta + (endCombatant.actor.system.resources.spendable.stoke.current ?? 0),

--- a/src/module/hooks/combat.mjs
+++ b/src/module/hooks/combat.mjs
@@ -9,7 +9,7 @@ export async function combatTurn(combat, context, options) {
     const startCombatant = combat.nextCombatant;
     await handleTurnEffects("End", combat, endCombatant, context, options);
     await handleTurnEffects("Start", combat, startCombatant, context, options);
-    if (game.settings.get('archmage', 'secondEdition')) {
+    if (CONFIG.ARCHMAGE.is2e) {
         await handleStoke(combat, context, options);
     }
 }

--- a/src/module/hooks/combat.mjs
+++ b/src/module/hooks/combat.mjs
@@ -186,6 +186,8 @@ async function handleStoke(combat, context, options) {
             'system.resources.spendable.stoke.current': stokeDelta + (endCombatant.actor.system.resources.spendable.stoke.current ?? 0),
         });
         await endCombatant.setFlag('archmage', 'breathUsed', false);
+        // Show scrolling text for the update.
+        endCombatant.actor._showScrollingText(stokeDelta, game.i18n.localize('ARCHMAGE.CHARACTER.RESOURCES.stoke'), {}, '#1776D5');
     }
 }
 

--- a/src/module/hooks/preCreateChatMessageHandler.mjs
+++ b/src/module/hooks/preCreateChatMessageHandler.mjs
@@ -125,8 +125,16 @@ export default class preCreateChatMessageHandler {
 
         // In 2e sorcerer breath spells add the E.D. to their crit range
         let addEdToCritRange = false;
+        let addStokeToCritRange = false;
         if (game.settings.get("archmage", "secondEdition")) {
-          addEdToCritRange = options.item.system.breathWeapon?.value?.length > 0;
+            addEdToCritRange = options.item.system.breathWeapon?.value?.length > 0;
+            // Dragons also can increase their crit range.
+            if (options.actor.system.details?.type?.value === 'dragon') {
+                const breathString = game.i18n.localize('ARCHMAGE.CHAT.breath').toLocaleLowerCase().trim();
+                if (options.item.name.toLocaleLowerCase().includes(breathString)) {
+                    addStokeToCritRange = true;
+                }
+            }
         }
 
         $content = $(`<div class="wrapper">${data.content}</div>`);
@@ -179,7 +187,7 @@ export default class preCreateChatMessageHandler {
                 }
 
                 if (row_text_clean.startsWith(game.i18n.localize("ARCHMAGE.CHAT.attack") + ':')) {
-                    hitEvaluationResults = HitEvaluation.processRowText(row_text, targets, $row_self, actor, addEdToCritRange);
+                    hitEvaluationResults = HitEvaluation.processRowText(row_text, targets, $row_self, actor, addEdToCritRange, addStokeToCritRange);
                 }
 
                 if (hitEvaluationResults) {

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -95,7 +95,7 @@ export class ItemArchmage extends Item {
 
     // Set a flag for stoke adjustments.
     if (game.settings.get('archmage', 'secondEdition')) {
-      if (this.actor.type === 'npc' && this.actor.system.details.type.value === 'dragon') {
+      if (this.actor.type === 'npc' && this.actor.system?.resources?.spendable?.stoke?.enabled) {
         if (game.combat?.combatant) {
           const combatantUuid = game.combat.combatant?.actor?.uuid;
           const breathString = game.i18n.localize('ARCHMAGE.CHAT.breath').toLocaleLowerCase().trim();

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -94,7 +94,7 @@ export class ItemArchmage extends Item {
     await this._handleRetainFocus(itemToRender, hitEvalRes, actorUpdateData, chatData);
 
     // Set a flag for stoke adjustments.
-    if (game.settings.get('archmage', 'secondEdition')) {
+    if (CONFIG.ARCHMAGE.is2e) {
       if (this.actor.type === 'npc' && this.actor.system?.resources?.spendable?.stoke?.enabled) {
         if (game.combat?.combatant) {
           const combatantUuid = game.combat.combatant?.actor?.uuid;

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -93,6 +93,20 @@ export class ItemArchmage extends Item {
     await this._handleBreathSpell(itemToRender);
     await this._handleRetainFocus(itemToRender, hitEvalRes, actorUpdateData, chatData);
 
+    // Set a flag for stoke adjustments.
+    if (game.settings.get('archmage', 'secondEdition')) {
+      if (this.actor.type === 'npc' && this.actor.system.details.type.value === 'dragon') {
+        if (game.combat?.combatant) {
+          const combatantUuid = game.combat.combatant?.actor?.uuid;
+          const breathString = game.i18n.localize('ARCHMAGE.CHAT.breath').toLocaleLowerCase().trim();
+          if (combatantUuid && combatantUuid == this.actor.uuid && this.name.toLocaleLowerCase().includes(breathString)) {
+            // This will be set to false at the start of the actor's turn.
+            game.combat.combatant.setFlag('archmage', 'breathUsed', true);
+          }
+        }
+      }
+    }
+
     // Run embedded macro.
     let macro = await this._rollExecuteMacro(itemToRender, itemUpdateData, actorUpdateData, chatData, hitEvalRes, sequencerAnim, token, usageMode);
     // Unpack macro data in case a sloppy macro replaces instead of modifying variables

--- a/src/module/rolls/HitEvaluation.mjs
+++ b/src/module/rolls/HitEvaluation.mjs
@@ -2,7 +2,7 @@ import ArchmageRolls from "../rolls/ArchmageRolls.mjs";
 
 export default class HitEvaluation {
 
-    static processRowText(row_text, targets, $row_self, attacker, addEdToCritRange) {
+    static processRowText(row_text, targets, $row_self, attacker, addEdToCritRange = false, addStokeToCritRange = false) {
         // If the user currently has Targets selected, try and figure out if we hit or missed said target
 
         let targetsHit = [];
@@ -39,6 +39,7 @@ export default class HitEvaluation {
             let target = (roll_index < targetsToProcess) ? targets[roll_index]: undefined;
             let critRangeMinTarget = critRangeMin - HitEvaluation._getTargetCritDefenseValue(target);
             if (addEdToCritRange) critRangeMinTarget -= attacker.system.attributes.escalation.value;
+            if (addStokeToCritRange) critRangeMinTarget -= Math.max(attacker.system?.resources?.spendable?.stoke?.current ?? 0, 0);
             for (let i = 0; i < roll_data.terms.length; i++) {
               var part = roll_data.terms[i];
               if (part.results) {

--- a/src/packs/src/srd-monsters/Blizzard_Dragon__White__5Vp1aeQc2jQGNgpy.yml
+++ b/src/packs/src/srd-monsters/Blizzard_Dragon__White__5Vp1aeQc2jQGNgpy.yml
@@ -119,6 +119,66 @@ system:
       value: 6
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: giUcCdg4MVr0RyUr
     flags: {}

--- a/src/packs/src/srd-monsters/Catacomb_Dragon__Black__8cTzRPlsPBXxpmiT.yml
+++ b/src/packs/src/srd-monsters/Catacomb_Dragon__Black__8cTzRPlsPBXxpmiT.yml
@@ -119,6 +119,66 @@ system:
       value: 3
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: 6LvyIWA0wzug5qLE
     flags: {}

--- a/src/packs/src/srd-monsters/Cenotaph_Dragon__White__jyFDzHVEsQjP2nJ4.yml
+++ b/src/packs/src/srd-monsters/Cenotaph_Dragon__White__jyFDzHVEsQjP2nJ4.yml
@@ -119,6 +119,66 @@ system:
       value: 3
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: Lpop0FIP64qxLTBq
     flags: {}

--- a/src/packs/src/srd-monsters/Empyrean_Dragon__Black__MT7D2ZQhiio010YI.yml
+++ b/src/packs/src/srd-monsters/Empyrean_Dragon__Black__MT7D2ZQhiio010YI.yml
@@ -119,6 +119,66 @@ system:
       value: 9
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: TJ9F0VxozBMgeGv3
     flags: {}

--- a/src/packs/src/srd-monsters/Flamewreathed_Dragon__Red__NC2LGEPu81AyTj3X.yml
+++ b/src/packs/src/srd-monsters/Flamewreathed_Dragon__Red__NC2LGEPu81AyTj3X.yml
@@ -119,6 +119,66 @@ system:
       value: 12
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: vapoOzENSucCNRet
     flags: {}

--- a/src/packs/src/srd-monsters/Gorge_Dragon__Black__FfG992lOYvyqrjkB.yml
+++ b/src/packs/src/srd-monsters/Gorge_Dragon__Black__FfG992lOYvyqrjkB.yml
@@ -119,6 +119,66 @@ system:
       value: 5
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: yNlT4OXPWCJ5gPAw
     flags: {}

--- a/src/packs/src/srd-monsters/Greathoard_elder__Red__Yxj7ERaB70RcSYkK.yml
+++ b/src/packs/src/srd-monsters/Greathoard_elder__Red__Yxj7ERaB70RcSYkK.yml
@@ -121,6 +121,66 @@ system:
       value: 11
       min: 0
       max: 10
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: SUqrHWPY9kuxRoOQ
     flags: {}

--- a/src/packs/src/srd-monsters/Hoardsong_Dragon__Red__6t1WceFl0n8rOgYp.yml
+++ b/src/packs/src/srd-monsters/Hoardsong_Dragon__Red__6t1WceFl0n8rOgYp.yml
@@ -121,6 +121,66 @@ system:
       value: 9
       min: 0
       max: 10
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: 3tExos08lleUG9Nh
     flags: {}

--- a/src/packs/src/srd-monsters/Huge_Black_Dragon_1j2K3ryrnDWKaKKV.yml
+++ b/src/packs/src/srd-monsters/Huge_Black_Dragon_1j2K3ryrnDWKaKKV.yml
@@ -119,6 +119,66 @@ system:
       value: 9
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: dnvMQCV0UFzAei7g
     flags: {}

--- a/src/packs/src/srd-monsters/Huge_Blue_Dragon_RPlCfAz5ypEeo5LH.yml
+++ b/src/packs/src/srd-monsters/Huge_Blue_Dragon_RPlCfAz5ypEeo5LH.yml
@@ -119,6 +119,66 @@ system:
       value: 12
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: WhYAp9jKHlpY0rba
     flags: {}

--- a/src/packs/src/srd-monsters/Huge_Brass_Dragon__Metallic__ZNlL3LuF3ASgA6W6.yml
+++ b/src/packs/src/srd-monsters/Huge_Brass_Dragon__Metallic__ZNlL3LuF3ASgA6W6.yml
@@ -119,6 +119,66 @@ system:
       value: 4
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: v6qWtnR7dj9DUMdA
     flags: {}

--- a/src/packs/src/srd-monsters/Huge_Bronze_Dragon__Metallic__1rxcwrJp1DqNLG8F.yml
+++ b/src/packs/src/srd-monsters/Huge_Bronze_Dragon__Metallic__1rxcwrJp1DqNLG8F.yml
@@ -119,6 +119,66 @@ system:
       value: 9
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: Xa0aF6tIzU5DXuI2
     flags: {}

--- a/src/packs/src/srd-monsters/Huge_Copper_Dragon__Metallic__uhXPwGgX5ZzOKuQn.yml
+++ b/src/packs/src/srd-monsters/Huge_Copper_Dragon__Metallic__uhXPwGgX5ZzOKuQn.yml
@@ -119,6 +119,66 @@ system:
       value: 11
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: VmBgBVJo1FUVXJVi
     flags: {}

--- a/src/packs/src/srd-monsters/Huge_Gold_Dragon__Metallic__VFls7iXvokI7AeWp.yml
+++ b/src/packs/src/srd-monsters/Huge_Gold_Dragon__Metallic__VFls7iXvokI7AeWp.yml
@@ -119,6 +119,66 @@ system:
       value: 14
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: 46dk3tJ99awXS5dY
     flags: {}

--- a/src/packs/src/srd-monsters/Huge_Green_Dragon_EBeb047C5LBIZE7r.yml
+++ b/src/packs/src/srd-monsters/Huge_Green_Dragon_EBeb047C5LBIZE7r.yml
@@ -119,6 +119,66 @@ system:
       value: 11
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: lB1XdXhba7ngTFVz
     flags: {}

--- a/src/packs/src/srd-monsters/Huge_Red_Dragon_piVOzj9ljQ2Nc8XA.yml
+++ b/src/packs/src/srd-monsters/Huge_Red_Dragon_piVOzj9ljQ2Nc8XA.yml
@@ -119,6 +119,66 @@ system:
       value: 13
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: MBC9eUJCQGEhcmqq
     flags: {}

--- a/src/packs/src/srd-monsters/Huge_Silver_Dragon__Metallic__JXu6g20rItl1bGeW.yml
+++ b/src/packs/src/srd-monsters/Huge_Silver_Dragon__Metallic__JXu6g20rItl1bGeW.yml
@@ -119,6 +119,66 @@ system:
       value: 13
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: VScEqreHW83n2XUt
     flags: {}

--- a/src/packs/src/srd-monsters/Huge_White_Dragon_ouNkVCZEHYF9WJEY.yml
+++ b/src/packs/src/srd-monsters/Huge_White_Dragon_ouNkVCZEHYF9WJEY.yml
@@ -119,6 +119,66 @@ system:
       value: 5
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: I1iQTHBj90UIUqlN
     flags: {}

--- a/src/packs/src/srd-monsters/Large_Black_Dragon_BPIodF4Ja1Fzrq0w.yml
+++ b/src/packs/src/srd-monsters/Large_Black_Dragon_BPIodF4Ja1Fzrq0w.yml
@@ -119,6 +119,66 @@ system:
       value: 6
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: 1zAVmX4quFmYQNMt
     flags: {}

--- a/src/packs/src/srd-monsters/Large_Blue_Dragon_HY35ul0coNqlTqhH.yml
+++ b/src/packs/src/srd-monsters/Large_Blue_Dragon_HY35ul0coNqlTqhH.yml
@@ -119,6 +119,66 @@ system:
       value: 8
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: T0Y6V05aqBDmQTpJ
     flags: {}

--- a/src/packs/src/srd-monsters/Large_Brass_Dragon__Metallic__6kxxGcBiwqvaKNZ2.yml
+++ b/src/packs/src/srd-monsters/Large_Brass_Dragon__Metallic__6kxxGcBiwqvaKNZ2.yml
@@ -119,6 +119,66 @@ system:
       value: 3
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: ujusJEYOwl9Wu44M
     flags: {}

--- a/src/packs/src/srd-monsters/Large_Bronze_Dragon__Metallic__XT9Kp19Tfm1f1iQ4.yml
+++ b/src/packs/src/srd-monsters/Large_Bronze_Dragon__Metallic__XT9Kp19Tfm1f1iQ4.yml
@@ -119,6 +119,66 @@ system:
       value: 6
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: AwFgxYpR5EKOnVHW
     flags: {}

--- a/src/packs/src/srd-monsters/Large_Copper_Dragon__Metallic__pvCCsyJ9PIt1AgMb.yml
+++ b/src/packs/src/srd-monsters/Large_Copper_Dragon__Metallic__pvCCsyJ9PIt1AgMb.yml
@@ -119,6 +119,66 @@ system:
       value: 9
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: p2SIaoQp3athDwIC
     flags: {}

--- a/src/packs/src/srd-monsters/Large_Gold_Dragon__Metallic__I7EJYb2eB5bArUz1.yml
+++ b/src/packs/src/srd-monsters/Large_Gold_Dragon__Metallic__I7EJYb2eB5bArUz1.yml
@@ -119,6 +119,66 @@ system:
       value: 11
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: tFatr6igOvUebAft
     flags: {}

--- a/src/packs/src/srd-monsters/Large_Green_Dragon_1QTA8lvKy6tanrLA.yml
+++ b/src/packs/src/srd-monsters/Large_Green_Dragon_1QTA8lvKy6tanrLA.yml
@@ -119,6 +119,66 @@ system:
       value: 7
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: MLOx0lGiB07Rw6iD
     flags: {}

--- a/src/packs/src/srd-monsters/Large_Red_Dragon_bJEZdUrLa8vmzaNs.yml
+++ b/src/packs/src/srd-monsters/Large_Red_Dragon_bJEZdUrLa8vmzaNs.yml
@@ -119,6 +119,66 @@ system:
       value: 10
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: 6yNFaNffcTSZP5jk
     flags: {}

--- a/src/packs/src/srd-monsters/Large_Silver_Dragon__Metallic__4JUQkcWeXyEzbc3y.yml
+++ b/src/packs/src/srd-monsters/Large_Silver_Dragon__Metallic__4JUQkcWeXyEzbc3y.yml
@@ -119,6 +119,66 @@ system:
       value: 10
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: vappNpzh3DGFdHSi
     flags: {}

--- a/src/packs/src/srd-monsters/Large_White_Dragon_T2GpGMD7RmJJFGGh.yml
+++ b/src/packs/src/srd-monsters/Large_White_Dragon_T2GpGMD7RmJJFGGh.yml
@@ -119,6 +119,66 @@ system:
       value: 4
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: 3ZqHjQjtAGqBgfmi
     flags: {}

--- a/src/packs/src/srd-monsters/Mausoleum_Dragon__White__d9lCDhHgAI0nQraN.yml
+++ b/src/packs/src/srd-monsters/Mausoleum_Dragon__White__d9lCDhHgAI0nQraN.yml
@@ -119,6 +119,66 @@ system:
       value: 5
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: QrSISLhrgGlSi9Ff
     flags: {}

--- a/src/packs/src/srd-monsters/Medium_Black_Dragon_2IKoP9zzdJEm7PrX.yml
+++ b/src/packs/src/srd-monsters/Medium_Black_Dragon_2IKoP9zzdJEm7PrX.yml
@@ -119,6 +119,66 @@ system:
       value: 3
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: T5BeEcIRV6MzoC99
     flags: {}

--- a/src/packs/src/srd-monsters/Medium_Blue_Dragon_k0iGuUowV5eOMdLZ.yml
+++ b/src/packs/src/srd-monsters/Medium_Blue_Dragon_k0iGuUowV5eOMdLZ.yml
@@ -119,6 +119,66 @@ system:
       value: 5
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: gGqv7ZsnBCquQ3Qj
     flags: {}

--- a/src/packs/src/srd-monsters/Medium_Brass_Dragon__Metallic__5d8L7CnRCOdHb8gj.yml
+++ b/src/packs/src/srd-monsters/Medium_Brass_Dragon__Metallic__5d8L7CnRCOdHb8gj.yml
@@ -119,6 +119,66 @@ system:
       value: 2
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: KXecFETPlRb7ce6Q
     flags: {}

--- a/src/packs/src/srd-monsters/Medium_Bronze_Dragon__Metallic__W89BD25m4Zhh5T9Z.yml
+++ b/src/packs/src/srd-monsters/Medium_Bronze_Dragon__Metallic__W89BD25m4Zhh5T9Z.yml
@@ -119,6 +119,66 @@ system:
       value: 3
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: h5j0g13cb5SocJQN
     flags: {}

--- a/src/packs/src/srd-monsters/Medium_Copper_Dragon__Metallic__bCzOAlNtNjnrJ9bx.yml
+++ b/src/packs/src/srd-monsters/Medium_Copper_Dragon__Metallic__bCzOAlNtNjnrJ9bx.yml
@@ -119,6 +119,66 @@ system:
       value: 4
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: v5Ue5Jh0fdffba3B
     flags: {}

--- a/src/packs/src/srd-monsters/Medium_Gold_Dragon__Metallic__69Dfv726UoabQXq9.yml
+++ b/src/packs/src/srd-monsters/Medium_Gold_Dragon__Metallic__69Dfv726UoabQXq9.yml
@@ -119,6 +119,66 @@ system:
       value: 7
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: ljHZQsaOWTaI2vyI
     flags: {}

--- a/src/packs/src/srd-monsters/Medium_Green_Dragon_DlH5UCarlFSQOerv.yml
+++ b/src/packs/src/srd-monsters/Medium_Green_Dragon_DlH5UCarlFSQOerv.yml
@@ -119,6 +119,66 @@ system:
       value: 4
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: l5m8keknWAkwTNZs
     flags: {}

--- a/src/packs/src/srd-monsters/Medium_Red_Dragon_L8N9oasC7gVZaPOi.yml
+++ b/src/packs/src/srd-monsters/Medium_Red_Dragon_L8N9oasC7gVZaPOi.yml
@@ -119,6 +119,66 @@ system:
       value: 6
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: RcgqwReQnctUUy4z
     flags: {}

--- a/src/packs/src/srd-monsters/Medium_Silver_Dragon__Metallic__Wl6NK0C7MA3xEWRa.yml
+++ b/src/packs/src/srd-monsters/Medium_Silver_Dragon__Metallic__Wl6NK0C7MA3xEWRa.yml
@@ -119,6 +119,66 @@ system:
       value: 6
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: iEyEJvTkX6cpKMIv
     flags: {}

--- a/src/packs/src/srd-monsters/Medium_White_Dragon_mZErP6QotjUwZTZq.yml
+++ b/src/packs/src/srd-monsters/Medium_White_Dragon_mZErP6QotjUwZTZq.yml
@@ -119,6 +119,66 @@ system:
       value: 2
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: nGQ1tl4SUUe5mLXJ
     flags: {}

--- a/src/packs/src/srd-monsters/Moon_Dragon__White__g9OquqvJoCJ2u9ka.yml
+++ b/src/packs/src/srd-monsters/Moon_Dragon__White__g9OquqvJoCJ2u9ka.yml
@@ -119,6 +119,66 @@ system:
       value: 7
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: quJpTrIGrjxPDwyI
     flags: {}

--- a/src/packs/src/srd-monsters/Shadow_Dragon_2aX994HRJMOg5RRb.yml
+++ b/src/packs/src/srd-monsters/Shadow_Dragon_2aX994HRJMOg5RRb.yml
@@ -119,6 +119,66 @@ system:
       value: 8
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: 16bu71tqURwAFtXh
     flags: {}

--- a/src/packs/src/srd-monsters/The_Purple_Dragon__Adventurer__3R3df3IVw2AqTPKh.yml
+++ b/src/packs/src/srd-monsters/The_Purple_Dragon__Adventurer__3R3df3IVw2AqTPKh.yml
@@ -94,6 +94,66 @@ system:
       value: ''
     vulnerability:
       value: ''
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 prototypeToken:
   name: The Purple Dragon (Adventurer)
   displayName: 0

--- a/src/packs/src/srd-monsters/The_Purple_Dragon__Champion__khOUqTjHj7al85zc.yml
+++ b/src/packs/src/srd-monsters/The_Purple_Dragon__Champion__khOUqTjHj7al85zc.yml
@@ -94,6 +94,66 @@ system:
       value: ''
     vulnerability:
       value: ''
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 prototypeToken:
   name: The Purple Dragon (Champion)
   displayName: 0

--- a/src/packs/src/srd-monsters/The_Purple_Dragon__Epic__5Fsvq4hTjfHVUqIo.yml
+++ b/src/packs/src/srd-monsters/The_Purple_Dragon__Epic__5Fsvq4hTjfHVUqIo.yml
@@ -94,6 +94,66 @@ system:
       value: ''
     vulnerability:
       value: ''
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 prototypeToken:
   name: The Purple Dragon (Epic)
   displayName: 0

--- a/src/packs/src/srd-monsters/Void_Dragon__Black__0IweiCnXWspTLEAg.yml
+++ b/src/packs/src/srd-monsters/Void_Dragon__Black__0IweiCnXWspTLEAg.yml
@@ -119,6 +119,66 @@ system:
       value: 7
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: LPDmUxsvMug8H5ld
     flags: {}

--- a/src/packs/src/srd-monsters/Volcano_Dragon__Red__GyXxuQTzrOygYw12.yml
+++ b/src/packs/src/srd-monsters/Volcano_Dragon__Red__GyXxuQTzrOygYw12.yml
@@ -119,6 +119,66 @@ system:
       value: 7
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: 050saFMaT2YuRraM
     flags: {}

--- a/src/packs/src/srd-monsters/White_Dragon_Hatchling_3nhRHjjPCsQjkQEq.yml
+++ b/src/packs/src/srd-monsters/White_Dragon_Hatchling_3nhRHjjPCsQjkQEq.yml
@@ -119,6 +119,66 @@ system:
       value: 1
       min: 0
       max: 12
+  resources:
+    perCombat: {}
+    spendable:
+      custom1:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom2:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom3:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom4:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom5:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom6:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom7:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom8:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      custom9:
+        label: ''
+        current: 0
+        max: 0
+        enabled: false
+        rest: none
+      stoke:
+        enabled: true
+        current: 0
 items:
   - _id: 41kgI304O72jbJ8g
     flags: {}

--- a/src/scss/v2/components/chat/_ongoing-effects.scss
+++ b/src/scss/v2/components/chat/_ongoing-effects.scss
@@ -22,6 +22,12 @@
       color: $c-white;
     }
 
+    .crit {
+      background: $c-hit-bg;
+      color: $c-hit;
+      font-weight: bold;
+    }
+
     .effects-wrapper {
       margin: 0;
       border: 1px solid #176527;

--- a/src/scss/v2/layout/_grid.scss
+++ b/src/scss/v2/layout/_grid.scss
@@ -60,6 +60,7 @@
 }
 
 // Grid offset.
+.grid-start-1 { grid-column-start: 1 }
 .grid-start-2 { grid-column-start: 2 }
 .grid-start-3 { grid-column-start: 3 }
 .grid-start-4 { grid-column-start: 4 }
@@ -72,6 +73,7 @@
 .grid-start-11 { grid-column-start: 11 }
 .grid-start-12 { grid-column-start: 12 }
 
+.grid-span-1 { grid-column-end: span 1 }
 .grid-span-2 { grid-column-end: span 2 }
 .grid-span-3 { grid-column-end: span 3 }
 .grid-span-4 { grid-column-end: span 4 }

--- a/src/template.yaml
+++ b/src/template.yaml
@@ -448,6 +448,66 @@ Actor:
         value: ''
       vulnerability:
         value: ''
+    resources:
+      perCombat: {}
+      spendable:
+        stoke:
+          enabled: false
+          current: 0
+        custom1:
+          label: ""
+          current: 0
+          max: 0
+          enabled: false
+          rest: "none"
+        custom2:
+          label: ""
+          current: 0
+          max: 0
+          enabled: false
+          rest: "none"
+        custom3:
+          label: ""
+          current: 0
+          max: 0
+          enabled: false
+          rest: "none"
+        custom4:
+          label: ""
+          current: 0
+          max: 0
+          enabled: false
+          rest: "none"
+        custom5:
+          label: ""
+          current: 0
+          max: 0
+          enabled: false
+          rest: "none"
+        custom6:
+          label: ""
+          current: 0
+          max: 0
+          enabled: false
+          rest: "none"
+        custom7:
+          label: ""
+          current: 0
+          max: 0
+          enabled: false
+          rest: "none"
+        custom8:
+          label: ""
+          current: 0
+          max: 0
+          enabled: false
+          rest: "none"
+        custom9:
+          label: ""
+          current: 0
+          max: 0
+          enabled: false
+          rest: "none"
 Item:
   types:
     - power

--- a/src/template.yaml
+++ b/src/template.yaml
@@ -82,9 +82,67 @@ Actor:
         biography:
           type: String
           label: Biography
+      resources:
+        perCombat: {}
+        spendable:
+          custom1:
+            label: ""
+            current: 0
+            max: 0
+            enabled: false
+            rest: "none"
+          custom2:
+            label: ""
+            current: 0
+            max: 0
+            enabled: false
+            rest: "none"
+          custom3:
+            label: ""
+            current: 0
+            max: 0
+            enabled: false
+            rest: "none"
+          custom4:
+            label: ""
+            current: 0
+            max: 0
+            enabled: false
+            rest: "none"
+          custom5:
+            label: ""
+            current: 0
+            max: 0
+            enabled: false
+            rest: "none"
+          custom6:
+            label: ""
+            current: 0
+            max: 0
+            enabled: false
+            rest: "none"
+          custom7:
+            label: ""
+            current: 0
+            max: 0
+            enabled: false
+            rest: "none"
+          custom8:
+            label: ""
+            current: 0
+            max: 0
+            enabled: false
+            rest: "none"
+          custom9:
+            label: ""
+            current: 0
+            max: 0
+            enabled: false
+            rest: "none"
   character:
     templates:
       - standard
+      - resources
     abilities:
       str:
         type: Number
@@ -353,54 +411,6 @@ Actor:
           max: 0
           enabled: false
           rest: "none"
-        custom2:
-          label: ""
-          current: 0
-          max: 0
-          enabled: false
-          rest: "none"
-        custom3:
-          label: ""
-          current: 0
-          max: 0
-          enabled: false
-          rest: "none"
-        custom4:
-          label: ""
-          current: 0
-          max: 0
-          enabled: false
-          rest: "none"
-        custom5:
-          label: ""
-          current: 0
-          max: 0
-          enabled: false
-          rest: "none"
-        custom6:
-          label: ""
-          current: 0
-          max: 0
-          enabled: false
-          rest: "none"
-        custom7:
-          label: ""
-          current: 0
-          max: 0
-          enabled: false
-          rest: "none"
-        custom8:
-          label: ""
-          current: 0
-          max: 0
-          enabled: false
-          rest: "none"
-        custom9:
-          label: ""
-          current: 0
-          max: 0
-          enabled: false
-          rest: "none"
         rerolls:
           enabled: false
           AC:
@@ -433,6 +443,7 @@ Actor:
   npc:
     templates:
       - standard
+      - resources
     details:
       flavor:
         value: ''
@@ -454,60 +465,6 @@ Actor:
         stoke:
           enabled: false
           current: 0
-        custom1:
-          label: ""
-          current: 0
-          max: 0
-          enabled: false
-          rest: "none"
-        custom2:
-          label: ""
-          current: 0
-          max: 0
-          enabled: false
-          rest: "none"
-        custom3:
-          label: ""
-          current: 0
-          max: 0
-          enabled: false
-          rest: "none"
-        custom4:
-          label: ""
-          current: 0
-          max: 0
-          enabled: false
-          rest: "none"
-        custom5:
-          label: ""
-          current: 0
-          max: 0
-          enabled: false
-          rest: "none"
-        custom6:
-          label: ""
-          current: 0
-          max: 0
-          enabled: false
-          rest: "none"
-        custom7:
-          label: ""
-          current: 0
-          max: 0
-          enabled: false
-          rest: "none"
-        custom8:
-          label: ""
-          current: 0
-          max: 0
-          enabled: false
-          rest: "none"
-        custom9:
-          label: ""
-          current: 0
-          max: 0
-          enabled: false
-          rest: "none"
 Item:
   types:
     - power

--- a/src/templates/active-effects/effect.html
+++ b/src/templates/active-effects/effect.html
@@ -182,6 +182,11 @@
                         <input class="attribute-input" name="ongoingDamageType" type="text" value="{{ongoingDamageType}}"
                                data-dtype="String" placeholder="Poison" />
                     </div>
+
+                    <div class="settings-group">
+                        <strong class="attribute-name">{{localize 'ARCHMAGE.ITEM.ongoingDamageCrit'}}</strong>
+                        <input class="attribute-input" name="ongoingDamageCrit" type="checkbox" {{checked ongoingDamageCrit}}/>
+                    </div>
                 </section>
             </div>
         </section>

--- a/src/templates/chat/apply-AE.html
+++ b/src/templates/chat/apply-AE.html
@@ -7,6 +7,13 @@
     <label>{{localize 'ARCHMAGE.CHAT.source'}}</label>
     <span>{{sourceName}}</span>
   </div>
+  {{#if ongoing}}
+  <div class="form-group">
+    <label>{{localize 'ARCHMAGE.ITEM.ongoingDamage'}}</label>
+    <label><input type="checkbox" name="ongoingHalf" />Half damage</label>
+    <label><input type="checkbox" name="ongoingCrit" />Critical Hit</label>
+  </div>
+  {{/if}}
   <div class="form-group">
     <label style="align-self: start;">{{localize 'ARCHMAGE.CHAT.duration'}}</label>
     <div class="form-fields" style="flex-direction: column; align-items: start;">

--- a/src/templates/chat/ongoing-effects-card.html
+++ b/src/templates/chat/ongoing-effects-card.html
@@ -44,9 +44,9 @@
 
 {{!-- Ongoing damage row partial. --}}
 {{#*inline "ongoing-damage"}}
-<div class="grid grid-7col effect" data-effect-id="{{effect._id}}" data-uuid="{{effect.parent.uuid}}" data-value="{{effect.flags.archmage.ongoingDamage}}" data-save="{{effect.flags.archmage.duration}}">
-    <a class="effect-link grid-span-4" draggable="true" data-type="ongoing-damage" data-id="{{effect.id}}" data-tooltip="{{effect.flags.archmage.tooltip}}" data-name="{{effect.name}}"
-        data-value="{{effect.flags.archmage.ongoingDamage}}" data-damage-type="{{effect.flags.archmage.ongoingDamageType}}" data-ends="{{effect.flags.archmage.duration}}" data-source="{{effect.origin}}">
+<div class="grid grid-7col effect {{#if effect.isCrit}}crit{{/if}}" data-effect-id="{{effect._id}}" data-uuid="{{effect.parent.uuid}}" data-value="{{effect.ongoingDamage}}" data-save="{{effect.flags.archmage.duration}}">
+    <a class="effect-link grid-span-4" draggable="true" data-type="ongoing-damage" data-id="{{effect.id}}" data-tooltip="{{effect.ongoingTooltip}}{{#if effect.isCrit}} (x2){{/if}}" data-name="{{effect.name}}"
+        data-value="{{effect.ongoingDamage}}" data-damage-type="{{effect.flags.archmage.ongoingDamageType}}" data-ends="{{effect.flags.archmage.duration}}" data-source="{{effect.origin}}">
         <img class="effects-icon" src="{{effect.icon}}" /> <span class="effect-name">{{effect.name}}</span>
     </a>
     {{> effect-actions showApply=true showSave=true showD20=false showDel=true span=3}}

--- a/src/vue/ArchmageNpcSheet.vue
+++ b/src/vue/ArchmageNpcSheet.vue
@@ -20,7 +20,7 @@
       <section class="section section--main flexcol">
 
         <!-- Class resources -->
-        <CharResources :actor="actor"/>
+        <CharResources v-if="hasResources && tabs.primary.actions.active"  :actor="actor"/>
 
         <!-- Tabs content -->
         <section class="section section--tabs-content flexcol">
@@ -171,6 +171,22 @@ export default {
         }
       }
       return foundry.utils.mergeObject(baseFlags, flags);
+    },
+    hasResources() {
+      let hasResources = false;
+      if (this.actor?.system?.resources) {
+        for (let resourceType of Object.values(this.actor.system.resources)) {
+          if (resourceType) {
+            for (let resource of Object.values(resourceType)) {
+              if (resource?.enabled) {
+                hasResources = true;
+                break;
+              }
+            }
+          }
+        }
+      }
+      return hasResources;
     }
   },
   watch: {},
@@ -195,8 +211,50 @@ export default {
     }
   }
 
+  .section--main {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+  }
+
   .section--resources {
     padding: 10px 0 20px;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: stretch;
+    flex: 0 0 140px;
+
+    &::before,
+    &::after {
+      display: none;
+    }
+
+    .unit,
+    .unit--custom {
+      flex: 0 auto;
+      max-width: none !important; // @todo clean this up, but it works for now.
+      width: 100%;
+      border-left: none;
+      padding: 0 10px 10px;
+
+      + .unit {
+        border-top: 2px solid $c-black--25;
+        padding-top: 10px;
+      }
+    }
+
+    .unit--custom {
+      border-top: 2px solid $c-black--25;
+      padding-top: 10px;
+    }
+
+    .resource-divider {
+      display: none;
+    }
+  }
+
+  .section--tabs-content {
+    flex: 1;
   }
 }
 </style>

--- a/src/vue/ArchmageNpcSheet.vue
+++ b/src/vue/ArchmageNpcSheet.vue
@@ -177,10 +177,14 @@ export default {
       if (this.actor?.system?.resources) {
         for (let resourceType of Object.values(this.actor.system.resources)) {
           if (resourceType) {
-            for (let resource of Object.values(resourceType)) {
-              if (resource?.enabled) {
-                hasResources = true;
-                break;
+            for (let [k,resource] of Object.entries(resourceType)) {
+              // Exclude stoke if this is a 1e game.
+              if (CONFIG.ARCHMAGE.is2e || k !== 'stoke') {
+                // Otherwise update the hasResources value.
+                if (resource?.enabled) {
+                  hasResources = true;
+                  break;
+                }
               }
             }
           }

--- a/src/vue/ArchmageNpcSheet.vue
+++ b/src/vue/ArchmageNpcSheet.vue
@@ -20,7 +20,7 @@
       <section class="section section--main flexcol">
 
         <!-- Class resources -->
-        <!-- <CharResources :actor="actor"/> -->
+        <CharResources :actor="actor"/>
 
         <!-- Tabs content -->
         <section class="section section--tabs-content flexcol">
@@ -50,19 +50,6 @@
       </section>
       <!-- /Main content -->
 
-      <!-- Bottom content -->
-      <!-- <section class="section section--bottom flexcol"> -->
-        <!-- Attributes section -->
-        <!-- <NpcAttributes :actor="actor"/> -->
-        <!-- <CharInitiative :actor="actor"/> -->
-        <!-- <CharAbilities :actor="actor"/> -->
-        <!-- <CharBackgrounds :actor="actor"/> -->
-        <!-- <CharIconRelationships :actor="actor"/> -->
-        <!-- <CharOut :actor="actor" :owner="owner"/> -->
-        <!-- <CharIncrementals :actor="actor"/> -->
-      <!-- </section> -->
-      <!-- /Bottom content -->
-
     </section>
     <!-- /Bottom group -->
 
@@ -75,6 +62,7 @@
 import { concat, localize } from '@/methods/Helpers';
 import CharDetails from '@/components/actor/character/main/CharDetails.vue';
 import CharEffects from '@/components/actor/character/main/CharEffects.vue';
+import CharResources from '@/components/actor/character/main/CharResources.vue';
 import NpcHeader from '@/components/actor/npc/NpcHeader.vue';
 import NpcActions from '@/components/actor/npc/NpcActions.vue';
 import NpcAttributes from '@/components/actor/npc/NpcAttributes.vue';
@@ -96,6 +84,7 @@ export default {
     NpcModifyLevel,
     CharDetails,
     CharEffects,
+    CharResources,
   },
   setup() {
     return {

--- a/src/vue/ArchmageNpcSheet.vue
+++ b/src/vue/ArchmageNpcSheet.vue
@@ -194,5 +194,9 @@ export default {
       margin-top: 0;
     }
   }
+
+  .section--resources {
+    padding: 10px 0 20px;
+  }
 }
 </style>

--- a/src/vue/components/actor/character/main/CharPowers.vue
+++ b/src/vue/components/actor/character/main/CharPowers.vue
@@ -29,7 +29,7 @@
       <div class="power-group-header">
         <!-- Group title and add button. -->
         <div class="power-header-title grid power-grid">
-          <h2 class="power-group-title unit-title">{{localize(group)}}</h2>
+          <h2 class="power-group-title unit-title">{{localize(CONFIG.ARCHMAGE.is2e && group === 'ARCHMAGE.daily' ? 'ARCHMAGE.arc' : group)}}</h2>
           <div class="item-controls">
             <a class="item-control item-create" data-item-type="power" :data-group-type="groupBy" :data-power-type="groupKey"><i class="fas fa-plus"></i> {{localize('ARCHMAGE.add')}}</a>
           </div>
@@ -90,7 +90,8 @@ export default {
   setup() {
     return {
       concat,
-      localize
+      localize,
+      CONFIG,
     }
   },
   components: {

--- a/src/vue/components/actor/character/main/CharResources.vue
+++ b/src/vue/components/actor/character/main/CharResources.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="section section--resources flexrow flexshrink" :data-resource-count="resourceCount" :data-custom-count="customResourceCount">
     <!-- Command Points -->
-    <section v-if="actor.system.resources.perCombat.commandPoints?.enabled" class="unit unit--command-points">
+    <section v-if="actor.system.resources?.perCombat?.commandPoints?.enabled" class="unit unit--command-points">
       <h2 class="unit-title">{{localize('ARCHMAGE.CHARACTER.RESOURCES.commandPoints')}}</h2>
       <div class="resource flexrow">
         <div class="resource--left">
@@ -25,21 +25,21 @@
       </div>
     </section>
     <!-- Focus -->
-    <section v-if="actor.system.resources.perCombat.focus?.enabled" class="unit unit--focus">
+    <section v-if="actor.system.resources?.perCombat?.focus?.enabled" class="unit unit--focus">
       <h2 class="unit-title">{{localize('ARCHMAGE.CHARACTER.RESOURCES.focus')}}</h2>
       <div class="resource flexrow">
         <input type="checkbox" name="system.resources.perCombat.focus.current" v-model="focus">
       </div>
     </section>
     <!-- Momentum -->
-    <section v-if="actor.system.resources.perCombat.momentum?.enabled" class="unit unit--momentum">
+    <section v-if="actor.system.resources?.perCombat?.momentum?.enabled" class="unit unit--momentum">
       <h2 class="unit-title">{{localize('ARCHMAGE.CHARACTER.RESOURCES.momentum')}}</h2>
       <div class="resource flexrow">
         <input type="checkbox" name="system.resources.perCombat.momentum.current" v-model="momentum">
       </div>
     </section>
     <!-- Combat Rhythm -->
-    <section v-if="actor.system.resources.perCombat.rhythm?.enabled && secondEdition" class="unit unit--rhythm">
+    <section v-if="actor.system.resources?.perCombat?.rhythm?.enabled && secondEdition" class="unit unit--rhythm">
       <h2 class="unit-title">{{localize('ARCHMAGE.CHARACTER.RESOURCES.rhythm')}}</h2>
       <div class="resource flexrow">
         <select name="system.resources.perCombat.rhythm.current" v-model="rhythm">
@@ -47,6 +47,13 @@
           <option value="offense">{{localize('ARCHMAGE.CHARACTER.RHYTHMCHOICES.offense')}}</option>
           <option value="defense">{{localize('ARCHMAGE.CHARACTER.RHYTHMCHOICES.defense')}}</option>
         </select>
+      </div>
+    </section>
+    <!-- Stoke -->
+    <section v-if="actor.system.resources.spendable.stoke?.enabled" class="unit unit--has-max unit--stoke">
+      <h2 class="unit-title">{{localize('ARCHMAGE.CHARACTER.RESOURCES.stoke')}}</h2>
+      <div class="resource flexrow">
+        <input type="number" name="system.resources.spendable.stoke.current" class="resource-current" v-model="stoke.current">
       </div>
     </section>
     <!-- Rerolls -->
@@ -75,7 +82,7 @@
       </div>
     </section>
     <!-- Rests -->
-    <section class="unit unit--rest">
+    <section v-if="actor.type === 'character'" class="unit unit--rest">
       <h2 class="unit-title">{{localize('ARCHMAGE.CHAT.Rests')}}</h2>
       <div class="resource flexcol">
         <button type="button" class="rest rest--quick" data-rest-type="quick" :data-tooltip="tooltip('pcRestQuick')"><i class="fas fa-campground"></i> {{localize('ARCHMAGE.CHAT.QuickRest')}}</button>
@@ -121,6 +128,10 @@ export default {
         value: 0,
         max: 0
       },
+      stoke: {
+        enabled: false,
+        current: 0,
+      },
       rerolls: {
         AC: {
           value: 0,
@@ -148,13 +159,14 @@ export default {
     },
     resourceCount() {
       let count = 0;
-      if (this.actor.system.resources.perCombat.commandPoints.enabled) count++;
-      if (this.actor.system.resources.spendable.ki.enabled) count++;
-      if (this.actor.system.resources.spendable.rerolls.enabled) count++;
-      if (this.actor.system.resources.perCombat.focus.enabled) count++;
-      if (this.actor.system.resources.perCombat.momentum.enabled) count++;
+      if (this.actor.system.resources.perCombat?.commandPoints?.enabled) count++;
+      if (this.actor.system.resources.spendable?.ki?.enabled) count++;
+      if (this.actor.system.resources.spendable?.rerolls?.enabled) count++;
+      if (this.actor.system.resources.perCombat?.focus?.enabled) count++;
+      if (this.actor.system.resources.perCombat?.momentum?.enabled) count++;
       if ( game.settings.get('archmage', 'secondEdition') ) {
-        if (this.actor.system.resources.perCombat.rhythm.enabled) count++;
+        if (this.actor.system.resources.perCombat?.rhythm?.enabled) count++;
+        if (this.actor.system.resources.spendable?.stoke?.enabled) count++;
       }
       return count;
     },
@@ -165,13 +177,14 @@ export default {
   },
   methods: {
     updateResourceProps() {
-      this.commandPoints = this.actor.system.resources.perCombat.commandPoints.current;
-      this.momentum = this.actor.system.resources.perCombat.momentum.current;
-      this.focus = this.actor.system.resources.perCombat.focus.current;
-      this.ki = this.actor.system.resources.spendable.ki;
-      this.rerolls = this.actor.system.resources.spendable.rerolls;
+      this.commandPoints = this.actor.system.resources.perCombat?.commandPoints?.current;
+      this.momentum = this.actor.system.resources.perCombat?.momentum?.current;
+      this.focus = this.actor.system.resources.perCombat?.focus?.current;
+      this.ki = this.actor.system.resources.spendable?.ki;
+      this.rerolls = this.actor.system.resources.spendable?.rerolls;
       if ( game.settings.get('archmage', 'secondEdition') ) {
-        this.rhythm = this.actor.system.resources.perCombat.rhythm.current;
+        this.stoke = this.actor.system.resources.spendable?.stoke;
+        this.rhythm = this.actor.system.resources.perCombat?.rhythm?.current;
       }
     }
   },

--- a/src/vue/components/actor/character/main/CharResources.vue
+++ b/src/vue/components/actor/character/main/CharResources.vue
@@ -50,7 +50,7 @@
       </div>
     </section>
     <!-- Stoke -->
-    <section v-if="actor.system.resources.spendable.stoke?.enabled" class="unit unit--has-max unit--stoke">
+    <section v-if="CONFIG.ARCHMAGE.is2e && actor.system.resources.spendable.stoke?.enabled" class="unit unit--has-max unit--stoke">
       <h2 class="unit-title">{{localize('ARCHMAGE.CHARACTER.RESOURCES.stoke')}}</h2>
       <div class="resource flexrow">
         <input type="number" name="system.resources.spendable.stoke.current" class="resource-current" v-model="stoke.current">
@@ -113,7 +113,8 @@ export default {
     return {
       concat,
       localize,
-      tooltip
+      tooltip,
+      CONFIG,
     }
   },
   components: {

--- a/src/vue/components/actor/npc/NpcHeader.vue
+++ b/src/vue/components/actor/npc/NpcHeader.vue
@@ -206,212 +206,212 @@
 .archmage-v2.npc-sheet {
   .npc-header {
     position: relative;
-  }
 
-  .section--details,
-  .section--header-top {
-    input {
-      text-align: left;
-    }
-  }
-
-  .section--header-top {
-    padding-right: $padding-lg;
-  }
-
-  .section--avatar {
-    flex: 0 auto;
-
-    #context-menu {
-      left: auto;
-      right: 0;
-    }
-  }
-
-  .unit {
-    input,
-    .rollable--init {
-      font-family: $font-stack-base;
-      font-size: $font-xs;
-      font-weight: normal;
-      border-color: transparent;
-    }
-
-    input:hover,
-    input:focus,
-    .edit-wrapper input {
-      border-bottom: 2px solid;
-    }
-  }
-
-  .unit--hide-label {
-    label {
-      display: none;
-    }
-  }
-
-  .unit--name {
-    margin: $padding-sm 0;
-
-    h1 {
-      font-family: $font-stack-secondary;
-      font-size: 24px;
-      font-weight: bold;
-      border: none;
-      line-height: 0.8;
-    }
-  }
-
-  .avatar {
-    overflow: hidden;
-    object-fit: cover;
-    max-width: 100%;
-    width: auto;
-    height: auto;
-    max-width: 110px;
-    max-height: 110px;
-    border: 0;
-
-    &.avatar--square {
-      width: auto;
-      height: 110px;
-    }
-
-    &.avatar--frame {
-      background: $c-white;
-      box-shadow: 0 0 10px $ct-border;
-      padding: 4px;
-    }
-
-    &.avatar--round {
-      border-radius: 50%;
-    }
-  }
-
-  .unit--img {
-    flex: 0 auto;
-    width: 110px;
-    margin-left: $padding-sm;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .unit--roles {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-start;
-    justify-content: flex-start;
-
-    .rollable--init {
-      flex: 0 auto;
-      margin: 0;
-    }
-
-    .edit-wrapper {
-      display: inline-block;
-      flex: 1;
-
-      ul {
-        display: flex;
-        justify-content: flex-start;
-        align-items: flex-start;
-        padding: 0;
-        margin: 0;
-        flex-wrap: wrap;
+    .section--details,
+    .section--header-top {
+      input {
+        text-align: left;
       }
-
-      li {
+    }
+  
+    .section--header-top {
+      padding-right: $padding-lg;
+    }
+  
+    .section--avatar {
+      flex: 0 auto;
+  
+      #context-menu {
+        left: auto;
+        right: 0;
+      }
+    }
+  
+    .unit {
+      input,
+      .rollable--init {
+        font-family: $font-stack-base;
+        font-size: $font-xs;
+        font-weight: normal;
+        border-color: transparent;
+      }
+  
+      input:hover,
+      input:focus,
+      .edit-wrapper input {
+        border-bottom: 2px solid;
+      }
+    }
+  
+    .unit--hide-label {
+      label {
+        display: none;
+      }
+    }
+  
+    .unit--name {
+      margin: $padding-sm 0;
+  
+      h1 {
+        font-family: $font-stack-secondary;
+        font-size: 24px;
+        font-weight: bold;
+        border: none;
+        line-height: 0.8;
+      }
+    }
+  
+    .avatar {
+      overflow: hidden;
+      object-fit: cover;
+      max-width: 100%;
+      width: auto;
+      height: auto;
+      max-width: 110px;
+      max-height: 110px;
+      border: 0;
+  
+      &.avatar--square {
+        width: auto;
+        height: 110px;
+      }
+  
+      &.avatar--frame {
+        background: $c-white;
+        box-shadow: 0 0 10px $ct-border;
+        padding: 4px;
+      }
+  
+      &.avatar--round {
+        border-radius: 50%;
+      }
+    }
+  
+    .unit--img {
+      flex: 0 auto;
+      width: 110px;
+      margin-left: $padding-sm;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  
+    .unit--roles {
+      display: flex;
+      flex-direction: row;
+      align-items: flex-start;
+      justify-content: flex-start;
+  
+      .rollable--init {
         flex: 0 auto;
-        list-style-type: none;
-        margin-left: 14px;
-        position: relative;
-
-        &::before {
-          display: block;
-          content: '';
-          position: absolute;
-          top: -4px;
-          bottom: 0;
-          left: -9px;
-          margin: auto;
-          width: 5px;
-          height: 5px;
-          background: $c-black;
-          border-radius: 100%;
+        margin: 0;
+      }
+  
+      .edit-wrapper {
+        display: inline-block;
+        flex: 1;
+  
+        ul {
+          display: flex;
+          justify-content: flex-start;
+          align-items: flex-start;
+          padding: 0;
+          margin: 0;
+          flex-wrap: wrap;
+        }
+  
+        li {
+          flex: 0 auto;
+          list-style-type: none;
+          margin-left: 14px;
+          position: relative;
+  
+          &::before {
+            display: block;
+            content: '';
+            position: absolute;
+            top: -4px;
+            bottom: 0;
+            left: -9px;
+            margin: auto;
+            width: 5px;
+            height: 5px;
+            background: $c-black;
+            border-radius: 100%;
+          }
         }
       }
     }
-  }
-
-  .unit--resistance,
-  .unit--vulnerability {
-    label {
-      font-weight: bold;
-      flex: 0 auto;
-    }
-  }
-
-  .unit--input {
-    display: flex;
-    flex-direction: row;
-  }
-
-  .section--details {
-    .editor-wrapper {
-      min-height: 0;
-    }
-    :deep(.editor-content) {
-      padding: 0;
-      background: transparent;
-    }
-
-    .unit--flavor {
-      font-style: italic;
-      margin: 0 0 $padding-sm 0;
-      line-height: 1.3;
-    }
-
-    .unit--flavor .editor-content {
-      padding: 0 $padding-sm;
-      min-height: 2.5em;
-    }
-
-    .unit--flavor .editor-content p {
-      margin: 0.2em 0;
-    }
-
-  }
-
-  .toggle-header {
-    transition: all ease-in-out 0.25s;
-    display: block;
-    position: absolute;
-    top: -$padding-sm;
-    right: -$padding-md;
-    padding: $padding-md;
-  }
-
-  .collapsed {
-    .unit--flavor {
-      display: none;
-    }
-    .section--header-top {
-      padding-right: 85px;
-    }
-    .unit--img {
-      width: 55px;
-      margin: 0 $padding-lg 0 $padding-sm;
-
-      .avatar {
-        width: auto;
-        height: 55px;
-        margin-top: -35px;
-        margin-right: 0px;
+  
+    .unit--resistance,
+    .unit--vulnerability {
+      label {
+        font-weight: bold;
+        flex: 0 auto;
       }
     }
+  
+    .unit--input {
+      display: flex;
+      flex-direction: row;
+    }
+  
+    .section--details {
+      .editor-wrapper {
+        min-height: 0;
+      }
+      :deep(.editor-content) {
+        padding: 0;
+        background: transparent;
+      }
+  
+      .unit--flavor {
+        font-style: italic;
+        margin: 0 0 $padding-sm 0;
+        line-height: 1.3;
+      }
+  
+      .unit--flavor .editor-content {
+        padding: 0 $padding-sm;
+        min-height: 2.5em;
+      }
+  
+      .unit--flavor .editor-content p {
+        margin: 0.2em 0;
+      }
+  
+    }
+  
     .toggle-header {
-      transform: rotate(180deg);
+      transition: all ease-in-out 0.25s;
+      display: block;
+      position: absolute;
+      top: -$padding-sm;
+      right: -$padding-md;
+      padding: $padding-md;
+    }
+  
+    .collapsed {
+      .unit--flavor {
+        display: none;
+      }
+      .section--header-top {
+        padding-right: 85px;
+      }
+      .unit--img {
+        width: 55px;
+        margin: 0 $padding-lg 0 $padding-sm;
+  
+        .avatar {
+          width: auto;
+          height: 55px;
+          margin-top: -35px;
+          margin-right: 0px;
+        }
+      }
+      .toggle-header {
+        transform: rotate(180deg);
+      }
     }
   }
 

--- a/src/vue/components/actor/npc/NpcHeader.vue
+++ b/src/vue/components/actor/npc/NpcHeader.vue
@@ -207,26 +207,6 @@
   .npc-header {
     position: relative;
 
-    .section--details,
-    .section--header-top {
-      input {
-        text-align: left;
-      }
-    }
-  
-    .section--header-top {
-      padding-right: $padding-lg;
-    }
-  
-    .section--avatar {
-      flex: 0 auto;
-  
-      #context-menu {
-        left: auto;
-        right: 0;
-      }
-    }
-  
     .unit {
       input,
       .rollable--init {
@@ -235,183 +215,203 @@
         font-weight: normal;
         border-color: transparent;
       }
-  
+
       input:hover,
       input:focus,
       .edit-wrapper input {
         border-bottom: 2px solid;
       }
     }
-  
-    .unit--hide-label {
-      label {
-        display: none;
-      }
+  }
+
+  .section--details,
+  .section--header-top {
+    input {
+      text-align: left;
     }
-  
-    .unit--name {
-      margin: $padding-sm 0;
-  
-      h1 {
-        font-family: $font-stack-secondary;
-        font-size: 24px;
-        font-weight: bold;
-        border: none;
-        line-height: 0.8;
-      }
+  }
+
+  .section--header-top {
+    padding-right: $padding-lg;
+  }
+
+  .section--avatar {
+    flex: 0 auto;
+
+    #context-menu {
+      left: auto;
+      right: 0;
     }
-  
-    .avatar {
-      overflow: hidden;
-      object-fit: cover;
-      max-width: 100%;
+  }
+
+  .unit--hide-label {
+    label {
+      display: none;
+    }
+  }
+
+  .unit--name {
+    margin: $padding-sm 0;
+
+    h1 {
+      font-family: $font-stack-secondary;
+      font-size: 24px;
+      font-weight: bold;
+      border: none;
+      line-height: 0.8;
+    }
+  }
+
+  .avatar {
+    overflow: hidden;
+    object-fit: cover;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-width: 110px;
+    max-height: 110px;
+    border: 0;
+
+    &.avatar--square {
       width: auto;
-      height: auto;
-      max-width: 110px;
-      max-height: 110px;
-      border: 0;
-  
-      &.avatar--square {
-        width: auto;
-        height: 110px;
-      }
-  
-      &.avatar--frame {
-        background: $c-white;
-        box-shadow: 0 0 10px $ct-border;
-        padding: 4px;
-      }
-  
-      &.avatar--round {
-        border-radius: 50%;
-      }
+      height: 110px;
     }
-  
-    .unit--img {
+
+    &.avatar--frame {
+      background: $c-white;
+      box-shadow: 0 0 10px $ct-border;
+      padding: 4px;
+    }
+
+    &.avatar--round {
+      border-radius: 50%;
+    }
+  }
+
+  .unit--img {
+    flex: 0 auto;
+    width: 110px;
+    margin-left: $padding-sm;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .unit--roles {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: flex-start;
+
+    .rollable--init {
       flex: 0 auto;
-      width: 110px;
-      margin-left: $padding-sm;
-      display: flex;
-      align-items: center;
-      justify-content: center;
+      margin: 0;
     }
-  
-    .unit--roles {
-      display: flex;
-      flex-direction: row;
-      align-items: flex-start;
-      justify-content: flex-start;
-  
-      .rollable--init {
-        flex: 0 auto;
-        margin: 0;
-      }
-  
-      .edit-wrapper {
-        display: inline-block;
-        flex: 1;
-  
-        ul {
-          display: flex;
-          justify-content: flex-start;
-          align-items: flex-start;
-          padding: 0;
-          margin: 0;
-          flex-wrap: wrap;
-        }
-  
-        li {
-          flex: 0 auto;
-          list-style-type: none;
-          margin-left: 14px;
-          position: relative;
-  
-          &::before {
-            display: block;
-            content: '';
-            position: absolute;
-            top: -4px;
-            bottom: 0;
-            left: -9px;
-            margin: auto;
-            width: 5px;
-            height: 5px;
-            background: $c-black;
-            border-radius: 100%;
-          }
-        }
-      }
-    }
-  
-    .unit--resistance,
-    .unit--vulnerability {
-      label {
-        font-weight: bold;
-        flex: 0 auto;
-      }
-    }
-  
-    .unit--input {
-      display: flex;
-      flex-direction: row;
-    }
-  
-    .section--details {
-      .editor-wrapper {
-        min-height: 0;
-      }
-      :deep(.editor-content) {
+
+    .edit-wrapper {
+      display: inline-block;
+      flex: 1;
+
+      ul {
+        display: flex;
+        justify-content: flex-start;
+        align-items: flex-start;
         padding: 0;
-        background: transparent;
+        margin: 0;
+        flex-wrap: wrap;
       }
-  
-      .unit--flavor {
-        font-style: italic;
-        margin: 0 0 $padding-sm 0;
-        line-height: 1.3;
-      }
-  
-      .unit--flavor .editor-content {
-        padding: 0 $padding-sm;
-        min-height: 2.5em;
-      }
-  
-      .unit--flavor .editor-content p {
-        margin: 0.2em 0;
-      }
-  
-    }
-  
-    .toggle-header {
-      transition: all ease-in-out 0.25s;
-      display: block;
-      position: absolute;
-      top: -$padding-sm;
-      right: -$padding-md;
-      padding: $padding-md;
-    }
-  
-    .collapsed {
-      .unit--flavor {
-        display: none;
-      }
-      .section--header-top {
-        padding-right: 85px;
-      }
-      .unit--img {
-        width: 55px;
-        margin: 0 $padding-lg 0 $padding-sm;
-  
-        .avatar {
-          width: auto;
-          height: 55px;
-          margin-top: -35px;
-          margin-right: 0px;
+
+      li {
+        flex: 0 auto;
+        list-style-type: none;
+        margin-left: 14px;
+        position: relative;
+
+        &::before {
+          display: block;
+          content: '';
+          position: absolute;
+          top: -4px;
+          bottom: 0;
+          left: -9px;
+          margin: auto;
+          width: 5px;
+          height: 5px;
+          background: $c-black;
+          border-radius: 100%;
         }
       }
-      .toggle-header {
-        transform: rotate(180deg);
+    }
+  }
+
+  .unit--resistance,
+  .unit--vulnerability {
+    label {
+      font-weight: bold;
+      flex: 0 auto;
+    }
+  }
+
+  .unit--input {
+    display: flex;
+    flex-direction: row;
+  }
+
+  .section--details {
+    .editor-wrapper {
+      min-height: 0;
+    }
+    :deep(.editor-content) {
+      padding: 0;
+      background: transparent;
+    }
+
+    .unit--flavor {
+      font-style: italic;
+      margin: 0 0 $padding-sm 0;
+      line-height: 1.3;
+    }
+
+    .unit--flavor .editor-content {
+      padding: 0 $padding-sm;
+      min-height: 2.5em;
+    }
+
+    .unit--flavor .editor-content p {
+      margin: 0.2em 0;
+    }
+
+  }
+
+  .toggle-header {
+    transition: all ease-in-out 0.25s;
+    display: block;
+    position: absolute;
+    top: -$padding-sm;
+    right: -$padding-md;
+    padding: $padding-md;
+  }
+
+  .collapsed {
+    .unit--flavor {
+      display: none;
+    }
+    .section--header-top {
+      padding-right: 85px;
+    }
+    .unit--img {
+      width: 55px;
+      margin: 0 $padding-lg 0 $padding-sm;
+
+      .avatar {
+        width: auto;
+        height: 55px;
+        margin-top: -35px;
+        margin-right: 0px;
       }
+    }
+    .toggle-header {
+      transform: rotate(180deg);
     }
   }
 

--- a/src/vue/components/actor/npc/NpcSettings.vue
+++ b/src/vue/components/actor/npc/NpcSettings.vue
@@ -11,6 +11,11 @@
       </div>
       <!-- Resource Settings -->
       <div class="unit unit--resources">
+        <!-- Stoke -->
+        <div v-if="actor?.system?.resources?.spendable?.stoke" class="settings-resource">
+          <input type="checkbox" name="system.resources.spendable.stoke.enabled" v-model="actor.system.resources.spendable.stoke.enabled">
+          <strong class="unit-subtitle">{{localize('ARCHMAGE.CHARACTER.RESOURCES.stoke')}}</strong>
+        </div>
         <!-- Custom -->
         <div v-for="(resource, r) in resourcesCustom" :key="r" class="settings-resource" :data-key="r">
           <input type="checkbox" :name="concat('system.resources.spendable.', r, '.enabled')" v-model="resource.enabled">
@@ -44,9 +49,11 @@ export default {
     },
     resourcesCustom() {
       let resources = {};
-      for (let [k,v] of Object.entries(this.actor.system.resources.spendable)) {
-        if ( v.secondEdition && !game.settings.get('archmage', 'secondEdition') ) continue;
-        if (k.includes('custom')) resources[k] = v;
+      if (this.actor.system?.resources?.spendable) {
+        for (let [k,v] of Object.entries(this.actor.system.resources.spendable)) {
+          if ( v.secondEdition && !game.settings.get('archmage', 'secondEdition') ) continue;
+          if (k.includes('custom')) resources[k] = v;
+        }
       }
       return resources;
     },

--- a/src/vue/components/actor/npc/NpcSettings.vue
+++ b/src/vue/components/actor/npc/NpcSettings.vue
@@ -12,7 +12,7 @@
       <!-- Resource Settings -->
       <div class="unit unit--resources">
         <!-- Stoke -->
-        <div v-if="actor?.system?.resources?.spendable?.stoke" class="settings-resource">
+        <div v-if="CONFIG.ARCHMAGE.is2e && actor?.system?.resources?.spendable?.stoke" class="settings-resource">
           <input type="checkbox" name="system.resources.spendable.stoke.enabled" v-model="actor.system.resources.spendable.stoke.enabled">
           <strong class="unit-subtitle">{{localize('ARCHMAGE.CHARACTER.RESOURCES.stoke')}}</strong>
         </div>
@@ -34,7 +34,8 @@ export default {
   setup() {
     return {
       concat,
-      localize
+      localize,
+      CONFIG,
     }
   },
   computed: {

--- a/src/vue/components/actor/npc/NpcSettings.vue
+++ b/src/vue/components/actor/npc/NpcSettings.vue
@@ -1,12 +1,20 @@
 <template>
   <section :class="classes">
     <h2 class="unit-title">{{localize('ARCHMAGE.CHARACTERSETTINGS.settings')}}</h2>
-    <section class="sheet-settings grid grid-2col">
+    <section class="sheet-settings grid grid-4col">
       <!-- Flag Settings -->
       <div class="unit unit--flags">
         <div v-for="(flag, f) in flags" :key="f" :data-key="f" class="settings-flags">
           <label :for="concat('flags.archmage.', f)" class="unit-subtitle flexrow"><input type="checkbox" :name="concat('flags.archmage.', f, )" v-model="flag.value"> {{flag.name}}</label>
           <p class="notes">{{flag.hint}}</p>
+        </div>
+      </div>
+      <!-- Resource Settings -->
+      <div class="unit unit--resources">
+        <!-- Custom -->
+        <div v-for="(resource, r) in resourcesCustom" :key="r" class="settings-resource" :data-key="r">
+          <input type="checkbox" :name="concat('system.resources.spendable.', r, '.enabled')" v-model="resource.enabled">
+          <strong class="unit-subtitle">{{localize(concat('ARCHMAGE.CHARACTER.RESOURCES.', r))}}</strong>
         </div>
       </div>
     </section>
@@ -34,6 +42,14 @@ export default {
       }
       return flags;
     },
+    resourcesCustom() {
+      let resources = {};
+      for (let [k,v] of Object.entries(this.actor.system.resources.spendable)) {
+        if ( v.secondEdition && !game.settings.get('archmage', 'secondEdition') ) continue;
+        if (k.includes('custom')) resources[k] = v;
+      }
+      return resources;
+    },
     classes() {
       return `section section--settings flexcol`;
     },
@@ -45,3 +61,18 @@ export default {
   async mounted() {}
 }
 </script>
+
+<style lang="scss">
+.archmage-v2.npc-sheet {
+  .section--settings {
+    .unit--flags {
+      grid-column-end: span 2;
+    }
+
+    .unit--resources {
+      grid-column-start: 3;
+      grid-column-end: span 2;
+    }
+  }
+}
+</style>

--- a/src/vue/components/parts/ToggleInput.vue
+++ b/src/vue/components/parts/ToggleInput.vue
@@ -32,7 +32,7 @@ export default {
   methods: {
     toggleEdit(event) {
       // Determine if this is an input or not.
-      const isInput = ['INPUT','SELECT'].includes(event.target.tagName);
+      const isInput = ['INPUT','SELECT','OPTION'].includes(event.target.tagName);
 
       // Toggle the state if this isn't an input, otherwise persist it.
       this.active = !isInput ? !this.active : this.active;
@@ -45,6 +45,13 @@ export default {
           setTimeout(() => {
             $el.focus().trigger('select');
           }, 100);
+        }
+      }
+
+      // If we're no longer active, blur the toggle.
+      if (!this.active) {
+        if (event.target.classList.contains('input-edit-toggle')) {
+          event.target.blur();
         }
       }
     },


### PR DESCRIPTION
- Added custom resources to NPC sheets.
- Added stoke to NPC sheets if the type is dragon and the 2e setting is enabled. Stoke will automatically increase the dragon's crit range for breath attacks, and it will increase or decrease depending on whether or not the dragon used an action with the name "breath" in it before the end of their turn.
- Updated dragons in the included compendiums to enable stoke in their resources settings.
- Added support for flashing dynamic token rings red when damaged or green when healed.
- #478 Added option on the apply effect dialog to set ongoing damage to half its damage (such as with resistance) or note that it was a crit. Halving it will reduce the ongoing damage in half when creating the effect, while setting it as a crit will only double it the first time it's applied to the actor.
- #479 Fixed bug in Firefox where the NPC details field group (size, initiative, type, etc.) collapsed every time you changed it.
  - Also fixed a bug in all browsers where you couldn't always reopen the details field group after closing it.
- #481 Fixed a bug where character powers and NPC actions were being created with the wrong type due to an old reference to `data` instead of `system`.
- Fixed a bug where dropping a `hampered` effect on an actor with the 2e setting enabled would cause a fatal error.
- Fixed a bug where dropping a built-in condition on an actor would create a similar effect rather than the actual condition status.
- Added a `CONFIG.ARCHMAGE.is2e` constant based on the `secondEdition` system setting that's initialized during the ready hook.
- Added new i18n keys, each of which should now be displayed on the character sheet when sorting powers by usage type.
  - `ARCHMAGE.arc` - "Arc"
  - `ARCHMAGE.arc-desperate` - "Arc/Desperate"
  - `ARCHMAGE.daily-desperate` - "Arc/Desperate" (same as the above due to 1e not having a "Daily/Desperate" usage pattern)

## Recordings
https://github.com/user-attachments/assets/7ab18548-3be1-4fa5-9dca-525f6b31d9f1

## Screenshots
![image](https://github.com/user-attachments/assets/71889ab4-bacc-4c57-80e2-757da87b6674)

## Relates to
https://github.com/asacolips-projects/13th-age/issues/431