### PR TITLE
Add support for container queries

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -35,6 +35,7 @@ ARCHMAGE:
   checkSkill: Skill Check
   checkSkillFormat: "{name} Skill Check"
   class: Class
+  combat: Combat
   Conflicted: Conflicted
   contextReroll: Reroll
   contextApplyDamage: Apply as Damage

--- a/src/module/actor/actor-sheet-v2.js
+++ b/src/module/actor/actor-sheet-v2.js
@@ -215,6 +215,21 @@ export class ActorArchmageSheetV2 extends ActorSheet {
     super.activateListeners(html);
     ActorHelpersV2._activatePortraitArtContextMenu(this, html)
 
+    // Close the mobile menu if open.
+    html.on('click', (event) => {
+      const button = event?.target?.closest('.sheet-tabs-toggle') ?? event.target;
+      // Exit early if is the mobile menu button itself, that's handled in the component.
+      if (button?.classList?.contains('sheet-tabs-toggle')) return;
+      // Otherwise close the menu.
+      const parent = event?.target?.classList?.contains('archmage-v2-vue')
+        ? event.target
+        : event?.target?.closest('.archmage-v2-vue');
+      const mobileMenu = parent.querySelector('.tabs--mobile.active');
+      if (mobileMenu) {
+        mobileMenu.classList.remove('active');
+      }
+    })
+
     if (!this.options.editable) return;
 
     // CRUD listeners.

--- a/src/module/actor/actor-sheet-v2.js
+++ b/src/module/actor/actor-sheet-v2.js
@@ -22,6 +22,7 @@ export class ActorArchmageSheetV2 extends ActorSheet {
   static get defaultOptions() {
     const options = super.defaultOptions;
     const compactMode = game.settings.get('archmage', 'compactMode');
+    const nightMode = game.settings.get("archmage", "nightmode");
     foundry.utils.mergeObject(options, {
       classes: options.classes.concat(['archmage-v2', 'actor', 'character-sheet']).filter(c => c !== 'archmage'),
       width: compactMode ? 826 : 960,
@@ -33,6 +34,10 @@ export class ActorArchmageSheetV2 extends ActorSheet {
 
     if (compactMode) {
       options.classes.push('compact-mode');
+    }
+
+    if (nightMode) {
+      options.classes.push('nightmode');
     }
 
     return options;

--- a/src/module/applications/compendium-browser.js
+++ b/src/module/applications/compendium-browser.js
@@ -31,7 +31,8 @@ export class ArchmageCompendiumBrowserApplication extends Application {
 
   /** @override */
   static get defaultOptions() {
-    return {...super.defaultOptions,
+    const nightMode = game.settings.get("archmage", "nightmode");
+    const options = {...super.defaultOptions,
       classes: [
         'form',
         'archmage-v2',
@@ -45,6 +46,12 @@ export class ArchmageCompendiumBrowserApplication extends Application {
       height: 775,
       resizable: true,
     };
+
+    if (nightMode) {
+      options.classes.push('nightmode');
+    }
+
+    return options;
   }
 
   /** @override */

--- a/src/module/hooks/preCreateChatMessageHandler.mjs
+++ b/src/module/hooks/preCreateChatMessageHandler.mjs
@@ -116,7 +116,7 @@ export default class preCreateChatMessageHandler {
             game.i18n.localize("ARCHMAGE.CHAT.breathWeapon") + ':'
         ];
 
-        let tokens = canvas.tokens.controlled;
+        let tokens = canvas?.tokens?.controlled;
         let actor = tokens ? tokens[0] : null;
         let token = tokens ? tokens[0] : null;
 

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -506,7 +506,7 @@ export class ItemArchmage extends Item {
   }
 
   _rollGetToken(itemToRender) {
-    let tokens = canvas.tokens.controlled;
+    let tokens = canvas?.tokens?.controlled;
     let token = tokens ? tokens[0] : null;
     if (!token || token.actor != itemToRender.actor) {
       tokens = itemToRender.actor.getActiveTokens(true);

--- a/src/module/setup/archmage-prepopulate.js
+++ b/src/module/setup/archmage-prepopulate.js
@@ -355,6 +355,7 @@ export class ArchmagePrepopulate {
     let options = {
       width: 1080,
       height: 1080,
+      resizable: true,
       classes: ['archmage-prepopulate']
     };
     let powers = Object.values(classCompendiums).reduce((accumulator, current) => {

--- a/src/module/setup/damageApplicator.js
+++ b/src/module/setup/damageApplicator.js
@@ -16,7 +16,7 @@ export class DamageApplicator {
   getTargets(targetType) {
     const targets = targetType === 'targeted'
       ? [...game.user.targets]
-      : canvas.tokens.controlled;
+      : (canvas?.tokens?.controlled ?? []);
 
     if (!targets || targets?.length < 1) {
       ui.notifications.warn(game.i18n.localize(`ARCHMAGE.UI.${targetType === 'targeted' ? 'noTarget' : 'noToken'}`));

--- a/src/scss/v2/archmage-v2.scss
+++ b/src/scss/v2/archmage-v2.scss
@@ -37,11 +37,6 @@
     }
   }
 
-  .window-content {
-    container-type: size;
-    container-name: archmage-window-content;
-  }
-
   // Character and NPC sheets.
   &.sheet,
   &.archmage-dialog {

--- a/src/scss/v2/archmage-v2.scss
+++ b/src/scss/v2/archmage-v2.scss
@@ -37,6 +37,11 @@
     }
   }
 
+  .window-content {
+    container-type: size;
+    container-name: archmage-window-content;
+  }
+
   // Character and NPC sheets.
   &.sheet,
   &.archmage-dialog {
@@ -100,5 +105,6 @@
   @import 'components/chat/ongoing-effects';
 }
 
+@import 'layout/container-queries';
 @import 'theme/nightmode';
 @import 'theme/colormodes';

--- a/src/scss/v2/components/_sheet.scss
+++ b/src/scss/v2/components/_sheet.scss
@@ -1,10 +1,7 @@
 .window-content {
   padding: 0;
-
-  .archmage-v2-vue {
-    background: url('#{$assets}/paper-v2.webp');
-    background-size: cover;
-  }
+  background: url('#{$assets}/paper-v2.webp');
+  background-size: cover;
 
   > form,
   .archmage-v2-vue,
@@ -59,7 +56,12 @@
   }
 }
 
-.section--sidebar {
+.container--bottom {
+  flex-wrap: nowrap;
+}
+
+// .section--sidebar {
+.tab.abilities {
   flex: 0 0 300px;
 
   .section + .section {
@@ -73,8 +75,16 @@
   }
 }
 
+// .section--main {
+.tab.combat {
+  flex: 1;
+  padding-left: 10px;
+}
+
+.section--sidebar,
 .section--main {
   flex: 1;
+  margin: 0;
 }
 
 img[data-edit="img"] {

--- a/src/scss/v2/components/_tabs.scss
+++ b/src/scss/v2/components/_tabs.scss
@@ -33,6 +33,19 @@
   .tab-link--settings {
     flex: 0 0 44px;
   }
+
+  .sheet-tabs {
+    flex-wrap: wrap;
+    margin: 10px 0;
+  
+    > span {
+      display: flex;
+    }
+  
+    .tab-link {
+      margin: 4px;
+    }
+  }
 }
 
 .section--tabs-content {
@@ -51,7 +64,7 @@
 // Hide the mobile tabs on desktop sheets.
 .tab.abilities,
 .tab.combat {
-  flex: 1;
+  // flex: 1;
   height: 100%;
 }
 .section--tabs-mobile {

--- a/src/scss/v2/components/_tabs.scss
+++ b/src/scss/v2/components/_tabs.scss
@@ -47,3 +47,16 @@
     }
   }
 }
+
+// Hide the mobile tabs on desktop sheets.
+.tab.abilities,
+.tab.combat {
+  flex: 1;
+  height: 100%;
+}
+.section--tabs-mobile {
+  display: none;
+}
+.tab[data-tab][data-group="mobile"] {
+  display: block;
+}

--- a/src/scss/v2/components/character/_resources.scss
+++ b/src/scss/v2/components/character/_resources.scss
@@ -8,8 +8,8 @@
     padding: 0 $padding-md;
     margin: 0;
     border-left: 2px solid $ct-border;
-    max-width: 25%;
-    flex: 0 auto;
+    // max-width: 25%;
+    flex: 0 0 140px;
 
     &:first-child {
       border-left: none;
@@ -24,7 +24,7 @@
     }
 
     .unit--custom {
-      max-width: 33%;
+      // max-width: 33%;
     }
   }
 
@@ -35,7 +35,7 @@
     }
 
     .unit--custom {
-      max-width: 33%;
+      // max-width: 33%;
     }
   }
 
@@ -57,15 +57,15 @@
   }
 
   .unit--command-points {
-    flex: 0 auto;
+    // flex: 0 auto;
   }
 
   .unit--ki {
-    flex: 0 auto;
+    // flex: 0 auto;
   }
 
   .unit--custom {
-    flex: 0 auto;
+    // flex: 0 auto;
   }
 
   input.resource-title-input {
@@ -75,7 +75,7 @@
   }
 
   .unit--rest {
-    flex: 0 auto;
+    // flex: 0 auto;
 
     button + button {
       margin-top: $padding-sm;

--- a/src/scss/v2/components/compendium-browser/_compendium-browser.scss
+++ b/src/scss/v2/components/compendium-browser/_compendium-browser.scss
@@ -10,6 +10,7 @@
 
 .container--bottom {
   .filters {
+    flex: 0 0 300px;
     align-items: flex-start;
     justify-content: flex-start;
 

--- a/src/scss/v2/layout/_container-queries.scss
+++ b/src/scss/v2/layout/_container-queries.scss
@@ -2,7 +2,8 @@
   .archmage-v2.sheet.character-sheet {
     .window-content {
       .archmage-vue {
-        overflow-y: auto;
+        height: 100%;
+        overflow: visible;
       }
 
       .archmage-v2-vue {
@@ -37,14 +38,97 @@
         }
       }
 
-      .container--top {
-        .character-header {
-          grid-template-columns: repeat(2, minmax(0, 1fr));
+      .section--tabs-mobile {
+        display: block;
+        position: relative;
+      }
 
-          .unit--level {
-            grid-column-start: 2;
-            grid-row-start: 1;
+      .sheet-tabs-toggle--mobile {
+        width: 44px;
+        height: 44px;
+      }
+
+      .tabs--mobile {
+        display: none;
+        border: none;
+        position: absolute;
+        top: auto;
+        right: 0;
+        background-color: $c-blue;
+        z-index: 99;
+        flex-direction: column;
+        justify-content: stretch;
+        align-items: flex-start;
+        padding: 0;
+        margin: 0 !important;
+
+        &.active {
+          display: flex;
+        }
+
+        > span {
+          width: 100%;
+          
+          .tab-link {
+            flex: 1;
+            color: $c-white--50;
+            background: transparent;
+
+            &.active,
+            &:hover,
+            &:focus {
+              color: $c-white;  
+            }
+
+            &:hover {
+              background-color: $c-white--25;
+            }
           }
+        }
+      }
+
+      .tab[data-tab][data-group="mobile"] {
+        display: none;
+
+        &.active {
+          display: block;
+        }
+      }
+
+      .container--top {
+        display: grid;
+        grid-template-columns: calc(100% - 44px) 44px;
+        grid-gap: 10px;
+
+        .character-header {
+          grid-template-columns: repeat(6, minmax(0, 1fr));
+          grid-column-start: 1;
+          grid-column-end: span 1;
+          grid-row-start: 1;
+
+          .unit--name {
+            grid-column-start: 1;
+            grid-column-end: span 4;
+          }
+
+          .unit--race { grid-column-end: span 3; }
+          .unit--class { grid-column-end: span 3; }
+          .unit--level { 
+            grid-column-start: 5;
+            grid-row-start: 1;
+            grid-column-end: span 2; 
+          }
+        }
+
+        .section--tabs-mobile {
+          grid-column-start: 2;
+          grid-row-start: 1;
+        }
+
+        .tab.attributes {
+          grid-column-start: 1;
+          grid-column-end: span 2;
+          grid-row-start: 2;
         }
 
         .section--attributes {
@@ -81,6 +165,14 @@
         }
       }
 
+      .tabs--primary {
+        .tab-link {
+          font-size: 16px;
+          padding: 4px 6px;
+          margin: 2px;
+        }
+      }
+
       .container--bottom {
         flex-direction: column;
 
@@ -94,11 +186,20 @@
         }
 
         .section--resources {
+          // display: flex;
+          // flex-direction: row;
+          // flex-wrap: wrap;
           display: grid;
-          grid-template-columns: repeat(3, minmax(0, 1fr));
+          grid-template-columns: repeat(2, minmax(0, 1fr));
 
           .unit {
             max-width: none;
+            margin: 8px 0;
+            border-left: none;
+          }
+
+          .resource-divider {
+            display: none;
           }
         }
 

--- a/src/scss/v2/layout/_container-queries.scss
+++ b/src/scss/v2/layout/_container-queries.scss
@@ -1,3 +1,11 @@
+// Define containers.
+.archmage-v2 {
+  .window-content {
+    container-type: size;
+    container-name: archmage-window-content;
+  }
+}
+
 // Bandaid fixes to make small window sizes more palatable.
 @container archmage-window-content (max-width: #{$cq-tablet}) {
   .archmage-v2.sheet {
@@ -19,6 +27,24 @@
 
       .tabs {
         zoom: 80%;
+      }
+    }
+  }
+}
+
+@container archmage-window-content (min-width: #{$cq-mobile}) and (max-height: 600px) {
+  .archmage-v2.sheet {
+    .window-content {
+      .archmage-vue {
+        height: 100%;
+        overflow-y: auto;
+        scrollbar-color: $c-blue transparent;
+        scrollbar-width: thin;
+      }
+      .archmage-v2-vue {
+        height: auto;
+        flex: 0 0 auto;
+        min-height: 100%;
       }
     }
   }
@@ -81,7 +107,9 @@
         }
 
         .section--tabs-mobile {
-          display: block;
+          display: flex;
+          align-items: flex-end;
+          padding-bottom: 11px;
           position: relative;
   
           &:hover {
@@ -94,13 +122,52 @@
         .sheet-tabs-toggle--mobile {
           width: 100%;
           height: 44px;
+          // font-size: 24px;
+          position: relative;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          border: none;
+          box-shadow: none;
+          border-radius: 0;
+          margin: 0;
+
+          &::before {
+            display: block;
+            content: '';
+            // position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            margin: auto;
+            width: 5px;
+            height: 5px;
+            background: white;
+            box-shadow:
+              // Top row.
+              -10px -10px 0 white,
+              0 -10px 0 white,
+              10px -10px 0 white,
+              // Middle row.
+              10px 0 0 white,
+              -10px 0 0 white,
+              -10px 10px 0 white,
+              0 10px 0 white,
+              10px 10px 0 white;
+
+          }
+
+          i {
+            display: none;
+          }
         }
   
         .tabs--mobile {
           display: none;
           border: none;
           position: absolute;
-          top: auto;
+          top: calc(100% - 12px);
           right: 0;
           background-color: $c-blue;
           z-index: 99;
@@ -340,6 +407,7 @@
   }
 }
 
+// NPCs on super small screens.
 @container archmage-window-content (max-width: #{$cq-tiny}) {
   .archmage-v2.sheet {
     .window-content {
@@ -354,6 +422,63 @@
               display: none;
             }
           }
+        }
+      }
+    }
+  }
+}
+
+// Power importer dialog.
+.archmage-prepopulate {
+  .window-content {
+    container-type: size;
+    container-name: archmage-prepopulate-content;
+  }
+}
+
+@container archmage-prepopulate-content (max-width: #{$cq-mobile}) {
+  .archmage-prepopulate {
+    .sheet-tabs {
+      border: none;
+
+      .item {
+        border: 2px solid $c-blue--dark;
+        margin: 4px;
+      }
+    }
+
+    .grid {
+      grid-template-columns: repeat(1, minmax(0, 1fr));
+    }
+
+    .l-center {
+      margin: auto;
+    }
+
+    .class-content {
+      .archmage-class-title {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        margin-top: 0;
+
+        &::before,
+        &::after {
+          position: relative;
+          flex: 1;
+        }
+      }
+
+      table {
+        display: block;
+        max-width: fit-content;
+        margin: 0 auto;
+        overflow-x: auto;
+        white-space: nowrap;
+
+        td {
+          min-width: 100px;
+          padding: 0 5px;
         }
       }
     }

--- a/src/scss/v2/layout/_container-queries.scss
+++ b/src/scss/v2/layout/_container-queries.scss
@@ -337,6 +337,14 @@
           .sheet-settings {
             grid-template-columns: repeat(1, minmax(0, 1fr));
           }
+
+          .effects-grid {
+            grid-template-columns: 40px auto 0px 0px 60px;
+          }
+
+          .effects-bonus {
+            display: none;
+          }
         }
 
         &.character {

--- a/src/scss/v2/layout/_container-queries.scss
+++ b/src/scss/v2/layout/_container-queries.scss
@@ -1,0 +1,135 @@
+@container archmage-window-content (max-width: #{$cq-mobile}) {
+  .archmage-v2.sheet.character-sheet {
+    .window-content {
+      .archmage-vue {
+        overflow-y: auto;
+      }
+
+      .archmage-v2-vue {
+        height: auto;
+        flex: 0 0 auto;
+
+        .section--attributes,
+        .section--sidebar,
+        .section--resources,
+        .section--tabs-content {
+          background: $c-white--25;
+          border: 1px solid $c-black--25;
+          padding: 10px;
+          margin: 10px 0;
+        }
+
+        .section--resources {
+          &::after {
+            display: none;
+          }
+        }
+
+        &.nightmode {
+          .section--attributes,
+          .section--sidebar,
+          .section--resources,
+          .section--tabs-content {
+            background: $c-black--25;
+            border: 1px solid $c-white--25;
+          }
+        }
+      }
+
+      .container--top {
+        .character-header {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+
+          .unit--level {
+            grid-column-start: 2;
+            grid-row-start: 1;
+          }
+        }
+
+        .section--attributes {
+          flex-direction: column;
+        }
+
+        .unit--attributes {
+          grid-template-columns: repeat(6, minmax(0, 1fr));
+
+          .unit {
+            grid-column-end: span 2;
+          }
+        }
+
+        .unit--saves {
+          grid-column-start: 2;
+
+          &::before {
+            display: none !important;
+          }
+        }
+      }
+
+      .container--bottom {
+        flex-direction: column;
+
+        .section--sidebar,
+        .section--main {
+          height: auto;
+          width: 100%;
+          overflow-x: hidden;
+          overflow-y: hidden;
+          flex: 1;
+        }
+
+        .sheet-tabs {
+          flex-wrap: wrap;
+          margin: 10px 0;
+
+          > span {
+            display: flex;
+          }
+
+          .tab-link {
+            margin: 4px;
+          }
+        }
+
+        .section--resources {
+          display: grid;
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+
+          .unit {
+            max-width: none;
+          }
+        }
+
+        // Space is at a premium on mobile. Hide feats, recharge, and search.
+        .filter-search-powers {
+          display: none;
+        }
+
+        .power-grid {
+          grid-template-columns: 32px auto 0px 44px 0px 36px 64px;
+
+          .power-recharge,
+          .power-feat-pips {
+            display: none;
+          }
+        }
+
+        .equipment-grid {
+          grid-template-columns: 32px auto 36px 0px 0px 0px 36px 56px;
+
+          .equipment-feat-pips,
+          .equipment-bonus,
+          .equipment-chakra,
+          .equipment-recharge {
+            display: none;
+          }
+        }
+
+        .sheet-settings {
+          grid-template-columns: repeat(1, minmax(0, 1fr));
+        }
+      }
+    }
+  }
+}

--- a/src/scss/v2/layout/_container-queries.scss
+++ b/src/scss/v2/layout/_container-queries.scss
@@ -188,6 +188,11 @@
   
           .unit--attributes {
             grid-template-columns: repeat(6, minmax(0, 1fr));
+            padding-bottom: 0;
+
+            &::after {
+              top: calc(50% + 6px);
+            }
   
             .unit {
               grid-column-end: span 2;
@@ -289,9 +294,13 @@
           grid-template-columns: repeat(4, minmax(0, 1fr));
           zoom: 80%;
 
-          &::before,
-          &::after {
+          &::before {
             display: none;
+          }
+
+          &::after {
+            top: 50%;
+            left: 1px;
           }
 
           .unit {

--- a/src/scss/v2/layout/_container-queries.scss
+++ b/src/scss/v2/layout/_container-queries.scss
@@ -15,6 +15,7 @@
         .section--tabs-content {
           background: $c-white--25;
           border: 1px solid $c-black--25;
+          border-radius: 4px;
           padding: 10px;
           margin: 10px 0;
         }
@@ -67,6 +68,19 @@
         }
       }
 
+      .sheet-tabs {
+        flex-wrap: wrap;
+        margin: 10px 0;
+
+        > span {
+          display: flex;
+        }
+
+        .tab-link {
+          margin: 4px;
+        }
+      }
+
       .container--bottom {
         flex-direction: column;
 
@@ -77,19 +91,6 @@
           overflow-x: hidden;
           overflow-y: hidden;
           flex: 1;
-        }
-
-        .sheet-tabs {
-          flex-wrap: wrap;
-          margin: 10px 0;
-
-          > span {
-            display: flex;
-          }
-
-          .tab-link {
-            margin: 4px;
-          }
         }
 
         .section--resources {
@@ -128,6 +129,55 @@
 
         .sheet-settings {
           grid-template-columns: repeat(1, minmax(0, 1fr));
+        }
+      }
+    }
+  }
+
+  .archmage-v2.sheet.npc-sheet {
+    .window-content {
+      .container--top {
+        .unit--attributes {
+          &::before {
+            top: 50%;
+            left: 2px;
+          }
+
+          &::after {
+            display: none;
+          }
+
+          .unit {
+            grid-column-end: span 3;
+          }
+        }
+
+        .unit--saves,
+        .unit--disengage {
+          grid-column-start: auto;
+          position: relative;
+        }
+      }
+
+      .unit--roles {
+        flex-direction: column;
+      }
+
+      .section--main {
+        flex-direction: column;
+      }
+  
+      .section--resources {
+        align-items: flex-center;
+        justify-content: flex-center;
+  
+        .unit {
+          padding: 10px;
+          border: none !important;
+        }
+  
+        .resource-divider {
+          display: none;
         }
       }
     }

--- a/src/scss/v2/layout/_container-queries.scss
+++ b/src/scss/v2/layout/_container-queries.scss
@@ -1,14 +1,57 @@
-@container archmage-window-content (max-width: #{$cq-mobile}) {
-  .archmage-v2.sheet.character-sheet {
+// Bandaid fixes to make small window sizes more palatable.
+@container archmage-window-content (max-width: #{$cq-tablet}) {
+  .archmage-v2.sheet {
     .window-content {
+      .unit--attributes {
+        zoom: 80%;
+      }
+
+      .tab.abilities {
+        flex: 0 0 200px;
+      }
+      .section--sidebar {
+        zoom: 80%;
+      }
+
+      .section--resources {
+        zoom: 90%;
+      }
+
+      .tabs {
+        zoom: 80%;
+      }
+    }
+  }
+}
+
+// Mobile layout.
+@container archmage-window-content (max-width: #{$cq-mobile}) {
+  .archmage-v2.sheet {
+    .window-content {
+      // Undo the tablet styles. ------------------------
+      .unit--attributes,
+      .section--resources,
+      .tabs,
+      .section--sidebar {
+        zoom: 100%;
+      }
+
+      .tab.abilities {
+        flex: 1;
+      }
+      // End the tablet styles section ------------------
+
       .archmage-vue {
         height: 100%;
-        overflow: visible;
+        overflow-y: auto;
+        scrollbar-color: $c-blue transparent;
+        scrollbar-width: thin;
       }
 
       .archmage-v2-vue {
         height: auto;
         flex: 0 0 auto;
+        min-height: 100%;
 
         .section--attributes,
         .section--sidebar,
@@ -36,220 +79,223 @@
             border: 1px solid $c-white--25;
           }
         }
-      }
-
-      .section--tabs-mobile {
-        display: block;
-        position: relative;
-      }
-
-      .sheet-tabs-toggle--mobile {
-        width: 44px;
-        height: 44px;
-      }
-
-      .tabs--mobile {
-        display: none;
-        border: none;
-        position: absolute;
-        top: auto;
-        right: 0;
-        background-color: $c-blue;
-        z-index: 99;
-        flex-direction: column;
-        justify-content: stretch;
-        align-items: flex-start;
-        padding: 0;
-        margin: 0 !important;
-
-        &.active {
-          display: flex;
-        }
-
-        > span {
-          width: 100%;
-          
-          .tab-link {
-            flex: 1;
-            color: $c-white--50;
-            background: transparent;
-
-            &.active,
-            &:hover,
-            &:focus {
-              color: $c-white;  
-            }
-
-            &:hover {
-              background-color: $c-white--25;
-            }
-          }
-        }
-      }
-
-      .tab[data-tab][data-group="mobile"] {
-        display: none;
-
-        &.active {
-          display: block;
-        }
-      }
-
-      .container--top {
-        display: grid;
-        grid-template-columns: calc(100% - 44px) 44px;
-        grid-gap: 10px;
-
-        .character-header {
-          grid-template-columns: repeat(6, minmax(0, 1fr));
-          grid-column-start: 1;
-          grid-column-end: span 1;
-          grid-row-start: 1;
-
-          .unit--name {
-            grid-column-start: 1;
-            grid-column-end: span 4;
-          }
-
-          .unit--race { grid-column-end: span 3; }
-          .unit--class { grid-column-end: span 3; }
-          .unit--level { 
-            grid-column-start: 5;
-            grid-row-start: 1;
-            grid-column-end: span 2; 
-          }
-        }
 
         .section--tabs-mobile {
-          grid-column-start: 2;
-          grid-row-start: 1;
-        }
-
-        .tab.attributes {
-          grid-column-start: 1;
-          grid-column-end: span 2;
-          grid-row-start: 2;
-        }
-
-        .section--attributes {
-          flex-direction: column;
-        }
-
-        .unit--attributes {
-          grid-template-columns: repeat(6, minmax(0, 1fr));
-
-          .unit {
-            grid-column-end: span 2;
+          display: block;
+          position: relative;
+  
+          &:hover {
+            .tabs--mobile {
+              display: flex;
+            }
           }
         }
-
-        .unit--saves {
-          grid-column-start: 2;
-
-          &::before {
-            display: none !important;
-          }
-        }
-      }
-
-      .sheet-tabs {
-        flex-wrap: wrap;
-        margin: 10px 0;
-
-        > span {
-          display: flex;
-        }
-
-        .tab-link {
-          margin: 4px;
-        }
-      }
-
-      .tabs--primary {
-        .tab-link {
-          font-size: 16px;
-          padding: 4px 6px;
-          margin: 2px;
-        }
-      }
-
-      .container--bottom {
-        flex-direction: column;
-
-        .section--sidebar,
-        .section--main {
-          height: auto;
+  
+        .sheet-tabs-toggle--mobile {
           width: 100%;
-          overflow-x: hidden;
-          overflow-y: hidden;
-          flex: 1;
+          height: 44px;
         }
-
-        .section--resources {
-          // display: flex;
-          // flex-direction: row;
-          // flex-wrap: wrap;
-          display: grid;
-          grid-template-columns: repeat(2, minmax(0, 1fr));
-
-          .unit {
-            max-width: none;
-            margin: 8px 0;
-            border-left: none;
-          }
-
-          .resource-divider {
-            display: none;
-          }
-        }
-
-        // Space is at a premium on mobile. Hide feats, recharge, and search.
-        .filter-search-powers {
+  
+        .tabs--mobile {
           display: none;
+          border: none;
+          position: absolute;
+          top: auto;
+          right: 0;
+          background-color: $c-blue;
+          z-index: 99;
+          flex-direction: column;
+          justify-content: stretch;
+          align-items: flex-start;
+          padding: 0;
+          margin: 0 !important;
+  
+          &.active {
+            display: flex;
+          }
+  
+          > span {
+            width: 100%;
+            
+            .tab-link {
+              flex: 1;
+              color: $c-white--50;
+              background: transparent;
+  
+              &.active,
+              &:hover,
+              &:focus {
+                color: $c-white;  
+              }
+  
+              &:hover {
+                background-color: $c-white--25;
+              }
+            }
+          }
         }
+  
+        .tab[data-tab][data-group="mobile"] {
+          display: none;
+  
+          &.active {
+            display: block;
+          }
+        }
+  
+        .container--top {
+          display: flex;
+          flex-direction: row;
+          flex-wrap: wrap;
+  
+          .character-header {
+            flex: 1;
+            order: 1;
+            grid-template-columns: repeat(6, minmax(0, 1fr));
 
-        .power-grid {
-          grid-template-columns: 32px auto 0px 44px 0px 36px 64px;
-
-          .power-recharge,
-          .power-feat-pips {
+            label {
+              opacity: 0.25;
+            }
+  
+            .unit--name {
+              grid-column-start: 1;
+              grid-column-end: span 4;
+            }
+  
+            .unit--race { grid-column-end: span 3; }
+            .unit--class { grid-column-end: span 3; }
+            .unit--level { 
+              grid-column-start: 5;
+              grid-row-start: 1;
+              grid-column-end: span 2; 
+            }
+          }
+  
+          .section--tabs-mobile {
+            flex: 0 0 44px;
+            margin-left: 10px;
+            order: 2;
+          }
+  
+          .tab.attributes {
+            flex: 100%;
+            order: 3;
+          }
+  
+          .section--attributes {
+            flex-direction: column;
+          }
+  
+          .unit--attributes {
+            grid-template-columns: repeat(6, minmax(0, 1fr));
+  
+            .unit {
+              grid-column-end: span 2;
+            }
+          }
+  
+          .unit--saves {
+            grid-column-start: 2;
+          }
+        }
+  
+        .tabs--primary {
+          .tab-link {
+            font-size: 16px;
+            padding: 4px 6px;
+            margin: 2px;
+          }
+        }
+  
+        .container--bottom {
+          flex-direction: column;
+  
+          .section--sidebar,
+          .section--main {
+            height: auto;
+            width: 100%;
+            overflow-x: visible;
+            overflow-y: visible;
+            flex: 1;
+          }
+  
+          .section--resources {
+            // display: flex;
+            // flex-direction: row;
+            // flex-wrap: wrap;
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+  
+            .unit {
+              max-width: none;
+              margin: 8px 0;
+              border-left: none;
+            }
+  
+            .resource-divider {
+              display: none;
+            }
+          }
+  
+          // Space is at a premium on mobile. Hide feats, recharge, and search.
+          .filter-search-powers {
             display: none;
+          }
+  
+          .power-grid {
+            grid-template-columns: 32px auto 0px 44px 0px 36px 64px;
+  
+            .power-recharge,
+            .power-feat-pips {
+              display: none;
+            }
+          }
+  
+          .equipment-grid {
+            grid-template-columns: 32px auto 36px 0px 0px 0px 36px 56px;
+  
+            .equipment-feat-pips,
+            .equipment-bonus,
+            .equipment-chakra,
+            .equipment-recharge {
+              display: none;
+            }
+          }
+  
+          .sheet-settings {
+            grid-template-columns: repeat(1, minmax(0, 1fr));
           }
         }
 
-        .equipment-grid {
-          grid-template-columns: 32px auto 36px 0px 0px 0px 36px 56px;
-
-          .equipment-feat-pips,
-          .equipment-bonus,
-          .equipment-chakra,
-          .equipment-recharge {
-            display: none;
+        &.character {
+          .unit--saves {
+            &::before {
+              display: none !important;
+            }
           }
-        }
-
-        .sheet-settings {
-          grid-template-columns: repeat(1, minmax(0, 1fr));
         }
       }
-    }
+
+    } // end
   }
 
   .archmage-v2.sheet.npc-sheet {
     .window-content {
       .container--top {
-        .unit--attributes {
-          &::before {
-            top: 50%;
-            left: 2px;
-          }
+        display: flex;
+        flex-direction: column;
 
+        .unit--attributes {
+          grid-template-columns: repeat(4, minmax(0, 1fr));
+          zoom: 80%;
+
+          &::before,
           &::after {
             display: none;
           }
 
           .unit {
-            grid-column-end: span 3;
+            grid-column-end: span 1;
           }
         }
 
@@ -279,6 +325,26 @@
   
         .resource-divider {
           display: none;
+        }
+      }
+    }
+  }
+}
+
+@container archmage-window-content (max-width: #{$cq-tiny}) {
+  .archmage-v2.sheet {
+    .window-content {
+      .archmage-v2-vue.npc {
+        .container--top {
+          .unit--attributes {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+          }
+
+          .unit--saves {
+            &::before {
+              display: none;
+            }
+          }
         }
       }
     }

--- a/src/scss/v2/theme/_nightmode.scss
+++ b/src/scss/v2/theme/_nightmode.scss
@@ -4,12 +4,13 @@ $c-night: #292929;
 $c-night-darker: #191919;
 $bx-night: inset 0 0 100px 0 $c-night-darker;
 
-.archmage-v2.sheet .window-content,
-.archmage-v2.archmage-dialog .window-content {
-  .archmage-v2-vue.nightmode {
+.archmage-v2.sheet.nightmode .window-content,
+.archmage-v2.archmage-dialog.nightmode .window-content {
+  background: $c-night;
+  box-shadow: $bx-night;
+
+  .archmage-v2-vue {
     // background-image: url('#{$assets}/paper-v2-nightmode.webp');
-    background: $c-night;
-    box-shadow: $bx-night;
     color: $c-white;
 
     .notes {

--- a/src/scss/v2/utils/_variables.scss
+++ b/src/scss/v2/utils/_variables.scss
@@ -16,6 +16,7 @@ $z-high: 10;
 $z-higher: 20;
 $z-overlay: 9999;
 
+$cq-tiny: 400px;
 $cq-mobile: 600px;
 $cq-tablet: 800px;
 $cq-desktop: 1024px;

--- a/src/scss/v2/utils/_variables.scss
+++ b/src/scss/v2/utils/_variables.scss
@@ -15,3 +15,7 @@ $z-normal: 1;
 $z-high: 10;
 $z-higher: 20;
 $z-overlay: 9999;
+
+$cq-mobile: 600px;
+$cq-tablet: 800px;
+$cq-desktop: 1024px;

--- a/src/scss/v2/utils/_variables.scss
+++ b/src/scss/v2/utils/_variables.scss
@@ -18,5 +18,5 @@ $z-overlay: 9999;
 
 $cq-tiny: 400px;
 $cq-mobile: 600px;
-$cq-tablet: 800px;
+$cq-tablet: 820px;
 $cq-desktop: 1024px;

--- a/src/vue/ArchmageCharacterSheet.vue
+++ b/src/vue/ArchmageCharacterSheet.vue
@@ -5,8 +5,11 @@
     <section class="container container--top flexcol">
       <!-- Header -->
       <CharHeader :actor="actor"/>
-      <!-- Attributes section -->
-      <CharAttributes :actor="actor"/>
+      <Tabs :actor="actor" group="mobile" :tabs="tabs.mobile" :flags="flags" hamburger="true" />
+      <Tab group="mobile" :tab="tabs.mobile.attributes">
+        <!-- Attributes section -->
+        <CharAttributes :actor="actor"/>
+      </Tab>
     </section>
     <!-- /Top group -->
 
@@ -14,50 +17,54 @@
     <section class="container container--bottom flexrow">
 
       <!-- Left sidebar -->
-      <section class="section section--sidebar flexcol">
-        <CharInitiative :actor="actor"/>
-        <CharAbilities :actor="actor"/>
-        <CharBackgrounds :actor="actor"/>
-        <CharIconRelationships :actor="actor"/>
-        <CharOut :actor="actor" :owner="context.owner"/>
-        <CharIncrementals :actor="actor"/>
-      </section>
+      <Tab group="mobile" :tab="tabs.mobile.abilities">
+        <section class="section section--sidebar flexcol">
+          <CharInitiative :actor="actor"/>
+          <CharAbilities :actor="actor"/>
+          <CharBackgrounds :actor="actor"/>
+          <CharIconRelationships :actor="actor"/>
+          <CharOut :actor="actor" :owner="context.owner"/>
+          <CharIncrementals :actor="actor"/>
+        </section>
+      </Tab>
       <!-- /Left sidebar -->
 
       <!-- Main content -->
-      <section class="section section--main flexcol">
-
-        <!-- Class resources -->
-        <CharResources :actor="actor"/>
-        <!-- Tabs -->
-        <Tabs :actor="actor" group="primary" :tabs="tabs.primary" :flags="flags"/>
-
-        <!-- Tabs content -->
-        <section class="section section--tabs-content flexcol">
-          <!-- Details tab -->
-          <Tab group="primary" :tab="tabs.primary.details">
-            <CharDetails :actor="actor" :owner="context.owner" :tab="tabs.primary.details" :flags="flags"/>
-          </Tab>
-          <!-- Powers tab -->
-          <Tab group="primary" :tab="tabs.primary.powers">
-            <CharPowers :actor="actor" :context="context" :tab="tabs.primary.powers" :flags="flags"/>
-          </Tab>
-          <!-- Inventory tab -->
-          <Tab group="primary" :tab="tabs.primary.inventory">
-            <CharInventory :actor="actor" :tab="tabs.primary.inventory" :flags="flags"/>
-          </Tab>
-          <!-- Effects tab -->
-          <Tab group="primary" :tab="tabs.primary.effects">
-            <CharEffects :actor="actor" :tab="tabs.primary.effects" :flags="flags"/>
-          </Tab>
-          <!-- Settings tab -->
-          <Tab group="primary" :tab="tabs.primary.settings" v-if="shouldDisplaySettingsTab(actor)">
-            <CharSettings :actor="actor" :tab="tabs.primary.settings"/>
-          </Tab>
+      <Tab group="mobile" :tab="tabs.mobile.combat">
+        <section class="section section--main flexcol">
+  
+          <!-- Class resources -->
+          <CharResources :actor="actor"/>
+          <!-- Tabs -->
+          <Tabs :actor="actor" group="primary" :tabs="tabs.primary" :flags="flags"/>
+  
+          <!-- Tabs content -->
+          <section class="section section--tabs-content flexcol">
+            <!-- Details tab -->
+            <Tab group="primary" :tab="tabs.primary.details">
+              <CharDetails :actor="actor" :owner="context.owner" :tab="tabs.primary.details" :flags="flags"/>
+            </Tab>
+            <!-- Powers tab -->
+            <Tab group="primary" :tab="tabs.primary.powers">
+              <CharPowers :actor="actor" :context="context" :tab="tabs.primary.powers" :flags="flags"/>
+            </Tab>
+            <!-- Inventory tab -->
+            <Tab group="primary" :tab="tabs.primary.inventory">
+              <CharInventory :actor="actor" :tab="tabs.primary.inventory" :flags="flags"/>
+            </Tab>
+            <!-- Effects tab -->
+            <Tab group="primary" :tab="tabs.primary.effects">
+              <CharEffects :actor="actor" :tab="tabs.primary.effects" :flags="flags"/>
+            </Tab>
+            <!-- Settings tab -->
+            <Tab group="primary" :tab="tabs.primary.settings" v-if="shouldDisplaySettingsTab(actor)">
+              <CharSettings :actor="actor" :tab="tabs.primary.settings"/>
+            </Tab>
+          </section>
+          <!-- /Tabs content -->
+  
         </section>
-        <!-- /Tabs content -->
-
-      </section>
+      </Tab>
       <!-- /Main content -->
 
     </section>
@@ -149,6 +156,23 @@ export default {
             hideLabel: true,
             hidden: (this.actor.flags?.archmage?.hideSettingsTab === true && !game.user.isGM)
           }
+        },
+        mobile: {
+          attributes: {
+            key: 'attributes',
+            label: localize('ARCHMAGE.attributes'),
+            active: false,
+          },
+          abilities: {
+            key: 'abilities',
+            label: localize('ARCHMAGE.abilities'),
+            active: false,
+          },
+          combat: {
+            key: 'combat',
+            label: localize('ARCHMAGE.combat'),
+            active: false,
+          }
         }
       }
     }
@@ -159,7 +183,7 @@ export default {
         return false;
       }
       return true;
-    }
+    },
   },
   computed: {
     nightmode() {
@@ -177,7 +201,8 @@ export default {
             'sortBy': {'value': 'custom'}
           },
           'tabs': {
-            'primary': {'value': 'powers'}
+            'primary': {'value': 'powers'},
+            'mobile': {'value': 'attributes'},
           },
         }
       }

--- a/src/vue/ArchmageCharacterSheet.vue
+++ b/src/vue/ArchmageCharacterSheet.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="concat('archmage-v2-vue flexcol ', nightmode)">
+  <div :class="concat('archmage-v2-vue character flexcol ', nightmode)">
 
     <!-- Top group -->
     <section class="container container--top flexcol">

--- a/src/vue/ArchmageNpcSheet.vue
+++ b/src/vue/ArchmageNpcSheet.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="concat('archmage-v2-vue flexcol ', nightmode)" @click="toggleEditWrappers">
+  <div :class="concat('archmage-v2-vue npc flexcol ', nightmode)" @click="toggleEditWrappers">
 
     <!-- Top group -->
     <section class="container container--top flexcol">

--- a/src/vue/components/actor/npc/NpcHeader.vue
+++ b/src/vue/components/actor/npc/NpcHeader.vue
@@ -299,7 +299,7 @@
 
   .unit--roles {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     align-items: flex-start;
     justify-content: flex-start;
 

--- a/src/vue/components/parts/Tabs.vue
+++ b/src/vue/components/parts/Tabs.vue
@@ -1,7 +1,10 @@
 <template>
-  <section class="section section--tabs flexshrink">
+  <section :class="`section section--tabs section--tabs-${group} flexshrink`">
     <!-- <input type="hidden" :name="concat('flags.archmage.sheetDisplay.tabs.', group, '.value')" v-model="currentTab"/> -->
-    <nav :class="'sheet-tabs tabs tabs--' + group" :data-group="group">
+    <button v-if="hamburger" :class="`sheet-tabs-toggle sheet-tabs-toggle--${group}`" @click="toggleMenu">
+      <i class="fas fa-bars"></i><span class="visually-hidden"> Toggle Navigation</span>
+    </button>
+    <nav :class="`sheet-tabs tabs tabs--${group}`" :data-group="group">
       <span v-for="(tab, tabKey) in tabs" :key="'tab-' + group + '-' + tabKey">
         <a @click="changeTab" :class="getTabClass(tab, tabKey)" :data-tab="tabKey" v-if="!tab.hidden">
           <i v-if="tab.icon" :class="concat('fas ', tab.icon)"></i>
@@ -16,7 +19,7 @@
 import { concat, getActor } from '@/methods/Helpers';
 export default {
   name: 'Tabs',
-  props: ['context', 'actor', 'group', 'tabs', 'flags'],
+  props: ['context', 'actor', 'group', 'tabs', 'flags', 'hamburger'],
   setup() {
     return { concat }
   },
@@ -47,6 +50,19 @@ export default {
         getActor(this.actor).then(actor => {
           actor.setFlag('archmage', `sheetDisplay.tabs.${this.group}.value`, this.currentTab);
         });
+      }
+      // Close the mobile menu if open. We also need a click listener in the actor sheet class
+      // to close it as well, ideally.
+      const menu = event?.target?.closest('.section--tabs')?.querySelector('.sheet-tabs');
+      if (menu) {
+        menu.classList.remove('active');
+      }
+    },
+    toggleMenu(event) {
+      const target = event.target;
+      const menu = target?.closest('.section--tabs')?.querySelector('.sheet-tabs');
+      if (menu) {
+        menu.classList.toggle('active');
       }
     },
     getTabClass(tab, index) {


### PR DESCRIPTION
- Updated both the character and NPC sheets to use container queries, allowing them to scale down to _much_ smaller sizes. The new breakpoints are essentially:
  - 1024px or less (width): Scale down a few problem areas like attributes, but keep the layout mostly the same.
  - 600px or less (height): Make the sheet itself scrollable rather than having nested scrolling regions (backgrounds and powers). 
  - 600px or less (width): Completely reflows the layout of the sheet to a more mobile-friendly design.
- Because these changes use container queries, it will take effect even when resizing character sheets and not touching your browser window itself. However, I also tested this with the Sheet Only module specifically and an iPhone SE, and it worked well in that context.

## Screenshots
![image](https://github.com/user-attachments/assets/bad42555-d4be-46cc-8dca-a158f30de841)

## Recordings
https://github.com/user-attachments/assets/cfef9fe4-5c1a-4d62-93bf-6295739fbfe0

