### PR TITLE
Feature/more durations

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -339,6 +339,7 @@ ARCHMAGE:
     NormalSaveEnds: Normal Save Ends
     HardSaveEnds: Hard Save Ends
     EndOfCombat: End of Battle
+    EndOfArc: End of Arc
     StartOfEachTurn: Start of Each Turn
   INCREMENTALS:
     abilityScoreBonusHint: +1 to 3 abilities (3rd/6th/9th Level)
@@ -585,6 +586,7 @@ ARCHMAGE:
     disengage: Disengage Check
     duration: Duration
     effect: Effect
+    effectRemoved: temporary effect removed
     effectTitle: General effect of a spell or power when it's used.
     epic: Epic Feat
     even: even

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -1338,7 +1338,7 @@ export class ActorArchmage extends Actor {
             message: `${game.i18n.localize("ARCHMAGE.CHAT.ItemReset")} ${maxQuantity}`
           });
         }
-        else if ((item.system.powerUsage?.value == 'recharge') && rechAttempts > 0) {
+        else if (['recharge', 'recharge-desperate'].includes(item.system.powerUsage?.value) && rechAttempts > 0) {
           // This captures other as well
           let successes = 0;
           for (let j = 0; j < rechAttempts; j++) {
@@ -1467,7 +1467,7 @@ export class ActorArchmage extends Actor {
       if (item.type != 'power' && item.type != 'equipment') continue;
 
       let itemUpdateData = {};
-      let usageArray = ['once-per-battle','daily','recharge', 'cyclic', 'daily-desperate'];
+      let usageArray = ['once-per-battle','daily','recharge', 'cyclic', 'recharge-desperate', 'daily-desperate'];
       let fallbackQuantity = item.system.quantity.value !== null ? 1 : null;
       let maxQuantity = item.system?.maxQuantity?.value ?? fallbackQuantity;
       if (maxQuantity && usageArray.includes(item.system.powerUsage?.value)
@@ -1551,14 +1551,14 @@ export class ActorArchmage extends Actor {
     let items = this.items.map(i => i);
     for (let i = 0; i < items.length; i++) {
       let item = items[i];
-      if (item.type != 'power' && item.type != 'equipment') continue;
+      if (!['power', 'equipment'].includes(item.type)) continue;
       let fallbackQuantity = item.system.quantity.value !== null ? 1 : null;
       let maxQuantity = item.system?.maxQuantity?.value ?? fallbackQuantity;
       // Re-use rechargeAttempts to store whether we already desperately recharged before
       let rechAttempts = maxQuantity - item.system.quantity.value;
       rechAttempts = Math.max(rechAttempts - item.system.rechargeAttempts.value, 0)
       if (maxQuantity && item.system.quantity.value < maxQuantity
-        && item.system.powerUsage?.value == 'daily-desperate') {
+        && ['recharge-desperate', 'daily-desperate'].includes(item.system.powerUsage?.value)) {
         if (rechAttempts > 0) {
           await item.update({
             'system.quantity.value': item.system.quantity.value + rechAttempts,

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -1499,14 +1499,14 @@ export class ActorArchmage extends Actor {
       if (item.type == 'equipment') {
         if (item.system.attributes.rerollAc.current != item.system.attributes.rerollAc.bonus) {
           itemUpdateData['system.attributes.rerollAc.current'] = item.system.attributes.rerollAc.bonus;
-          templateData.resources.push({
+          templateData.items.push({
             key: game.i18n.localize("ARCHMAGE.CHARACTER.RESOURCES.rerollAc"),
             message: `${game.i18n.localize("ARCHMAGE.CHAT.ItemReset")} ${item.system.attributes.rerollAc.bonus}`
           });
         }
         if (item.system.attributes.rerollSave.current != item.system.attributes.rerollSave.bonus) {
           itemUpdateData['system.attributes.rerollSave.current'] = item.system.attributes.rerollSave.bonus;
-          templateData.resources.push({
+          templateData.items.push({
             key: game.i18n.localize("ARCHMAGE.CHARACTER.RESOURCES.rerollSave"),
             message: `${game.i18n.localize("ARCHMAGE.CHAT.ItemReset")} ${item.system.attributes.rerollSave.bonus}`
           });
@@ -1515,6 +1515,21 @@ export class ActorArchmage extends Actor {
       // Update item
       if ( !foundry.utils.isEmpty(itemUpdateData) ) await item.update(itemUpdateData);
     }
+
+    // Effects
+    let effectsToDelete = [];
+    for (const effect of this.effects) {
+      if (!effect.active) continue;
+      const duration = effect.flags.archmage?.duration || "Unknown";
+      if (duration === "EndOfArc") {
+        effectsToDelete.push(effect.id);
+        templateData.items.push({
+          key: effect.name,
+          message: game.i18n.localize("ARCHMAGE.CHAT.effectRemoved")
+        });
+      }
+    }
+    if (effectsToDelete.length > 0) await this.deleteEmbeddedDocuments("ActiveEffect", effectsToDelete);
 
     // Print outcomes to chat
     const template = `systems/archmage/templates/chat/rest-full-card.html`

--- a/src/module/hooks/combat.mjs
+++ b/src/module/hooks/combat.mjs
@@ -33,7 +33,7 @@ export async function handleTurnEffects(prefix, combat, combatant, context, opti
     for (const effect of combatant.actor.effects) {
         if (!effect.active) continue;
         // Handle ongoing.
-        const isOngoing = effect.flags.archmage?.ongoingDamage != 0;
+        const isOngoing = effect.flags.archmage?.ongoingDamage ? true: false;
         effect.isOngoing = isOngoing;
         const isCrit = isOngoing && effect.flags.archmage?.ongoingDamageCrit === true;
         effect.isCrit = isCrit;
@@ -71,7 +71,7 @@ export async function handleTurnEffects(prefix, combat, combatant, context, opti
         effectsToDelete = [];
         if (otherCombatant?.actor?.effects) {
             for (const effect of otherCombatant.actor.effects) {
-                const isOngoing = effect.flags.archmage?.ongoingDamage != 0;
+                const isOngoing = effect.flags.archmage?.ongoingDamage ? true: false;;
                 effect.isOngoing = isOngoing;
                 const isCrit = isOngoing && effect.flags.archmage?.ongoingDamageCrit === true;
                 effect.isCrit = isCrit;
@@ -130,7 +130,7 @@ export async function preDeleteCombat(combat, context, options) {
 
             for (const effect of combatant.actor.effects) {
                 if (!effect.active) continue;
-                const isOngoing = effect.flags.archmage?.ongoingDamage != 0;
+                const isOngoing = effect.flags.archmage?.ongoingDamage ? true: false;
                 effect.isOngoing = isOngoing;
                 const isCrit = isOngoing && effect.flags.archmage?.ongoingDamageCrit === true;
                 effect.isCrit = isCrit;

--- a/src/module/hooks/combat.mjs
+++ b/src/module/hooks/combat.mjs
@@ -143,8 +143,8 @@ export async function preDeleteCombat(combat, context, options) {
                     effect.ongoingDamage = effect.ongoingDamage * 2;
                 }
                 const duration = effect.flags.archmage?.duration || "Unknown";
-                // If duration is "Infinite" skip
-                if (duration === "Infinite") continue;
+                // If duration is longer than battle skip
+                if (["Infinite", "EndOfArc"].includes(duration)) continue;
                 // If it's a save-ends effect store it as such
                 else if (saveEndsEffects.includes(duration)) {
                     currentCombatantEffectData.savesEnds.push(effect);

--- a/src/module/hooks/preCreateChatMessageHandler.mjs
+++ b/src/module/hooks/preCreateChatMessageHandler.mjs
@@ -4,7 +4,7 @@ import ArchmageRolls from "../rolls/ArchmageRolls.mjs";
 import Triggers from "../Triggers/Triggers.mjs";
 
 
-const REGEX_ONGOING_DAMAGE = /(<a (?:(?!<a ).)*?><i class="fas fa-dice-d20"><\/i>)*(-?\d+)(<\/a>)* ongoing ([a-zA-Z]*) ?damage( \((\w*) save ends, \d*\+\))?;/g;
+const REGEX_ONGOING_DAMAGE = /(<a (?:(?!<a ).)*?><i class="fas fa-dice-d20"><\/i>)*(-?\d+)(<\/a>)* ongoing ([a-zA-Z]*) ?damage( \((\w*) save ends, \d*\+\))?/g;
 
 
 export default class preCreateChatMessageHandler {

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -530,6 +530,7 @@ export class ItemArchmage extends Item {
   _getUsageClass(item) {
     let use = item.system.powerUsage?.value ? item.system.powerUsage.value : 'other';
     if (['daily', 'daily-desperate'].includes(use)) use = 'daily';
+    if (['recharge', 'recharge-desperate'].includes(use)) use = 'recharge';
     else if (use == 'cyclic') {
       if (item.actor.system.attributes.escalation.value > 0
         && item.actor.system.attributes.escalation.value % 2 == 0) {

--- a/src/module/rolls/HitEvaluation.mjs
+++ b/src/module/rolls/HitEvaluation.mjs
@@ -14,7 +14,7 @@ export default class HitEvaluation {
         let hasMissed = undefined;
 
         let defense = HitEvaluation._getTargetDefense(row_text);
-        let critRangeMin = 20 - attacker?.system.attributes.critMod.atk.value;
+        let critRangeMin = 20 - attacker?.system?.attributes.critMod.atk.value;
 
         let $rolls = $row_self.find('.inline-result');
         if ($rolls.length == 0) {
@@ -72,7 +72,7 @@ export default class HitEvaluation {
                       hasFumbled = true;
                     }
                     // Barbarian crit.
-                    else if (attacker?.system.details.detectedClasses?.includes("barbarian")
+                    else if (attacker?.system?.details.detectedClasses?.includes("barbarian")
                       && !game.settings.get("archmage", "secondEdition")
                       && roll_data.formula.match(/^2d20kh/g) && part.results[0].result > 10
                       && part.results[1].result > 10) {

--- a/src/module/setup/config.js
+++ b/src/module/setup/config.js
@@ -558,6 +558,7 @@ ARCHMAGE.effectDurationTypes = {
   'NormalSaveEnds': 'ARCHMAGE.DURATION.NormalSaveEnds',
   'HardSaveEnds': 'ARCHMAGE.DURATION.HardSaveEnds',
   'EndOfCombat': 'ARCHMAGE.DURATION.EndOfCombat',
+  'EndOfArc': 'ARCHMAGE.DURATION.EndOfArc',
   'StartOfEachTurn': 'ARCHMAGE.DURATION.StartOfEachTurn'
 };
 

--- a/src/module/setup/config.js
+++ b/src/module/setup/config.js
@@ -513,6 +513,7 @@ ARCHMAGE.powerUsages = {
   'recharge': 'Recharge',
   'daily': 'Daily',
   'cyclic': 'Cyclic',
+  'recharge-desperate': 'Recharge/Desperate',
   'daily-desperate': 'Daily/Desperate',
   'other': 'Other'
 };
@@ -521,6 +522,7 @@ ARCHMAGE.equipUsages = {
   'once-per-battle': 'Per Battle',
   'recharge': 'Recharge',
   'daily': 'Daily',
+  'recharge-desperate': 'Recharge/Desperate',
   'daily-desperate': 'Daily/Desperate',
   'other': 'Other'
 };

--- a/src/module/setup/macros.js
+++ b/src/module/setup/macros.js
@@ -328,38 +328,17 @@ export class ArchmageMacros {
    */
   static async wizardLight(speaker, actor, token, character, archmage) {
     if (!token) return;
-    const radiusBright = 3;
-    const radiusDim = 4;
-    let conf = {
-      alpha: 0.35,
-      angle: 0,
-      coloration: 1,
-      gradual: true,
-      luminosity: 0.5,
-      saturation: 0,
-      contrast: 0,
-      shadows: 0,
-      animation: {
-        speed: 2,
-        intensity: 2,
-        reverse: false,
-        type: "torch",
-      },
-      darkness: {
-        min: 0,
-        max: 1,
-      },
-    };
-    if (token.data.light.bright != 0) {
-      conf.bright = 0;
-      conf.dim = 0;
-      await token.document.update({light: conf});
-      archmage.suppressMessage = true;
+    if (!token.light) {
+      let data = foundry.data.LightData.cleanData();
+      data.bright = 3;
+      data.dim = 4;
+      data.animation.type = 'torch';
+      data.animation.speed = 3;
+      data.animation.intensity = 3;
+      await token.document.update({light: data});
     } else {
-      conf.bright = radiusBright;
-      conf.dim = radiusDim;
-      await token.document.update({light: conf});
+      await token.document.update({light: undefined});
+      archmage.suppressMessage = true;
     }
-
   }
 }

--- a/src/vue/components/actor/character/main/CharPowers.vue
+++ b/src/vue/components/actor/character/main/CharPowers.vue
@@ -58,7 +58,7 @@
               </ul>
             </div>
             <div class="power-action" v-if="power.system.actionType.value">{{getActionShort(power.system.actionType.value)}}</div>
-            <div class="power-recharge" v-if="power.system.recharge.value && power.system.powerUsage.value == 'recharge'">
+            <div class="power-recharge" v-if="power.system.recharge.value && ['recharge', 'recharge-desperate'].includes(power.system.powerUsage.value)">
               <Rollable name="recharge" type="recharge" :opt="power._id">{{Number(power.system.recharge.value) || 16}}+</Rollable>
             </div>
             <div class="power-uses" :data-item-id="power._id" :data-quantity="power.system.quantity.value"><span v-if="power.system.quantity.value !== null">{{power.system.quantity.value}}</span></div>
@@ -351,6 +351,7 @@ export default {
     powerUsageClass(power) {
       let use = power.system.powerUsage.value ? power.system.powerUsage.value : 'other';
       if (['daily', 'daily-desperate'].includes(use)) use = 'daily';
+      if (['recharge', 'recharge-desperate'].includes(use)) use = 'recharge';
       else if (use == 'cyclic') {
         if (this.actor.system.attributes.escalation.value > 0
           && this.actor.system.attributes.escalation.value % 2 == 0) {

--- a/src/vue/components/parts/Power.vue
+++ b/src/vue/components/parts/Power.vue
@@ -171,6 +171,7 @@ export default {
      powerUsageClass(power) {
       let use = power.system.powerUsage.value ? power.system.powerUsage.value : 'other';
       if (['daily', 'daily-desperate'].includes(use)) use = 'daily';
+      if (['recharge', 'recharge-desperate'].includes(use)) use = 'recharge';
       else if (use == 'cyclic') {
         if (this.actor && this.actor?.system.attributes.escalation?.value > 0
           && this.actor?.system.attributes.escalation.value % 2 == 0) {


### PR DESCRIPTION
- Add new `End of Arc` AE duration for the rare effects that last until the next full heal up
- Add new `Recharge/Desperate` usage pattern for powers and equipment
- Fix ongoing damage text not being correctly recognized
- Fix more instances of actor-less powers/actions not rolling to chat
- Fix ongoing damage check misidentifying conditions with durations as ongoing damage
- Fix light system macro not working on Foundry v12