### PR TITLE
Additional improvements to pasting

### DIFF
--- a/src/module/item/_vue-application-mixin.mjs
+++ b/src/module/item/_vue-application-mixin.mjs
@@ -77,18 +77,6 @@ export default function VueRenderingMixin(BaseApplication) {
        * @override
        */
       async _renderFrame(options) {
-        // @todo find a better spot for this.
-        if (this.document.compendium) {
-          const hasOption = this.options.window.controls.find(o => o.action === 'importFromCompendium');
-          if (!hasOption) {
-            this.options.window.controls.push({
-              action: "importFromCompendium",
-              icon: "fa-solid fa-download",
-              label: "Import",
-            });
-          }
-        }
-
         // Retrieve the context and element.
         const context = await this._prepareContext(options);
         const element = await super._renderFrame(options);

--- a/src/module/item/_vue-application-mixin.mjs
+++ b/src/module/item/_vue-application-mixin.mjs
@@ -3,6 +3,9 @@ import { createApp } from "../../scripts/lib/vue.esm-browser.js";
 export default function VueRenderingMixin(BaseApplication) {
 
     class VueApplication extends BaseApplication {
+      /** Helper property for checking the shift key during paste events. */
+      isShift = false;
+
       /** Vue application instance created with createApp(). */
       vueApp = null;
 
@@ -166,8 +169,20 @@ export default function VueRenderingMixin(BaseApplication) {
           }
         }
         else {
+          // Set a variable when the shift key is pressed to avoid paste events.
+          this.element.addEventListener('keydown', (event) => {
+            if (event.shiftKey && !this.isShift) {
+              this.isShift = true;
+            }
+          });
+          this.element.addEventListener('keyup', (event) => {
+            if (event.shiftKey && this.isShift) {
+              this.isShift = false;
+            }
+          });
+          // Handle paste events.
           this.element.querySelectorAll('.editor-content').forEach((editor) => {
-            editor.addEventListener('paste', (event) => this._parsePastedContent(event))
+            editor.addEventListener('paste', (event) => this._parsePastedContent(event));
           });
         }
       }
@@ -197,7 +212,7 @@ export default function VueRenderingMixin(BaseApplication) {
       /* -------------------------------------------- */
 
       _parsePastedContent(event) {
-        if (game.settings.get('archmage', 'allowPasteParsing')) {
+        if (!this.isShift && game.settings.get('archmage', 'allowPasteParsing')) {
           const target = event.target;
           const prosemirror = target.closest('prose-mirror');
 

--- a/src/module/item/_vue-application-mixin.mjs
+++ b/src/module/item/_vue-application-mixin.mjs
@@ -171,12 +171,12 @@ export default function VueRenderingMixin(BaseApplication) {
         else {
           // Set a variable when the shift key is pressed to avoid paste events.
           this.element.addEventListener('keydown', (event) => {
-            if (event.shiftKey && !this.isShift) {
+            if (event.key === 'Shift' && !this.isShift) {
               this.isShift = true;
             }
           });
           this.element.addEventListener('keyup', (event) => {
-            if (event.shiftKey && this.isShift) {
+            if (event.key === 'Shift' && this.isShift) {
               this.isShift = false;
             }
           });

--- a/src/module/item/base-item-sheet-v2.js
+++ b/src/module/item/base-item-sheet-v2.js
@@ -54,48 +54,6 @@ export class ArchmageBaseItemSheetV2 extends foundry.applications.sheets.ItemShe
     // You may want to add other special handling here
     // Foundry comes with a large number of utility classes, e.g. SearchFilter
     // That you may want to implement yourself.
-    console.log('onRender', this.element);
-    this.element.addEventListener('paste', '.prose-mirror-wrapper .editor-content', (event) => this.parsePastedContent(event));
-  }
-
-  parsePastedContent(event) {
-    console.log('event', event);
-    if (game.settings.get('archmage', 'allowPasteParsing')) {
-      event.preventDefault();
-      const target = event.target;
-      const prosemirror = target.closest('prose-mirror');
-      const options = {
-        field: prosemirror.name,
-      };
-      // Retrieve the value from the field and the clipboard.
-      const oldValue = target.innerHTML ?? '';
-      const paste = (event.clipboardData || window.clipboardData).getData('text');
-      const result = game.archmage.ArchmageUtility.parseClipboardText(paste, options);
-      let newValue = result;
-
-      // Handle selections.
-      const selection = window.getSelection();
-      let startRange = target.selectionStart ?? oldValue.length;
-      let endRange = target.selectionEnd ?? startRange;
-      // If there's a selection, replace it.
-      if (selection.rangeCount) {
-        newValue = `${oldValue.slice(0, startRange)}${result}${oldValue.slice(endRange)}`;
-        startRange += result.length;
-      }
-      // Otherwise, append it.
-      else {
-        newValue = `${oldValue}${result}`;
-      }
-
-      // Update field contents.
-      target.innerHTML = newValue;
-
-      // Update cursor position.
-      if (startRange) {
-        target.focus();
-        target.setSelectionRange(startRange, startRange);
-      }
-    }
   }
 
   /** ************

--- a/src/module/item/base-item-sheet-v2.js
+++ b/src/module/item/base-item-sheet-v2.js
@@ -54,6 +54,48 @@ export class ArchmageBaseItemSheetV2 extends foundry.applications.sheets.ItemShe
     // You may want to add other special handling here
     // Foundry comes with a large number of utility classes, e.g. SearchFilter
     // That you may want to implement yourself.
+    console.log('onRender', this.element);
+    this.element.addEventListener('paste', '.prose-mirror-wrapper .editor-content', (event) => this.parsePastedContent(event));
+  }
+
+  parsePastedContent(event) {
+    console.log('event', event);
+    if (game.settings.get('archmage', 'allowPasteParsing')) {
+      event.preventDefault();
+      const target = event.target;
+      const prosemirror = target.closest('prose-mirror');
+      const options = {
+        field: prosemirror.name,
+      };
+      // Retrieve the value from the field and the clipboard.
+      const oldValue = target.innerHTML ?? '';
+      const paste = (event.clipboardData || window.clipboardData).getData('text');
+      const result = game.archmage.ArchmageUtility.parseClipboardText(paste, options);
+      let newValue = result;
+
+      // Handle selections.
+      const selection = window.getSelection();
+      let startRange = target.selectionStart ?? oldValue.length;
+      let endRange = target.selectionEnd ?? startRange;
+      // If there's a selection, replace it.
+      if (selection.rangeCount) {
+        newValue = `${oldValue.slice(0, startRange)}${result}${oldValue.slice(endRange)}`;
+        startRange += result.length;
+      }
+      // Otherwise, append it.
+      else {
+        newValue = `${oldValue}${result}`;
+      }
+
+      // Update field contents.
+      target.innerHTML = newValue;
+
+      // Update cursor position.
+      if (startRange) {
+        target.focus();
+        target.setSelectionRange(startRange, startRange);
+      }
+    }
   }
 
   /** ************

--- a/src/module/item/base-item-sheet-v2.js
+++ b/src/module/item/base-item-sheet-v2.js
@@ -26,6 +26,22 @@ export class ArchmageBaseItemSheetV2 extends foundry.applications.sheets.ItemShe
 
   /* -------------------------------------------- */
 
+  /** @inheritDoc */
+  _initializeApplicationOptions(options) {
+    options = super._initializeApplicationOptions(options);
+    if (options.document.compendium) {
+      const hasOption = options.window.controls.find(o => o.action === 'importFromCompendium');
+      if (!hasOption) {
+        options.window.controls.push({
+          action: "importFromCompendium",
+          icon: "fa-solid fa-download",
+          label: "Import",
+        });
+      }
+    }
+    return options;
+  }
+
   /**
    * Actions performed after any render of the Application.
    * Post-render steps are not awaited by the render process.

--- a/src/module/setup/utility-classes.js
+++ b/src/module/setup/utility-classes.js
@@ -556,19 +556,22 @@ export class ArchmageUtility {
     ];
     // Matches the above list, but also checks for "nth" and so on as a prefix to
     // avoid turning "4th level" and so on into "4th @lvl".
-    const attrsRegex = new RegExp(`((?:\\d+th)*\\s*)(${attrs.join('|')})`, 'gi');
+    const attrsRegex = new RegExp(`((?:(?:\\d+th)|(?:breath)|(?:triple-|double-))*\\s*)(${attrs.join('|')})`, 'gi');
     parsedText = parsedText.replace(attrsRegex, (match, prefix, attr) => {
       const cleaned = attr.trim().toLocaleLowerCase();
       if (cleaned === 'weapon') {
-        return '@wpn.m.dice';
+        return !prefix.match(/breath/gi) ? '@wpn.m.dice' : match;
       }
       if (cleaned === 'level') {
         return !prefix.match(/\d+th|\d+nd|\d+rd|\d+st/gi)
           ? (options.attack ? '@std' : '@lvl')
-          : attr;
+          : match;
       }
       if (cleaned === 'escalation die') {
         return '@ed';
+      }
+      if (cleaned === 'strength') {
+        if (prefix.match(/triple-|double-/gi)) return match;
       }
       return options.damage
         ? `@${cleaned.slice(0,3)}.dmg`
@@ -616,6 +619,7 @@ export class ArchmageUtility {
     // Return the trimmed and cleaned string.
     return parsedText.replace('( ', '(')
       .replace(' )', ')')
+      .replace('.]]', ']].')
       .replace(/ +/g, ' ')
       .replace(/\s*\++\s*/g, '+')
       .trim();

--- a/src/vue/components/actor/character/sidebar/CharBackgrounds.vue
+++ b/src/vue/components/actor/character/sidebar/CharBackgrounds.vue
@@ -7,7 +7,7 @@
         <span class="rollable rollable--background flexshrink" data-roll-type="background" :data-roll-opt="item.name.value"></span>
         <span class="background-sign">+</span>
         <input type="number" v-bind:name="concat('system.backgrounds.', index, '.bonus.value')" class="background-bonus" v-model="item.bonus.value"/>
-        <TextareaGrow :name="`system.backgrounds.${index}.name.value`" :value="item.name.value" classes="background-name"/>
+        <TextareaGrow :name="`system.backgrounds.${index}.name.value`" :value="item.name.value" classes="background-name" :disable-paste-parsing="true"/>
       </li>
     </ul>
   </section>

--- a/src/vue/components/parts/InlineRollsReferenceHint.vue
+++ b/src/vue/components/parts/InlineRollsReferenceHint.vue
@@ -1,7 +1,8 @@
 <template>
+  <!-- @todo figure out why link tabbing is greedy. Use -1 tabindex for now to turn it off. -->
   <!-- @todo localize this, but ideally with some sort of an enricher. -->
-  <p v-if="compact"><a href="javascript:void(0)" click="preventDefault" role="button" class="archmage-rolls-reference">Inline rolls</a> allowed here.</p>
-  <p v-else class="hint">Use <a href="javascript:void(0)" click="preventDefault" role="button" class="archmage-rolls-reference">inline rolls</a> such as <strong>[[d20+@str.mod+@std+@atk.a.bonus]] vs AC</strong> to insert dice rolls wherever you need them. Any roll formula will work!</p>
+  <p v-if="compact"><a href="javascript:void(0)" click="preventDefault" role="button" tabindex="-1" class="archmage-rolls-reference">Inline rolls</a> allowed here.</p>
+  <p v-else class="hint">Use <a href="javascript:void(0)" click="preventDefault" role="button" tabindex="-1" class="archmage-rolls-reference">inline rolls</a> such as <strong>[[d20+@str.mod+@std+@atk.a.bonus]] vs AC</strong> to insert dice rolls wherever you need them. Any roll formula will work!</p>
 </template>
 
 <script setup>

--- a/src/vue/components/parts/InlineRollsReferenceHint.vue
+++ b/src/vue/components/parts/InlineRollsReferenceHint.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- @todo localize this, but ideally with some sort of an enricher. -->
-  <p v-if="compact"><a href="javascript:void(0)" click="preventDefault" role="button" tabindex="0" class="archmage-rolls-reference">Inline rolls</a> allowed here.</p>
-  <p v-else class="hint">Use <a href="javascript:void(0)" click="preventDefault" role="button" tabindex="0" class="archmage-rolls-reference">inline rolls</a> such as <strong>[[d20+@str.mod+@std+@atk.a.bonus]] vs AC</strong> to insert dice rolls wherever you need them. Any roll formula will work!</p>
+  <p v-if="compact"><a href="javascript:void(0)" click="preventDefault" role="button" class="archmage-rolls-reference">Inline rolls</a> allowed here.</p>
+  <p v-else class="hint">Use <a href="javascript:void(0)" click="preventDefault" role="button" class="archmage-rolls-reference">inline rolls</a> such as <strong>[[d20+@str.mod+@std+@atk.a.bonus]] vs AC</strong> to insert dice rolls wherever you need them. Any roll formula will work!</p>
 </template>
 
 <script setup>

--- a/src/vue/components/parts/TextareaGrow.vue
+++ b/src/vue/components/parts/TextareaGrow.vue
@@ -14,7 +14,7 @@
 <script>
 export default {
   name: 'TextareaGrow',
-  props: ['classes', 'value', 'name', 'placeholder', 'data-tooltip', 'data-tooltip-direction'],
+  props: ['classes', 'value', 'name', 'placeholder', 'data-tooltip', 'data-tooltip-direction', 'disable-paste-parsing'],
   data() {
     return {
       valueAttr: ''
@@ -33,7 +33,7 @@ export default {
       this.$emit('update:value', event.target.value);
     },
     parsePastedContent(event) {
-      if (game.settings.get('archmage', 'allowPasteParsing')) {
+      if (!this.disablePasteParsing && game.settings.get('archmage', 'allowPasteParsing')) {
         event.preventDefault();
         const options = {
           field: event.target.name,

--- a/src/vue/components/parts/TextareaGrow.vue
+++ b/src/vue/components/parts/TextareaGrow.vue
@@ -7,6 +7,8 @@
       :placeholder="placeholder"
       spellcheck="false"
       @paste="parsePastedContent"
+      @keydown="(event) => handleShiftKey(event, 'keydown')"
+      @keyup="(event) => handleShiftKey(event, 'keyup')"
     ></textarea>
   </div>
 </template>
@@ -17,7 +19,8 @@ export default {
   props: ['classes', 'value', 'name', 'placeholder', 'data-tooltip', 'data-tooltip-direction', 'disable-paste-parsing'],
   data() {
     return {
-      valueAttr: ''
+      valueAttr: '',
+      isShift: false,
     }
   },
   computed: {
@@ -32,8 +35,20 @@ export default {
       this.valueAttr = event.target.value;
       this.$emit('update:value', event.target.value);
     },
+    handleShiftKey(event, eventName) {
+      if (eventName === 'keydown') {
+        if (!this.isShift && event.shiftKey) {
+          this.isShift = true;
+        }
+      }
+      else if (eventName === 'keyup') {
+        if (this.isShift && event.shiftKey) {
+          this.isShift = false;
+        }
+      }
+    },
     parsePastedContent(event) {
-      if (!this.disablePasteParsing && game.settings.get('archmage', 'allowPasteParsing')) {
+      if (!this.isShift && !this.disablePasteParsing && game.settings.get('archmage', 'allowPasteParsing')) {
         event.preventDefault();
         const options = {
           field: event.target.name,

--- a/src/vue/components/parts/TextareaGrow.vue
+++ b/src/vue/components/parts/TextareaGrow.vue
@@ -37,12 +37,12 @@ export default {
     },
     handleShiftKey(event, eventName) {
       if (eventName === 'keydown') {
-        if (!this.isShift && event.shiftKey) {
+        if (!this.isShift && event.key === 'Shift') {
           this.isShift = true;
         }
       }
       else if (eventName === 'keyup') {
-        if (this.isShift && event.shiftKey) {
+        if (this.isShift && event.key === 'Shift') {
           this.isShift = false;
         }
       }


### PR DESCRIPTION
- Moved the "Import" action for compendium items out of the render method and into the options initialization.
- Added an event listener for paste parsing on prosemirror editors.

## To do
- [x] Add ability to bypass paste parsing with the shift key
- [x] `Triple-strength monster` parsing as `Triple-[[@str.dmg]] monster`
- [x] `Breath weapon` parsing as `Breath [[@wpn.m.dice]]`
- [x] `10 x escalation die.` parsing as `[[10 * @ed.]]`
- [x] ~~Various issues related to the contents of the Minotaur's _Big Fear_ ability.~~ Skipping this one, it would cause more trouble for actual formulas if we fixed it. It was specifically a bug with the "dazed (-4 attack)" phrase.