### PR TITLE
Fix/conditions

### DIFF
--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -1229,7 +1229,7 @@ async function _applyAE(actor, data) {
     // Load the source actor and grab its image if possible
     let sourceActor = await fromUuid(data.source);
     // let img = sourceActor?.img ?? "icons/skills/toxins/symbol-poison-drop-skull-green.webp";
-    const img = data.value >= 0 ? "icons/svg/degen.svg" : "ARCHMAGE.EFFECT.StatusRegen";
+    const img = data.value >= 0 ? "icons/svg/degen.svg" : "icons/svg/regen.svg";
 
     let effectData = {
       name: data.name,

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -214,6 +214,7 @@ Hooks.once('init', async function() {
     config: true,
     default: false,
     type: Boolean,
+    requiresReload: true,
     onChange: enable => _setArchmageStatusEffects(enable)
   });
   _setArchmageStatusEffects(game.settings.get('archmage', 'extendedStatusEffects'));

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -1228,7 +1228,8 @@ async function _applyAE(actor, data) {
 
     // Load the source actor and grab its image if possible
     let sourceActor = await fromUuid(data.source);
-    let img = sourceActor?.img ?? "icons/skills/toxins/symbol-poison-drop-skull-green.webp";
+    // let img = sourceActor?.img ?? "icons/skills/toxins/symbol-poison-drop-skull-green.webp";
+    const img = data.value >= 0 ? "icons/svg/degen.svg" : "ARCHMAGE.EFFECT.StatusRegen";
 
     let effectData = {
       name: data.name,

--- a/src/module/hooks/preCreateChatMessageHandler.mjs
+++ b/src/module/hooks/preCreateChatMessageHandler.mjs
@@ -72,9 +72,10 @@ export default class preCreateChatMessageHandler {
                     name = name.replace(/^R: /, "");
                     let tooltip = message;
                     if ( savesEndsText ) tooltip += " " + savesEndsText;
+                    const img = damageValue >= 0 ? "icons/svg/degen.svg" : "icons/svg/regen.svg";
                     let ongoingEffectLink = `<a class="effect-link" draggable="true" data-type="ongoing-damage" data-id="ongoing" title=""
                         data-value="${damageValue}" data-damage-type="${damageType}" data-ends="${saveEndsConfigValue}"
-                        data-tooltip="${tooltip}" data-source="${source}" data-name="${name}"><i class="fas fa-flask-round-poison"></i> ${message}</a>`;
+                        data-tooltip="${tooltip}" data-source="${source}" data-name="${name}"><img class="effects-icon" src="${img}"/> ${message}</a>`;
                     row.innerHTML = row.innerHTML.replace(ongoingEffect[0], ongoingEffectLink);
                 });
             }

--- a/src/module/hooks/preCreateChatMessageHandler.mjs
+++ b/src/module/hooks/preCreateChatMessageHandler.mjs
@@ -3,6 +3,10 @@ import Targeting from "../rolls/Targeting.mjs";
 import ArchmageRolls from "../rolls/ArchmageRolls.mjs";
 import Triggers from "../Triggers/Triggers.mjs";
 
+
+const REGEX_ONGOING_DAMAGE = /(<a (?:(?!<a ).)*?><i class="fas fa-dice-d20"><\/i>)*(-?\d+)(<\/a>)* ongoing ([a-zA-Z]*) ?damage( \((\w*) save ends, \d*\+\))?;/g;
+
+
 export default class preCreateChatMessageHandler {
 
     static replaceEffectAndConditionReferences(uuid, $rows) {
@@ -53,11 +57,10 @@ export default class preCreateChatMessageHandler {
         // If there are ongoing effects, we need to find the ongoing effect and replace it with a link to the ongoing effect, pulling the value form the roll
 
         for (const row of $rows) {
-            const regex = /(<a (?:(?!<a ).)*?><i class="fas fa-dice-d20"><\/i>)*(\d+)(<\/a>)* ongoing ([a-zA-Z]*) ?damage( \((\w*) save ends, \d*\+\))?/g;
-            const ongoingEffects = Array.from(row.innerHTML.matchAll(regex));
+            const ongoingEffects = Array.from(row.innerHTML.matchAll(REGEX_ONGOING_DAMAGE));
             if (ongoingEffects.length > 0) {
                 ongoingEffects.forEach((ongoingEffect) => {
-                    let damageValue = ongoingEffect[2];
+                    let damageValue = Number(ongoingEffect[2]);
                     let damageType = ongoingEffect[4];
                     if ( damageType ) damageType += " ";
                     let savesEndsText = ongoingEffect[5];

--- a/src/module/setup/config.js
+++ b/src/module/setup/config.js
@@ -342,6 +342,17 @@ ARCHMAGE.extendedStatusEffects = [
       }
     }
   },
+  // Flying.
+  {
+    id: "flying",
+    name: "ARCHMAGE.EFFECT.StatusFlying",
+    icon: "icons/svg/wing.svg",
+    flags: {
+      archmage: {
+        duration: "Unknown",
+      }
+    }
+  },
   // Bonus defenses.
   {
     id: "bonusDefenses",
@@ -391,17 +402,6 @@ ARCHMAGE.extendedStatusEffects = [
     id: "invisible", //hidden - renamed to play nice with v11 statuses
     name: "ARCHMAGE.EFFECT.StatusHidden",
     icon: "icons/svg/mystery-man.svg",
-    flags: {
-      archmage: {
-        duration: "Unknown",
-      }
-    }
-  },
-  // Flying.
-  {
-    id: "flying",
-    name: "ARCHMAGE.EFFECT.StatusFlying",
-    icon: "icons/svg/wing.svg",
     flags: {
       archmage: {
         duration: "Unknown",


### PR DESCRIPTION
- Adjust conditions order
- Force reload on (un)setting extended condition setting to ensure list is correctly pruned
- Adjust ongoing effects icons to match related extended conditions
- Add support for negative ongoing damage (a.k.a. healing)