### PR TITLE
Add natural roll result(s) to d20 roll tooltips

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -628,6 +628,7 @@ ARCHMAGE:
     missOddPlaceholder: Effects that happen on odd misses
     MomentReset: lost
     natural: natural
+    NaturalRoll: 'Natural {naturalRolls}'
     NoResources: Not enough resources
     NoUses: No uses left
     NoUsesMsg: No uses left, do you want to use this anyway?

--- a/src/module/rolls/HitEvaluation.mjs
+++ b/src/module/rolls/HitEvaluation.mjs
@@ -32,6 +32,13 @@ export default class HitEvaluation {
             roll_data.terms.forEach(p => {if (p.faces === 20) isD20 = true;});
             if (!isD20) return;
 
+            // Add natural-roll tooltips
+            const origTooltip = $roll_self.attr('data-tooltip');
+            const naturalRolls = roll_data.terms.filter(p => p.faces === 20)
+              .flatMap(term => term.results.map(die => die.result))
+              .join(', ');
+            $roll_self.attr('data-tooltip', origTooltip + '\n' + game.i18n.format('ARCHMAGE.CHAT.NaturalRoll', {naturalRolls}))
+
             // Crit/fumble check
             let rollResult = 0;
             let hasCrit = false;
@@ -112,7 +119,7 @@ export default class HitEvaluation {
             defenses: defenses,
             $rolls: $rolls
         };
-        
+
     }
 
     // Get either the Token overridden value or the base sheet value


### PR DESCRIPTION
This allows a player to peek at the natural roll results without clicking open the roll.

![CleanShot 2024-08-31 at 06 21 20](https://github.com/user-attachments/assets/042198ef-ec5d-4ff0-a3ec-4026a880a742)
