### PR TITLE
Add condition enrichment to descriptions

### DIFF
--- a/src/module/item/action-sheet-v2.js
+++ b/src/module/item/action-sheet-v2.js
@@ -108,7 +108,7 @@ export class ArchmageActionSheetV2 extends VueRenderingMixin(ArchmageBaseItemShe
     // Enrich the description.
     context.editors = {
       'system.description.value': {
-        enriched: await TextEditor.enrichHTML(this.item.system.description?.value ?? '', enrichmentOptions),
+        enriched: await wrapRolls(this.item.system.description.value ?? '', [], 'short', {}, 'description', enrichmentOptions),
         element: foundry.applications.elements.HTMLProseMirrorElement.create({
           ...editorOptions,
           name: 'system.description.value',

--- a/src/module/item/power-sheet-v2.js
+++ b/src/module/item/power-sheet-v2.js
@@ -140,7 +140,7 @@ export class ArchmagePowerSheetV2 extends VueRenderingMixin(ArchmageBaseItemShee
     // Enrich the description.
     context.editors = {
       'system.description.value': {
-        enriched: await TextEditor.enrichHTML(this.item.system.description?.value ?? '', enrichmentOptions),
+        enriched: await wrapRolls(this.item.system.description.value ?? '', [], 'short', {}, 'description', enrichmentOptions),
         element: foundry.applications.elements.HTMLProseMirrorElement.create({
           ...editorOptions,
           name: 'system.description.value',

--- a/src/templates/chat/action-card.html
+++ b/src/templates/chat/action-card.html
@@ -47,7 +47,7 @@
     {{/if}}
     {{#if data.description.value}}
       <div class="card-row">
-        {{{data.description.value}}}
+        <div class="card-prop">{{{data.description.value}}}</div>
       </div>
     {{/if}}
     </div>

--- a/src/templates/chat/equipment-card.html
+++ b/src/templates/chat/equipment-card.html
@@ -9,7 +9,7 @@
             {{#if data.embeddedMacro.value}}
                 <div class="card-row"><em>({{localize "ARCHMAGE.CHAT.embeddedMacro"}})</em></div>
             {{/if}}
-            {{{data.description.value}}}
+            <div class="card-prop">{{{data.description.value}}}</div>
         </div>
     </div>
 

--- a/src/templates/chat/loot-card.html
+++ b/src/templates/chat/loot-card.html
@@ -9,7 +9,7 @@
             {{#if data.embeddedMacro.value}}
                 <div class="card-row"><em>({{localize "ARCHMAGE.CHAT.embeddedMacro"}})</em></div>
             {{/if}}
-            {{{data.description.value}}}
+            <div class="card-prop">{{{data.description.value}}}</div>
         </div>
     </div>
 

--- a/src/templates/chat/nastierspecial-card.html
+++ b/src/templates/chat/nastierspecial-card.html
@@ -13,7 +13,7 @@
               <div class="card-row"><em>({{localize "ARCHMAGE.CHAT.embeddedMacro"}})</em></div>
           {{/if}}
           {{#if data.description.value}}
-              <div class="card-row card-row-description">
+              <div class="card-prop card-row-description">
                   {{{data.description.value}}}
               </div>
           {{/if}}

--- a/src/templates/chat/power-card.html
+++ b/src/templates/chat/power-card.html
@@ -29,7 +29,7 @@
                 {{/if}}
                 {{#if data.description.value}}
                     <div class="card-row">
-                        {{{data.description.value}}}
+                        <div class="card-prop">{{{data.description.value}}}</div>
                     </div>
                 {{/if}}
                 {{#if data.feats}}

--- a/src/templates/chat/tool-card.html
+++ b/src/templates/chat/tool-card.html
@@ -9,7 +9,7 @@
             {{#if data.embeddedMacro.value}}
                 <div class="card-row"><em>({{localize "ARCHMAGE.CHAT.embeddedMacro"}})</em></div>
             {{/if}}
-            {{{data.description.value}}}
+            <div class="card-prop">{{{data.description.value}}}</div>
         </div>
     </div>
 

--- a/src/templates/chat/trait-card.html
+++ b/src/templates/chat/trait-card.html
@@ -13,7 +13,7 @@
               <div class="card-row"><em>({{localize "ARCHMAGE.CHAT.embeddedMacro"}})</em></div>
           {{/if}}
           {{#if data.description.value}}
-              <div class="card-row card-row-description">
+              <div class="card-prop card-row-description">
                   {{{data.description.value}}}
               </div>
           {{/if}}


### PR DESCRIPTION
- Updated chat Handlebars templates to include the '.card-prop' class around them as an extra div so that they're picked up by the condition and ongoing effect parser.
- Updated action-sheet-v2 and power-sheet-v2 to parse conditions on enriched fields.

## Screenshots
![image](https://github.com/user-attachments/assets/8e19e9d1-d3c6-454e-9006-650a6bbca50c)
