### PR TITLE
Natural-result roll: rerolls

### DIFF
--- a/src/module/rolls/HitEvaluation.mjs
+++ b/src/module/rolls/HitEvaluation.mjs
@@ -35,7 +35,7 @@ export default class HitEvaluation {
             // Add natural-roll tooltips
             const origTooltip = $roll_self.attr('data-tooltip');
             const naturalRolls = roll_data.terms.filter(p => p.faces === 20)
-              .flatMap(term => term.results.map(die => die.result))
+              .flatMap(term => term.results.map(die => die.active ? die.result : `<s>${die.result}</s>`))
               .join(', ');
             const tooltipValue = game.i18n.format('ARCHMAGE.CHAT.NaturalRoll', {naturalRolls});
             $roll_self.attr('data-tooltip', origTooltip + '<br>' + tooltipValue)

--- a/src/module/rolls/HitEvaluation.mjs
+++ b/src/module/rolls/HitEvaluation.mjs
@@ -39,6 +39,9 @@ export default class HitEvaluation {
               .join(', ');
             const tooltipValue = game.i18n.format('ARCHMAGE.CHAT.NaturalRoll', {naturalRolls});
             $roll_self.attr('data-tooltip', origTooltip + '<br>' + tooltipValue)
+
+            // Add and/or replace the natural-roll span
+            if ($roll_self.next().attr("class") === "natural-rolls") $roll_self.next().remove();
             $roll_self.after(`<span class="natural-rolls" data-tooltip="${tooltipValue}">
               <i class="fas fa-n"></i>
               ${naturalRolls}

--- a/src/scss/global/_archmage-global.scss
+++ b/src/scss/global/_archmage-global.scss
@@ -169,6 +169,11 @@ option[selected] {
     margin: 0 3px;
     font-size: 12px;
 
+    s {
+      color: #aaa;
+      text-decoration: none;
+    }
+
     i {
       font-size: 10px;
     }


### PR DESCRIPTION
This addresses two shortcomings of the natural-result widget: rerolled dice, and context-menu rerolls.


https://github.com/user-attachments/assets/ebb26c1d-7959-4b67-b136-d22b9de7b431

