### PR TITLE
2e icon rolls and benefits

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -549,6 +549,7 @@ ARCHMAGE:
     wondrousLabel: Wondrous
   CHAT:
     actionType: Action Type
+    advantages: Advantages
     adventurer: Adventurer Feat
     always: Always
     alwaysPlaceholder: Some effect that always happens

--- a/src/module/actor/actor-sheet-v2.js
+++ b/src/module/actor/actor-sheet-v2.js
@@ -631,7 +631,7 @@ export class ActorArchmageSheetV2 extends ActorSheet {
 
       rollResults = result.terms[0].results;
       rollResults.forEach(rollResult => {
-        if (game.settings.get("archmage", "secondEdition")) {
+        if (CONFIG.ARCHMAGE.is2e) {
           if ([5, 6].includes(rollResult.result)) {
             sixes++;
             actorIconResults.push(6);

--- a/src/module/actor/actor-sheet-v2.js
+++ b/src/module/actor/actor-sheet-v2.js
@@ -631,7 +631,13 @@ export class ActorArchmageSheetV2 extends ActorSheet {
 
       rollResults = result.terms[0].results;
       rollResults.forEach(rollResult => {
-        if (rollResult.result == 5) {
+        if (game.settings.get("archmage", "secondEdition")) {
+          if ([5, 6].includes(rollResult.result)) {
+            sixes++;
+            actorIconResults.push(6);
+          }
+        }
+        else if (rollResult.result == 5) {
           fives++;
           actorIconResults.push(5);
         }
@@ -659,6 +665,7 @@ export class ActorArchmageSheetV2 extends ActorSheet {
       const templateData = {
         actor: this.actor,
         tokenId: token ? `${token.id}` : null,
+        secondEdition: game.settings.get("archmage", "secondEdition"),
         icon: icon,
         fives: fives,
         sixes: sixes,

--- a/src/module/actor/actor-sheet-v2.js
+++ b/src/module/actor/actor-sheet-v2.js
@@ -665,7 +665,7 @@ export class ActorArchmageSheetV2 extends ActorSheet {
       const templateData = {
         actor: this.actor,
         tokenId: token ? `${token.id}` : null,
-        secondEdition: game.settings.get("archmage", "secondEdition"),
+        secondEdition: CONFIG.ARCHMAGE.is2e,
         icon: icon,
         fives: fives,
         sixes: sixes,

--- a/src/scss/global/_archmage-global.scss
+++ b/src/scss/global/_archmage-global.scss
@@ -1939,6 +1939,9 @@ option[selected] {
           }
         }
 
+        &.second-edition .roll.die.result-5 {
+          background: #93c385;
+        }
       }
     }
   }

--- a/src/scss/v2/components/character/_icons.scss
+++ b/src/scss/v2/components/character/_icons.scss
@@ -32,9 +32,14 @@
     background: $c-white;
     border: 1px solid $c-black;
     text-align: center;
-    line-height: $font-sm;
+    line-height: 21px;
     font-size: $font-sm;
     cursor: pointer;
+    font-weight: 900;
+
+    &.secondEdition {
+      line-height: $font-sm;
+    }
 
     &[data-roll="0"] {
       color: transparent;

--- a/src/templates/chat/icon-relationship-card.html
+++ b/src/templates/chat/icon-relationship-card.html
@@ -11,7 +11,7 @@
                 <span class="part-formula">{{data.roll.formula}}</span>
                 <span class="part-total">{{data.roll.total}}</span>
             </header>
-            <ol class="dice-rolls">
+            <ol class="dice-rolls {{#if secondEdition}}second-edition{{/if}}">
               {{#each data.roll.terms as |term i|}}
                 {{#each term.results as |result r|}}
                 <li class="roll die d{{term.faces}} result-{{result.result}}">{{result.result}}</li>

--- a/src/templates/chat/icon-relationship-card.html
+++ b/src/templates/chat/icon-relationship-card.html
@@ -8,7 +8,7 @@
       <section class="tooltip-part">
         <div class="dice">
             <header class="part-header flexrow">
-                <span class="part-formula">{{data.roll.formula}}</span>             
+                <span class="part-formula">{{data.roll.formula}}</span>
                 <span class="part-total">{{data.roll.total}}</span>
             </header>
             <ol class="dice-rolls">
@@ -23,8 +23,12 @@
     </div>
     <div class="card-row">
       <div class="card-prop">
+        {{#if secondEdition}}
+        <span {{#if hasSixes}}style="color: green;"{{/if}}><b>{{ localize 'ARCHMAGE.CHAT.advantages' }}: </b> {{sixes}}</span><br />
+        {{else}}
         <span {{#if hasSixes}}style="color: green;"{{/if}}><b>{{ localize 'ARCHMAGE.CHAT.unambiguousAdvantages' }}: </b> {{sixes}}</span><br />
         <span {{#if hasFives}}style="color: orange;"{{/if}}><b>{{ localize 'ARCHMAGE.CHAT.complicatedAdvantages'}}: </b> {{fives}}</span>
+        {{/if}}
       </div>
     </div>
   </div>

--- a/src/vue/components/actor/character/sidebar/CharIconRelationships.vue
+++ b/src/vue/components/actor/character/sidebar/CharIconRelationships.vue
@@ -9,7 +9,16 @@
             <span class="icon-name">{{item.bonus.value}} {{item.name.value}}</span>
           </div>
           <ul v-if="item.results" class="icon-rolls flexrow" :key="changeKey">
-            <li v-for="(roll, rollIndex) in item.results" :key="rollIndex" class="icon-roll" :data-key="index" :data-roll-key="rollIndex" :data-roll="roll ?? 0">{{getRollResult(roll)}}</li>
+            <li v-for="(roll, rollIndex) in item.results"
+                :key="rollIndex"
+                class="icon-roll"
+                :class="{secondEdition: is2e}"
+                :data-key="index"
+                :data-roll-key="rollIndex"
+                :data-roll="roll ?? 0"
+            >
+              {{rollResultText(roll)}}
+            </li>
           </ul>
         </div>
         <div :class="concat('icon-edit flexrow', isEdit(index, !editArray[index]))">
@@ -41,7 +50,8 @@ export default {
   },
   data: () => ({
     editArray: [],
-    changeKey: 0
+    changeKey: 0,
+    is2e: CONFIG.ARCHMAGE.is2e
   }),
   computed: {
     icons() {
@@ -98,6 +108,17 @@ export default {
         results [6] = '✓';
       }
       return results[roll] ?? 0;
+    },
+    rollResultText(roll) {
+      const results = {
+        5: '5',
+        6: '6'
+      }
+      if (CONFIG.ARCHMAGE.is2e) {
+        results[5] = '~';
+        results[6] = '+';
+      }
+      return results[roll] ?? '';
     }
   },
   watch: {

--- a/src/vue/components/actor/character/sidebar/CharIconRelationships.vue
+++ b/src/vue/components/actor/character/sidebar/CharIconRelationships.vue
@@ -9,7 +9,7 @@
             <span class="icon-name">{{item.bonus.value}} {{item.name.value}}</span>
           </div>
           <ul v-if="item.results" class="icon-rolls flexrow" :key="changeKey">
-            <li v-for="(roll, rollIndex) in item.results" :key="rollIndex" class="icon-roll" :data-key="index" :data-roll-key="rollIndex" :data-roll="getRollResult(roll)">{{getRollResult(roll)}}</li>
+            <li v-for="(roll, rollIndex) in item.results" :key="rollIndex" class="icon-roll" :data-key="index" :data-roll-key="rollIndex" :data-roll="roll ?? 0">{{getRollResult(roll)}}</li>
           </ul>
         </div>
         <div :class="concat('icon-edit flexrow', isEdit(index, !editArray[index]))">
@@ -89,7 +89,15 @@ export default {
       }
     },
     getRollResult(roll) {
-      return roll == 5 || roll == 6 ? roll : 0;
+      const results = {
+        5: 5,
+        6: 6
+      }
+      if (game.settings.get('archmage', 'secondEdition')) {
+        results[5] = '?';
+        results [6] = '✓';
+      }
+      return results[roll] ?? 0;
     }
   },
   watch: {

--- a/src/vue/components/actor/character/sidebar/CharIconRelationships.vue
+++ b/src/vue/components/actor/character/sidebar/CharIconRelationships.vue
@@ -98,17 +98,6 @@ export default {
         return this.editArray[index] === type ? ' hide ' : '';
       }
     },
-    getRollResult(roll) {
-      const results = {
-        5: 5,
-        6: 6
-      }
-      if (game.settings.get('archmage', 'secondEdition')) {
-        results[5] = '?';
-        results [6] = '✓';
-      }
-      return results[roll] ?? 0;
-    },
     rollResultText(roll) {
       const results = {
         5: '5',


### PR DESCRIPTION
Updating the UI and logic for 2e-style icon benefits.

- [x] Display a 6 as a `+` and a 5 as a `~`
- [x] When rolling, interpret 5s as 6s
- [x] On the card: update the language and display 5s as green

The `?` value allows for e.g. the Necro's "It's Complicated" talent, which at my table we interpret as a benefit with an automatic twist.

![CleanShot 2024-08-30 at 13 40 51](https://github.com/user-attachments/assets/448cf955-d8bc-4ee2-84fd-9a887fb87739)

![CleanShot 2024-08-30 at 10 38 46](https://github.com/user-attachments/assets/ac261316-95c6-4a42-9ecd-bb7bb12d6680)

Also updated the 1e version to be better centered:

![CleanShot 2024-08-30 at 13 41 16](https://github.com/user-attachments/assets/a8113db4-d61e-4471-a349-584ecf1c1966)

