### PR TITLE
Fix/deny ED AE flag and other fixes

### DIFF
--- a/src/module/active-effects/effect-sheet.js
+++ b/src/module/active-effects/effect-sheet.js
@@ -39,7 +39,7 @@ export class EffectArchmageSheet extends ActiveEffectConfig {
     }
 
     const edChange = context.effect.changes.find(x => x.key === "system.attributes.escalation.value");
-    //effect.system.blockedFromEscalationDie = edChange ? edChange.value === "0" : false;
+    context.blockedFromEscalationDie = edChange ? edChange.value === "0" : false;
 
     context.supportsDescription = game.release.generation >= 11;
     context.durationOptions = CONFIG.ARCHMAGE.effectDurationTypes;
@@ -162,7 +162,7 @@ export class EffectArchmageSheet extends ActiveEffectConfig {
     // Apply the combined effect changes.
     ae.changes = changes.concat(newChanges);
 
-    if ( formData.system.blockedFromEscalationDie ) {
+    if ( formData.blockedFromEscalationDie ) {
       ae.changes.push({
         key: 'system.attributes.escalation.value',
         mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,

--- a/src/module/actor/actor-sheet-v2.js
+++ b/src/module/actor/actor-sheet-v2.js
@@ -679,8 +679,8 @@ export class ActorArchmageSheetV2 extends ActorSheet {
       // Basic chat message data
       const chatData = {
         user: game.user.id,
-        type: CONST.CHAT_MESSAGE_TYPES.ROLL,
-        roll: roll,
+        roll: roll,  // TODO: fix template to use rolls prop
+        rolls: [roll],
         speaker: game.archmage.ArchmageUtility.getSpeaker(this.actor)
       };
 
@@ -776,8 +776,8 @@ export class ActorArchmageSheetV2 extends ActorSheet {
     // Basic chat message data
     const chatData = {
       user: game.user.id,
-      type: CONST.CHAT_MESSAGE_TYPES.ROLL,
-      roll: roll,
+      roll: roll,  // TODO: fix template to use rolls prop
+      rolls: [roll],
       speaker: game.archmage.ArchmageUtility.getSpeaker(actor)
     };
 

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -812,8 +812,7 @@ export class ActorArchmage extends Actor {
     // Basic chat message data
     const chatData = {
       user: game.user.id,
-      type: CONST.CHAT_MESSAGE_TYPES.ROLL,
-      roll: roll,
+      rolls: [roll],
       speaker: game.archmage.ArchmageUtility.getSpeaker(this)
     };
 

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -153,11 +153,11 @@ export class ActorArchmage extends Actor {
         break;
       // Handle escalation die.
       case 'ed':
-        relevant = (c => {return c.key == 'attributes.escalation.value';});
+        relevant = (c => {return c.key == 'system.attributes.escalation.value';});
         break;
       // Handle standard bonuses.
       case 'std':
-        relevant = (c => {return c.key == 'attributes.standardBonuses.value';});
+        relevant = (c => {return c.key == 'system.attributes.standardBonuses.value';});
         break;
       // Handle remaining active effects.
       case 'post':
@@ -169,7 +169,7 @@ export class ActorArchmage extends Actor {
       return changes.concat(e.changes.map(c => {
         c = foundry.utils.duplicate(c);
         c.effect = e;
-        c.name = e?.name ?? e.label; // @todo remove when v10 support is dropped
+        c.name = e?.name;
         c.priority = c.priority ?? (c.mode * 10);
         return c;
       })).filter(relevant);

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -909,8 +909,6 @@ export class ActorArchmage extends Actor {
       // Prepare chat data for the template.
       const chatData = {
         user: game.user.id,
-        type: CONST.CHAT_MESSAGE_TYPES.ROLL,
-        roll: roll,
         rolls: [roll],
         speaker: game.archmage.ArchmageUtility.getSpeaker(this)
       };
@@ -1991,7 +1989,7 @@ export class ActorArchmage extends Actor {
       let effectsToDelete = [];
       const negRecoveryLabel = game.i18n.localize("ARCHMAGE.EFFECT.AE.negativeRecovery");
       this.effects.forEach(x => {
-        if (x.label == negRecoveryLabel) effectsToDelete.push(x.id);
+        if (x.name == negRecoveryLabel) effectsToDelete.push(x.id);
       });
       await this.deleteEmbeddedDocuments("ActiveEffect", effectsToDelete)
 

--- a/src/module/actor/dice.js
+++ b/src/module/actor/dice.js
@@ -96,6 +96,7 @@ export class DiceArchmage {
       // Prepare chat data for the template.
       const chatData = {
         user: game.user.id,
+        roll: roll,  // TODO: fix template to use rolls prop
         rolls: [roll],
         speaker: game.archmage.ArchmageUtility.getSpeaker(actor)
       };

--- a/src/module/actor/dice.js
+++ b/src/module/actor/dice.js
@@ -96,8 +96,6 @@ export class DiceArchmage {
       // Prepare chat data for the template.
       const chatData = {
         user: game.user.id,
-        type: CONST.CHAT_MESSAGE_TYPES.ROLL,
-        roll: roll,
         rolls: [roll],
         speaker: game.archmage.ArchmageUtility.getSpeaker(actor)
       };

--- a/src/module/setup/archmage-prepopulate.js
+++ b/src/module/setup/archmage-prepopulate.js
@@ -35,14 +35,23 @@ export class ArchmagePrepopulate {
    */
   async getCompendiums(classes = [], race = '') {
     let validRaces = Object.values(CONFIG.ARCHMAGE.raceList);
-    let classPacks = await game.packs.filter(p => classes.includes(this.cleanClassName(p.metadata.name, true)) && !p.metadata.name.includes("2e"));
     let racePacks = await game.packs.filter(p => p.metadata.name == 'races');
     if (game.settings.get('archmage', 'secondEdition')) {
-      let classPacks2e = await game.packs.filter(p => classes.includes(this.cleanClassName(p.metadata.name, true)) && p.metadata.name.includes("2e"));
-      if (classPacks2e.length > 0) classPacks = classPacks2e;
       let racePacks2e = await game.packs.filter(p => p.metadata.name == 'kin-powers-2e');
       if (racePacks2e.length > 0) racePacks = racePacks2e;
     }
+    // Search class packs by class
+    let classPacks = {};
+    for (const cls of classes) {
+      classPacks[cls] = await game.packs.filter(p => cls === this.cleanClassName(p.metadata.name, true) && !p.metadata.name.includes("2e"));
+      if (game.settings.get('archmage', 'secondEdition')) {
+        // Check if we have a 2e version
+        let classPack2e = await game.packs.filter(p => cls === this.cleanClassName(p.metadata.name, true) && p.metadata.name.includes("2e"));
+        if (classPack2e.length > 0) classPacks[cls] = classPack2e;
+      }
+    }
+    // Reduce back to flat array of packs
+    classPacks = Object.values(classPacks).reduce((a,b) => a.concat(b))
     let content = {};
 
     // Load racial powers

--- a/src/module/setup/utility-classes.js
+++ b/src/module/setup/utility-classes.js
@@ -50,9 +50,9 @@ export class ArchmageUtility {
     // Return early if there is nothing to wait on.
     // Our own inline rolls are handled separately,
     // so we only wait for roll messages or if default DSN inline rolls are used.
-    if (chatData.type !== CONST.CHAT_MESSAGE_TYPES.ROLL &&
+    if ((!chatData.rolls || chatData.rolls.length == 0) &&
         !game.settings.get("dice-so-nice", "animateInlineRoll")) {
-      return ChatMessage.create(chatData, context);
+      return await ChatMessage.create(chatData, context);
     }
 
     // Try to wait for the 3d dice animation to finish.

--- a/src/templates/active-effects/effect.html
+++ b/src/templates/active-effects/effect.html
@@ -116,6 +116,11 @@
                     </div>
                     <p class="notes">{{localize 'ARCHMAGE.ITEM.critModBonusHint'}}</p>
 
+                    <div class="settings-group">
+                        <strong class="attribute-name">{{localize 'ARCHMAGE.ITEM.escalationBlockedHint'}}</strong>
+                        <input type="checkbox" name="blockedFromEscalationDie" value="1" data-dtype="Boolean" {{checked blockedFromEscalationDie}} />
+                    </div>
+
                     <div class="settings-group form-group" style="padding-top: 10px;">
                         <label>{{localize 'ARCHMAGE.ITEM.defenseBonuses'}}</label>
                     </div>
@@ -170,13 +175,6 @@
                                data-dtype="Number" placeholder="0" />
                     </div>
                     <p class="notes">{{localize 'ARCHMAGE.ITEM.critDefBonusHint'}}</p>
-
-                    {{#unless isNpc}}
-                    <div class="settings-group">
-                        <strong class="attribute-name">{{localize 'ARCHMAGE.ITEM.escalationBlockedHint'}}</strong>
-                        <input type="checkbox" name="blockedFromEscalationDie" value="1" data-dtype="Boolean" {{checked system.blockedFromEscalationDie}} />
-                    </div>
-                    {{/unless}}
 
                     <div class="settings-group form-group" style="padding-top: 10px;">
                         <label>{{localize 'ARCHMAGE.ITEM.ongoingDamage'}}</label>


### PR DESCRIPTION
- Fix deny ED AE flag not being persisted
- Fix `@ed` and `@std` overrides non being applied correctly
- Fix power importer getting confused with multiclasses between 1e and 2e classes with the 2e module active
- Fix an issue that prevented animated dice from working and outcomes to be saved to the actor for saves, Icon rolls, and Command Point rolls
- Fix a number of deprecation warnings