### PR TITLE
Add damage applicator dialog for mooks

### DIFF
--- a/src/module/setup/damageApplicator.js
+++ b/src/module/setup/damageApplicator.js
@@ -13,9 +13,12 @@ export class DamageApplicator {
     if (roll instanceof Roll) {
       return roll.total;
     }
-    const match = REGEX_EXPANDED_INLINE_ROLL.exec(roll[0].innerText);
+    // Try the regex for expanded rolls.
+    let match = REGEX_EXPANDED_INLINE_ROLL.exec(roll[0].innerText);
     if (match) return Number.parseInt(match[1]);
-    return 0;  // Fallback if we failed to parse
+    // Regex failed to match, try grabbing the inner text.
+    match = Number.parseInt(roll[0].innerText.trim());
+    return match || 0;  // Fallback if we failed to parse
   }
 
   getTargets(targetType) {

--- a/src/module/setup/damageApplicator.js
+++ b/src/module/setup/damageApplicator.js
@@ -45,8 +45,29 @@ export class DamageApplicator {
     }
 
     const targets = this.getTargets(targetType);
+    const mooks = targets.filter(t => t.actor.type === 'npc' && t.actor.system.details.role.value === 'mook');
     // Apply damage if user is a GM.
     if (game.user.isGM || targetType === 'selected') {
+      if (mooks && mooks.length > 0) {
+        foundry.applications.api.DialogV2.prompt({
+          window: {title: 'Mooks detected!'},
+          classes: ['mook-damage-application'],
+          rejectClose: false,
+          position: { width: 620 },
+          content: `
+            <ul class="mooks-list">
+              ${mooks.map(token => `<li class="flexrow"><img src="${token.actor.img}" width="50" height="50"><span class="mook-name">${token.name}</span><label>Damage <input type="number" value="30"/></label></li>`).join('')}
+            </ul>
+            <div class="flexrow mooks-total"><span class="total-label">Total Damage</span><strong class="total-damage">90</strong></div>
+          `,
+          ok: {
+            label: "Apply Damage",
+            callback: (event, button, dialog) => {
+              console.log('stuff', button);
+            }
+          }
+        });
+      }
       targets.forEach(token => {
         let actorData = foundry.utils.duplicate(token.actor);
         token.actor.update({

--- a/src/scss/v2/components/items/_item-sheet-app-v2.scss
+++ b/src/scss/v2/components/items/_item-sheet-app-v2.scss
@@ -1,3 +1,37 @@
+.mook-damage-application {
+  ul.mooks-list {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+
+    li {
+      padding: 0;
+      margin: 0;
+      gap: 8px;
+
+      img {
+        flex: 0 0 50px;
+      }
+
+      span {
+        flex: 1;
+      }
+
+      label {
+        flex: 0 0 auto;
+
+        input {
+          width: 100px;
+        }
+      }
+    }
+  }
+
+  .total-damage {
+    flex: 0 0 auto;
+  }
+}
+
 .archmage-appv2 {
   max-height: 90vh;
 


### PR DESCRIPTION
Adds a new dialog as an interrupt when damage is applied to tokens that include mooks.

## Goal
- Filters for mooks out of the list of selected/targeted tokens.
- If mooks are found, show a dialog that attempts to divide the total damage among them if there's overspill.
- Mooks would be removed from the list of tokens to apply damage to automatically since the damage menu would cover them.

## To Do
- [ ] Make it interactive and functional

## Screenshots
![image](https://github.com/user-attachments/assets/c1635614-0004-43c1-ae89-43e87dae1198)
