### PR TITLE
Add skulls and stoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 ._*
 /node_modules
+/foundry
 /dist
 /public
 /systems

--- a/jsconfig.json.example
+++ b/jsconfig.json.example
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "ES6",
+    "target": "ES6"
+  },
+  "exclude": ["node_modules", "**/node_modules/*", "dist"],
+  "include": [
+    "src/module/**/*.js",
+    "src/vue/**/*.js",
+    "foundry/client/**/*.js",
+    "foundry/**/*.mjs"
+  ],
+  "typeAcquisition": {
+    "include": ["jquery"]
+  }
+}

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -752,7 +752,7 @@ export class ActorArchmage extends Actor {
     data.abil = data.abilities;
 
     // Process resource shorthands and custom resource names
-    if (this.type == "character"){
+    if (this.type === "character"){
       data.rsc = {
         cps: data.resources.perCombat.commandPoints.current,
         focus: data.resources.perCombat.focus.current,
@@ -768,6 +768,15 @@ export class ActorArchmage extends Actor {
           data.rsc[label+"max"] = v.max;
         }
       }
+    }
+
+    // Handle stoke.
+    if (this.type === "npc") {
+      data.rsc = {
+        stoke: data.resources?.spendable?.stoke?.enabled
+          ? (data.resources?.spendable?.stoke?.current || 0)
+          : 0,
+      };
     }
 
     if (item?.system.powerLevel?.value) {

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -728,6 +728,11 @@ export class ActorArchmage extends Actor {
           data.std = v.value;
           break;
 
+        case 'saves':
+          if (this.type === "character") data.skulls = v.deathFails.value || 0;
+          if (!(k in data)) data[k] = v;
+          break;
+
         default:
           if (!(k in data)) data[k] = v;
           break;

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -231,6 +231,10 @@ Hooks.once('init', async function() {
     delete CONFIG.statusEffects[id].changes;
     CONFIG.statusEffects[id].journal = "uHqgXlfj0rkf0XRE";
 
+    // Update grabbed.
+    id = CONFIG.statusEffects.findIndex(e => e.id == "grabbed");
+    CONFIG.statusEffects[id].journal = "e74tdY4XILWFW9VB";
+
     // Update stunned
     id = CONFIG.statusEffects.findIndex(e => e.id == "stunned");
     CONFIG.statusEffects[id].journal = "2rxwthymp5rl1dqf";

--- a/src/module/setup/config.js
+++ b/src/module/setup/config.js
@@ -294,6 +294,18 @@ ARCHMAGE.statusEffects = [
       }
     }
   },
+  // Grabbed.
+  {
+    id: "grabbed",
+    name: "ARCHMAGE.EFFECT.StatusGrabbed",
+    icon: "icons/svg/item-bag.svg",
+    journal: "aDEmM5lU3pfG3t7S",
+    flags: {
+      archmage: {
+        duration: "Unknown",
+      }
+    }
+  },
 ];
 // Extended (optional) status effects
 ARCHMAGE.extendedStatusEffects = [
@@ -390,17 +402,6 @@ ARCHMAGE.extendedStatusEffects = [
     id: "flying",
     name: "ARCHMAGE.EFFECT.StatusFlying",
     icon: "icons/svg/wing.svg",
-    flags: {
-      archmage: {
-        duration: "Unknown",
-      }
-    }
-  },
-  // Grabbed.
-  {
-    id: "grabbed",
-    name: "ARCHMAGE.EFFECT.StatusGrabbed",
-    icon: "icons/svg/item-bag.svg",
     flags: {
       archmage: {
         duration: "Unknown",

--- a/src/module/setup/config.js
+++ b/src/module/setup/config.js
@@ -136,6 +136,18 @@ ARCHMAGE.statusEffects = [
       }
     }
   },
+  // Grabbed.
+  {
+    id: "grabbed",
+    name: "ARCHMAGE.EFFECT.StatusGrabbed",
+    icon: "icons/svg/item-bag.svg",
+    journal: "aDEmM5lU3pfG3t7S",
+    flags: {
+      archmage: {
+        duration: "Unknown",
+      }
+    }
+  },
   // Hampered / Hindered.
   {
     id: "hampered",
@@ -288,18 +300,6 @@ ARCHMAGE.statusEffects = [
         value: '-4'
       }
     ],
-    flags: {
-      archmage: {
-        duration: "Unknown",
-      }
-    }
-  },
-  // Grabbed.
-  {
-    id: "grabbed",
-    name: "ARCHMAGE.EFFECT.StatusGrabbed",
-    icon: "icons/svg/item-bag.svg",
-    journal: "aDEmM5lU3pfG3t7S",
     flags: {
       archmage: {
         duration: "Unknown",

--- a/src/packs/src/conditions/Grabbed__2e__e74tdY4XILWFW9VB.yml
+++ b/src/packs/src/conditions/Grabbed__2e__e74tdY4XILWFW9VB.yml
@@ -1,0 +1,60 @@
+name: Grabbed (2e)
+_id: e74tdY4XILWFW9VB
+pages:
+  - sort: 100000
+    name: Grabbed (2e)
+    type: text
+    _id: bfHdjOkHZLVGbwtr
+    system: {}
+    title:
+      show: false
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <p>When a monster that is grabbing you starts its turn, it deals
+        automatic damage to you as a free action. The automatic damage is equal
+        to half the normal damage that it deals with its basic melee
+        attack.</p><p>You are engaged with the creature grabbing you, and you
+        can't move away unless you teleport, pop free, or successfully
+        disengage. You can't make opportunity attacks, but you can make normal
+        attacks on your turn.</p><p>If you are smaller than the creature that is
+        grabbing you, it can move and carry you along no problem. If you are the
+        same size or larger, the creature grabbing you has to let go of you if
+        it wants to move.</p>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      dwEgyf88FCl0gnfL: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: archmage
+      systemVersion: 1.31.0
+      createdTime: 1725298853097
+      modifiedTime: 1725299335739
+      lastModifiedBy: dwEgyf88FCl0gnfL
+    _key: '!journal.pages!e74tdY4XILWFW9VB.bfHdjOkHZLVGbwtr'
+folder: null
+sort: 0
+ownership:
+  default: 0
+  dwEgyf88FCl0gnfL: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: archmage
+  systemVersion: 1.31.0
+  createdTime: 1725298843421
+  modifiedTime: 1725298843421
+  lastModifiedBy: dwEgyf88FCl0gnfL
+_key: '!journal!e74tdY4XILWFW9VB'
+

--- a/src/packs/src/conditions/Grabbed_aDEmM5lU3pfG3t7S.yml
+++ b/src/packs/src/conditions/Grabbed_aDEmM5lU3pfG3t7S.yml
@@ -1,0 +1,63 @@
+name: Grabbed
+_id: aDEmM5lU3pfG3t7S
+pages:
+  - sort: 100000
+    name: Grabbed
+    type: text
+    _id: bARhilQBGWTzzm91
+    system: {}
+    title:
+      show: false
+      level: 1
+    image: {}
+    text:
+      format: 1
+      content: >-
+        <p>When you’re grabbed you are engaged with the creature grabbing you
+        and you can’t move away unless you teleport, somehow pop free first, or
+        successfully disengage. Disengage checks take a –5 penalty unless you
+        hit the creature that is grabbing you the same turn that you’re trying
+        to disengage.</p><p>If you are smaller than the creature that is
+        grabbing you, it can move and carry you along with no problem. If you
+        are the same size or larger, it has to let go of you if it wants to
+        move.</p><p>Grabbed creatures can’t make opportunity attacks. That also
+        applies if the creature grabbing you decides to let go and move away
+        from you; it doesn’t have to disengage or take an opportunity attack
+        from you, it just leaves you behind.</p><p>Grabbed creatures can’t use
+        ranged attacks, although melee and close attacks are fine.</p><p>The
+        creature grabbing you gets a +4 attack bonus against you.</p>
+    video:
+      controls: true
+      volume: 0.5
+    src: null
+    ownership:
+      default: -1
+      dwEgyf88FCl0gnfL: 3
+    flags: {}
+    _stats:
+      compendiumSource: null
+      duplicateSource: null
+      coreVersion: '12.331'
+      systemId: archmage
+      systemVersion: 1.31.0
+      createdTime: 1725299287670
+      modifiedTime: 1725299314798
+      lastModifiedBy: dwEgyf88FCl0gnfL
+    _key: '!journal.pages!aDEmM5lU3pfG3t7S.bARhilQBGWTzzm91'
+folder: null
+sort: 0
+ownership:
+  default: 0
+  dwEgyf88FCl0gnfL: 3
+flags: {}
+_stats:
+  compendiumSource: null
+  duplicateSource: null
+  coreVersion: '12.331'
+  systemId: archmage
+  systemVersion: 1.31.0
+  createdTime: 1725299283142
+  modifiedTime: 1725299283142
+  lastModifiedBy: dwEgyf88FCl0gnfL
+_key: '!journal!aDEmM5lU3pfG3t7S'
+

--- a/src/packs/src/conditions/Vulnerable__2E__uHqgXlfj0rkf0XRE.yml
+++ b/src/packs/src/conditions/Vulnerable__2E__uHqgXlfj0rkf0XRE.yml
@@ -15,25 +15,19 @@ pages:
         bonus damage equal to double your level as you attack. In other words,
         hit or miss, crit or fumble, deal bonus damage equal to double your
         level before applying any other damage from the attack.
-        (<i>Exception</i>: Mooks and weaklings only deal damage equal to their
-        level, not twice their level.)</p> <p>When you attack a creature that’s
-        vulnerable to that attack, you deal bonus damage equal to double your
-        level whether you hit or miss. If you score a critical hit, double that
-        and deal bonus damage equal to 4 times your level! If you roll a 1 and
-        fumble, you deal 0 damage as usual, vulnerable can’t help you when you
-        fumble. (Exception: Mooks and weaklings only deal damage equal to their
-        level, not twice their level.)</p> <p></p>As usual, a natural 1 fumble
-        attack against a vulnerable target still deals no damage, and a critical
-        hit against a vulnerable target doubles the bonus damage—in other words,
-        a critical deals bonus damage equal to quadruple the attackers’
-        level.<p></p>
+        (<em>Exception</em>: Mooks and weaklings only deal damage equal to their
+        level, not twice their level.)</p><p>As usual, a natural 1 fumble attack
+        against a vulnerable target still deals no damage, and a critical hit
+        against a vulnerable target doubles the bonus damage—in other words, a
+        critical deals bonus damage equal to quadruple the attackers’
+        level.</p><p></p>
     _stats:
       coreVersion: '12.331'
       systemId: null
       systemVersion: null
       createdTime: null
-      modifiedTime: null
-      lastModifiedBy: null
+      modifiedTime: 1725298808747
+      lastModifiedBy: dwEgyf88FCl0gnfL
       compendiumSource: null
       duplicateSource: null
     _id: DSm7r73qk49CXuBZ

--- a/src/vue/components/actor/npc/NpcHeader.vue
+++ b/src/vue/components/actor/npc/NpcHeader.vue
@@ -28,10 +28,9 @@
             <template v-slot:display>
               <ul>
                 <li class="level">{{levelFormatted}}</li>
-                <li v-if="sizeFormatted" class="details">{{sizeFormatted}}</li>
-                <li v-if="strengthFormatted" class="details">{{strengthFormatted}}</li>
+                <li v-if="strengthFormatted && this.actor.system.details?.strength?.value !== 'normal'" class="details">{{strengthFormatted}}</li>
                 <li v-if="roleFormatted" class="role">{{roleFormatted}}</li>
-                <li v-if="typeFormatted" class="type">[{{typeFormatted}}]</li>
+                <li v-if="typeFormatted" class="type">[<span class="size" v-if="this.actor.system.details?.size?.value !== 'normal'">{{ sizeFormatted }}</span>{{typeFormatted}}]</li>
               </ul>
             </template>
             <!-- Form inputs for creature details. -->
@@ -112,7 +111,8 @@
         return game.archmage.ArchmageUtility.formatLevel(this.actor.system.attributes.level.value ?? 0);
       },
       sizeFormatted() {
-        return CONFIG.ARCHMAGE.creatureSizes[this.actor.system.details?.size?.value] ?? this.actor.system.details?.size?.value;
+        let size = CONFIG.ARCHMAGE.creatureSizes[this.actor.system.details?.size?.value] ?? this.actor.system.details?.size?.value;
+        return typeof size == 'string' ? `${size.toUpperCase()} ` : '';
       },
       strengthFormatted() {
         return CONFIG.ARCHMAGE.creatureStrengths[this.actor.system.details?.strength?.value] ?? this.actor.system.details?.strength?.value;
@@ -309,8 +309,9 @@
     }
 
     .edit-wrapper {
-      display: inline-block;
+      display: flex;
       flex: 1;
+      width: 100%;
 
       ul {
         display: flex;


### PR DESCRIPTION
- Added `@skulls` to character roll data.
- Added `@rsc.stoke` to NPC roll data. Defaults to 0 if not enabled currently.
- Improved formatting of NPC sheet headers (size, type, role, etc.) to better match the Gamma packet format.
- Moved grabbed from the extended conditions list to the standard conditions list and added journal entries for it.
- Added an example of using `jsconfig.json` to connect VS Code with Foundry's API for intellisense.

## Screenshots
![image](https://github.com/user-attachments/assets/8e4588dc-3ba6-4e42-af74-889913ee904a)
