### PR TITLE
Natural d20 rolls in chat cards

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -232,6 +232,8 @@ ARCHMAGE:
     ShowDebugLogsName: Show debug logs?
     showDefensesInChatHint: Enable this to display a list of targeted defenses in the attack line of chat power cards.
     showDefensesInChatName: Show target(s) defense(s) in chat
+    showNaturalRollsHint: Enable this to display natural dice results for d20 rolls in chat power cards.
+    showNaturalRollsName: Show natural d20 rolls in chat
     staggeredOverlayHint: If enabled the staggered condition will be automatically applied as a token overlay instead of a normal condition.
     staggeredOverlayName: Staggered as overlay
     sheetTooltipsHint: Adds tooltips to sheets containing relevant SRD rules and tips. May be most useful when first learning the system or for the GM who only references player sheets occasionally. Client setting.

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -525,6 +525,17 @@ Hooks.once('init', async function() {
     requiresReload: true
   });
 
+  game.settings.register('archmage', 'showNaturalRolls', {
+    name: game.i18n.localize("ARCHMAGE.SETTINGS.showNaturalRollsName"),
+    hint: game.i18n.localize("ARCHMAGE.SETTINGS.showNaturalRollsHint"),
+    scope: 'client',
+    config: true,
+    default: false,
+    type: Boolean,
+    requiresReload: false,
+    onChange: newValue => $('#chat-log').toggleClass('show-natural-rolls', newValue)
+  });
+
   game.settings.register('archmage', 'colorBlindMode', {
     name: game.i18n.localize("ARCHMAGE.SETTINGS.ColorblindName"),
     hint: game.i18n.localize("ARCHMAGE.SETTINGS.ColorblindHint"),
@@ -697,8 +708,7 @@ function addEscalationDie() {
     return doc.sheet.render(true);
   });
 
-  // TODO: if setting is turned on
-  $('#chat-log').addClass('show-natural-rolls');
+  $('#chat-log').toggleClass('show-natural-rolls', game.settings.get('archmage', 'showNaturalRolls'));
 }
 
 /* -------------------------------------------- */
@@ -855,6 +865,7 @@ Hooks.on('renderSettingsConfig', (app, html, data) => {
       settings: [
         'nightmode',
         'compactMode',
+        'showNaturalRolls',
         'sheetTooltips',
       ],
       highlights: [

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -696,6 +696,9 @@ function addEscalationDie() {
 
     return doc.sheet.render(true);
   });
+
+  // TODO: if setting is turned on
+  $('#chat-log').addClass('show-natural-rolls');
 }
 
 /* -------------------------------------------- */

--- a/src/module/rolls/HitEvaluation.mjs
+++ b/src/module/rolls/HitEvaluation.mjs
@@ -37,8 +37,9 @@ export default class HitEvaluation {
             const naturalRolls = roll_data.terms.filter(p => p.faces === 20)
               .flatMap(term => term.results.map(die => die.result))
               .join(', ');
-            $roll_self.attr('data-tooltip', origTooltip + ' / ' + game.i18n.format('ARCHMAGE.CHAT.NaturalRoll', {naturalRolls}))
-            $roll_self.after(`<span class="natural-rolls">
+            const tooltipValue = game.i18n.format('ARCHMAGE.CHAT.NaturalRoll', {naturalRolls});
+            $roll_self.attr('data-tooltip', origTooltip + ' / ' + tooltipValue)
+            $roll_self.after(`<span class="natural-rolls" data-tooltip="${tooltipValue}">
               <i class="fas fa-n"></i>
               ${naturalRolls}
             </span>`);

--- a/src/module/rolls/HitEvaluation.mjs
+++ b/src/module/rolls/HitEvaluation.mjs
@@ -37,7 +37,11 @@ export default class HitEvaluation {
             const naturalRolls = roll_data.terms.filter(p => p.faces === 20)
               .flatMap(term => term.results.map(die => die.result))
               .join(', ');
-            $roll_self.attr('data-tooltip', origTooltip + '\n' + game.i18n.format('ARCHMAGE.CHAT.NaturalRoll', {naturalRolls}))
+            $roll_self.attr('data-tooltip', origTooltip + ' / ' + game.i18n.format('ARCHMAGE.CHAT.NaturalRoll', {naturalRolls}))
+            $roll_self.after(`<span class="natural-rolls">
+              <i class="fas fa-n"></i>
+              ${naturalRolls}
+            </span>`);
 
             // Crit/fumble check
             let rollResult = 0;

--- a/src/module/rolls/HitEvaluation.mjs
+++ b/src/module/rolls/HitEvaluation.mjs
@@ -38,7 +38,7 @@ export default class HitEvaluation {
               .flatMap(term => term.results.map(die => die.result))
               .join(', ');
             const tooltipValue = game.i18n.format('ARCHMAGE.CHAT.NaturalRoll', {naturalRolls});
-            $roll_self.attr('data-tooltip', origTooltip + ' / ' + tooltipValue)
+            $roll_self.attr('data-tooltip', origTooltip + '<br>' + tooltipValue)
             $roll_self.after(`<span class="natural-rolls" data-tooltip="${tooltipValue}">
               <i class="fas fa-n"></i>
               ${naturalRolls}

--- a/src/scss/global/_archmage-global.scss
+++ b/src/scss/global/_archmage-global.scss
@@ -159,6 +159,23 @@ option[selected] {
       color: $c-black;
     }
   }
+
+  .natural-rolls {
+    display: none;
+    border: 2px solid #aaa;
+    border-radius: 4px;
+    line-height: 0;
+    padding: 2px;
+    margin: 0 3px;
+    font-size: 12px;
+
+    i {
+      font-size: 10px;
+    }
+  }
+  &.show-natural-rolls .natural-rolls {
+    display: inline-block;
+  }
 }
 
 .ability-usage {


### PR DESCRIPTION
Generates spans to display natural d20 rolls in chat cards, which are `display: none` by default, and shown with a CSS class if a certain setting is enabled.

- [x] Generate the spans
- [x] CSS to hide by default, and show with a class on `#chat-log`
- [x] Add a client setting to enable displaying them

![CleanShot 2024-09-01 at 08 22 39](https://github.com/user-attachments/assets/0dd1652d-826d-462e-90f0-3e6121450ab5)
