### PR TITLE
Magic item tiers

### DIFF
--- a/src/module/item/item-sheet.js
+++ b/src/module/item/item-sheet.js
@@ -109,6 +109,7 @@ export class ItemArchmageSheet extends ItemSheet {
     // Equipment-specific data
     else if (this.item.type === 'equipment') {
       context['equipUsages'] = CONFIG.ARCHMAGE.equipUsages;
+      context['tiers'] = CONFIG.ARCHMAGE.featTiers;
     }
 
     if (this.actor) {

--- a/src/packs/src/srd-magic-items/Abandon__Melee_weapon__1eq1BAT2e6dPzlvR.yml
+++ b/src/packs/src/srd-magic-items/Abandon__Melee_weapon__1eq1BAT2e6dPzlvR.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Acrobat_s_Stick__staff__Y6K5ZsUP3boBtYos.yml
+++ b/src/packs/src/srd-magic-items/Acrobat_s_Stick__staff__Y6K5ZsUP3boBtYos.yml
@@ -81,6 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Adaptation_RIrHa5AFQSgRrHd0.yml
+++ b/src/packs/src/srd-magic-items/Adaptation_RIrHa5AFQSgRrHd0.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Adroit_Avoidance_H6VyBmHoGWsD8RVX.yml
+++ b/src/packs/src/srd-magic-items/Adroit_Avoidance_H6VyBmHoGWsD8RVX.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Ambidexterity_cffgDnU4sbIrfgcS.yml
+++ b/src/packs/src/srd-magic-items/Ambidexterity_cffgDnU4sbIrfgcS.yml
@@ -81,6 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Anger_Armor__heavy_armor__IOhq6MqTnpbqXps9.yml
+++ b/src/packs/src/srd-magic-items/Anger_Armor__heavy_armor__IOhq6MqTnpbqXps9.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Arcane_Contact_oUL3GUwP7bpYFsNc.yml
+++ b/src/packs/src/srd-magic-items/Arcane_Contact_oUL3GUwP7bpYFsNc.yml
@@ -83,6 +83,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Archer_s_Gauntlets_OX8Ym1H6Y4GJUnAn.yml
+++ b/src/packs/src/srd-magic-items/Archer_s_Gauntlets_OX8Ym1H6Y4GJUnAn.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Axe_of_Bloody_Vengeance___3_weapon__N0XveL9X1L9F3J6T.yml
+++ b/src/packs/src/srd-magic-items/Axe_of_Bloody_Vengeance___3_weapon__N0XveL9X1L9F3J6T.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Axe_of_Bloody_Vengeance___3_weapon__N0XveL9X1L9F3J6T.yml
+++ b/src/packs/src/srd-magic-items/Axe_of_Bloody_Vengeance___3_weapon__N0XveL9X1L9F3J6T.yml
@@ -76,7 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Backbiter_Bow__bow__96OPIT2cN2Hcs3b2.yml
+++ b/src/packs/src/srd-magic-items/Backbiter_Bow__bow__96OPIT2cN2Hcs3b2.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Bait_Breastplate__any_armor__tyYgYwFC1p47aH2L.yml
+++ b/src/packs/src/srd-magic-items/Bait_Breastplate__any_armor__tyYgYwFC1p47aH2L.yml
@@ -79,7 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Bait_Breastplate__any_armor__tyYgYwFC1p47aH2L.yml
+++ b/src/packs/src/srd-magic-items/Bait_Breastplate__any_armor__tyYgYwFC1p47aH2L.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Bashing_hWC4oifdZvqujdrA.yml
+++ b/src/packs/src/srd-magic-items/Bashing_hWC4oifdZvqujdrA.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Bearclaw_xrSKpjtlSuXsONsT.yml
+++ b/src/packs/src/srd-magic-items/Bearclaw_xrSKpjtlSuXsONsT.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Blade_of_Unerring_Panache___2_weapon__rThiRBKjQTPxr9rC.yml
+++ b/src/packs/src/srd-magic-items/Blade_of_Unerring_Panache___2_weapon__rThiRBKjQTPxr9rC.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Blademaster_s_Belt_J8Z4UI9SgmrqFqhd.yml
+++ b/src/packs/src/srd-magic-items/Blademaster_s_Belt_J8Z4UI9SgmrqFqhd.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Bloodthirsty__Any_weapon__L8xEcxTA1LlBBV9s.yml
+++ b/src/packs/src/srd-magic-items/Bloodthirsty__Any_weapon__L8xEcxTA1LlBBV9s.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Body_Breaking__Dagger_of_DjmtneqgPskZE33p.yml
+++ b/src/packs/src/srd-magic-items/Body_Breaking__Dagger_of_DjmtneqgPskZE33p.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Boots_of_Elvenkind_H3a2fBth57Dd6brx.yml
+++ b/src/packs/src/srd-magic-items/Boots_of_Elvenkind_H3a2fBth57Dd6brx.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Boots_of_Ferocious_Charge_owaL61tsoErs9fjw.yml
+++ b/src/packs/src/srd-magic-items/Boots_of_Ferocious_Charge_owaL61tsoErs9fjw.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Boots_of_Rhythm_DgoCS3FyC2FYV306.yml
+++ b/src/packs/src/srd-magic-items/Boots_of_Rhythm_DgoCS3FyC2FYV306.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Boots_of_Sure_Feet_jbMav0pEopdyZl5i.yml
+++ b/src/packs/src/srd-magic-items/Boots_of_Sure_Feet_jbMav0pEopdyZl5i.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Brazen_Armor___3_armor__QmTW6fZFQc76eKk6.yml
+++ b/src/packs/src/srd-magic-items/Brazen_Armor___3_armor__QmTW6fZFQc76eKk6.yml
@@ -79,7 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Brazen_Armor___3_armor__QmTW6fZFQc76eKk6.yml
+++ b/src/packs/src/srd-magic-items/Brazen_Armor___3_armor__QmTW6fZFQc76eKk6.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Brutal_Vigor_GPcxLB6Oml51aDTK.yml
+++ b/src/packs/src/srd-magic-items/Brutal_Vigor_GPcxLB6Oml51aDTK.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Certain_Pain__Two_handed_melee_weapon__jOVZJDQxVqie3JmD.yml
+++ b/src/packs/src/srd-magic-items/Certain_Pain__Two_handed_melee_weapon__jOVZJDQxVqie3JmD.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Cheap_Shot_vyGpv0mf5PtaIHD8.yml
+++ b/src/packs/src/srd-magic-items/Cheap_Shot_vyGpv0mf5PtaIHD8.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Chicken_Shield__shield__37pot1g3ClLPQu83.yml
+++ b/src/packs/src/srd-magic-items/Chicken_Shield__shield__37pot1g3ClLPQu83.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Chicken_Shield__shield__37pot1g3ClLPQu83.yml
+++ b/src/packs/src/srd-magic-items/Chicken_Shield__shield__37pot1g3ClLPQu83.yml
@@ -80,7 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'epic'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Chitin_Claw__ring__UTtwthIxMJCBQMs7.yml
+++ b/src/packs/src/srd-magic-items/Chitin_Claw__ring__UTtwthIxMJCBQMs7.yml
@@ -81,6 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Chosen_One__Sign_of_the_FGEpNL8QOyQnIco7.yml
+++ b/src/packs/src/srd-magic-items/Chosen_One__Sign_of_the_FGEpNL8QOyQnIco7.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Chuul_Helm__helm__JiyEkGEs7TPrq4Ko.yml
+++ b/src/packs/src/srd-magic-items/Chuul_Helm__helm__JiyEkGEs7TPrq4Ko.yml
@@ -83,6 +83,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Chuulish_Cuirass__heavy_armor__nEcV0HlfDtLDkybB.yml
+++ b/src/packs/src/srd-magic-items/Chuulish_Cuirass__heavy_armor__nEcV0HlfDtLDkybB.yml
@@ -83,6 +83,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Circlet_of_Approachability_xorAvJGB5vwEsqYO.yml
+++ b/src/packs/src/srd-magic-items/Circlet_of_Approachability_xorAvJGB5vwEsqYO.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Clawed_Tentacles__gloves__DKUzxcqOfRQLx9Cy.yml
+++ b/src/packs/src/srd-magic-items/Clawed_Tentacles__gloves__DKUzxcqOfRQLx9Cy.yml
@@ -83,6 +83,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Clever_Step__Usually_light_armor__Dfb4Sd4SbJFbUVms.yml
+++ b/src/packs/src/srd-magic-items/Clever_Step__Usually_light_armor__Dfb4Sd4SbJFbUVms.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Climactic_Shot__Ranged_weapon__2E8OU7TDNoBU9u16.yml
+++ b/src/packs/src/srd-magic-items/Climactic_Shot__Ranged_weapon__2E8OU7TDNoBU9u16.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Codex_of_Foreshadowed_Victory_Ryt0fhNvOtyGRM8o.yml
+++ b/src/packs/src/srd-magic-items/Codex_of_Foreshadowed_Victory_Ryt0fhNvOtyGRM8o.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Crown_of_the_Mighty_Strike_NTTFlNvpmrpdZIIP.yml
+++ b/src/packs/src/srd-magic-items/Crown_of_the_Mighty_Strike_NTTFlNvpmrpdZIIP.yml
@@ -81,7 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'epic'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Crown_of_the_Mighty_Strike_NTTFlNvpmrpdZIIP.yml
+++ b/src/packs/src/srd-magic-items/Crown_of_the_Mighty_Strike_NTTFlNvpmrpdZIIP.yml
@@ -81,6 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Cruel__Any_weapon__O8FVdySsL4K6CGAH.yml
+++ b/src/packs/src/srd-magic-items/Cruel__Any_weapon__O8FVdySsL4K6CGAH.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Cudgel_of_Heedlessness__heavy_two_handed_melee_weapon__ErHLLCdmd56mnS4t.yml
+++ b/src/packs/src/srd-magic-items/Cudgel_of_Heedlessness__heavy_two_handed_melee_weapon__ErHLLCdmd56mnS4t.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Cudgel_of_Heedlessness__heavy_two_handed_melee_weapon__ErHLLCdmd56mnS4t.yml
+++ b/src/packs/src/srd-magic-items/Cudgel_of_Heedlessness__heavy_two_handed_melee_weapon__ErHLLCdmd56mnS4t.yml
@@ -80,7 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Cups_JtNb3vrh9TorLjfM.yml
+++ b/src/packs/src/srd-magic-items/Cups_JtNb3vrh9TorLjfM.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Dancing_Shoes__boots__fBWiaCbULpTb6n34.yml
+++ b/src/packs/src/srd-magic-items/Dancing_Shoes__boots__fBWiaCbULpTb6n34.yml
@@ -82,6 +82,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Danger_Bracers__light_armor__9uGHcph67a5oAefZ.yml
+++ b/src/packs/src/srd-magic-items/Danger_Bracers__light_armor__9uGHcph67a5oAefZ.yml
@@ -78,7 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'epic'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Danger_Bracers__light_armor__9uGHcph67a5oAefZ.yml
+++ b/src/packs/src/srd-magic-items/Danger_Bracers__light_armor__9uGHcph67a5oAefZ.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Death_Claw__gloves__bIMVB8xEPGP4Faxg.yml
+++ b/src/packs/src/srd-magic-items/Death_Claw__gloves__bIMVB8xEPGP4Faxg.yml
@@ -82,6 +82,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Death__Epic__zhNgAfygmpz0rqNh.yml
+++ b/src/packs/src/srd-magic-items/Death__Epic__zhNgAfygmpz0rqNh.yml
@@ -78,7 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'epic'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Death__Epic__zhNgAfygmpz0rqNh.yml
+++ b/src/packs/src/srd-magic-items/Death__Epic__zhNgAfygmpz0rqNh.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Deck_of_Many_Cards__wondrous_item__Zt6NfT3r8PG8OfJy.yml
+++ b/src/packs/src/srd-magic-items/Deck_of_Many_Cards__wondrous_item__Zt6NfT3r8PG8OfJy.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Defense_yEbWu3wMPVzNOMyw.yml
+++ b/src/packs/src/srd-magic-items/Defense_yEbWu3wMPVzNOMyw.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Dexterous_Parry__One_handed_melee_weapon__u6qvIuRYtiqxKVnw.yml
+++ b/src/packs/src/srd-magic-items/Dexterous_Parry__One_handed_melee_weapon__u6qvIuRYtiqxKVnw.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Diabolical_Staff_immemisvGhlW7W8R.yml
+++ b/src/packs/src/srd-magic-items/Diabolical_Staff_immemisvGhlW7W8R.yml
@@ -82,7 +82,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Diabolical_Staff_immemisvGhlW7W8R.yml
+++ b/src/packs/src/srd-magic-items/Diabolical_Staff_immemisvGhlW7W8R.yml
@@ -82,6 +82,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Disappointment_Hat__hat__f3w9jq8gXtzWNOIV.yml
+++ b/src/packs/src/srd-magic-items/Disappointment_Hat__hat__f3w9jq8gXtzWNOIV.yml
@@ -82,6 +82,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Distraction__Two_handed_melee_weapon__rU8IkvweCU1K2upT.yml
+++ b/src/packs/src/srd-magic-items/Distraction__Two_handed_melee_weapon__rU8IkvweCU1K2upT.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Divine_Harmony__Knot_of_vZFoi8arRIv68k66.yml
+++ b/src/packs/src/srd-magic-items/Divine_Harmony__Knot_of_vZFoi8arRIv68k66.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Dodging_Doom__Symbol_of_MXaa0SHvGpNVNlNl.yml
+++ b/src/packs/src/srd-magic-items/Dodging_Doom__Symbol_of_MXaa0SHvGpNVNlNl.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Dominating_Truth__Symbol_of_EpbQiyQ82s8v4wGV.yml
+++ b/src/packs/src/srd-magic-items/Dominating_Truth__Symbol_of_EpbQiyQ82s8v4wGV.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Drakefanged_WVmoOgehjansRXSR.yml
+++ b/src/packs/src/srd-magic-items/Drakefanged_WVmoOgehjansRXSR.yml
@@ -84,6 +84,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Dwarven_Mug_0uVTow5KdGhk4Y4T.yml
+++ b/src/packs/src/srd-magic-items/Dwarven_Mug_0uVTow5KdGhk4Y4T.yml
@@ -86,6 +86,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Elven_gj4wvkuSAhE0ywU2.yml
+++ b/src/packs/src/srd-magic-items/Elven_gj4wvkuSAhE0ywU2.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Energy_eRe1ydl5rO4li9Ik.yml
+++ b/src/packs/src/srd-magic-items/Energy_eRe1ydl5rO4li9Ik.yml
@@ -77,6 +77,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Evasion_xXYMRD2YTMnVmbh7.yml
+++ b/src/packs/src/srd-magic-items/Evasion_xXYMRD2YTMnVmbh7.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Evil_Eyes__gloves__9k4aivHQPWZMKfWO.yml
+++ b/src/packs/src/srd-magic-items/Evil_Eyes__gloves__9k4aivHQPWZMKfWO.yml
@@ -86,6 +86,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Flaming__Champion__yNyhPEbdc4xt9qbn.yml
+++ b/src/packs/src/srd-magic-items/Flaming__Champion__yNyhPEbdc4xt9qbn.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Flaming__Champion__yNyhPEbdc4xt9qbn.yml
+++ b/src/packs/src/srd-magic-items/Flaming__Champion__yNyhPEbdc4xt9qbn.yml
@@ -76,7 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Flaring_Wand_GwH4ZzLfpiE4pL3r.yml
+++ b/src/packs/src/srd-magic-items/Flaring_Wand_GwH4ZzLfpiE4pL3r.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Flurry__Two_handed_melee_weapon__TjnY1TH289NHE6lJ.yml
+++ b/src/packs/src/srd-magic-items/Flurry__Two_handed_melee_weapon__TjnY1TH289NHE6lJ.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Forceful_Impact_csks9tECEJx2Yvtu.yml
+++ b/src/packs/src/srd-magic-items/Forceful_Impact_csks9tECEJx2Yvtu.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Gathered_Power__Symbol_of_ZVs8fNtGFlRF0sD8.yml
+++ b/src/packs/src/srd-magic-items/Gathered_Power__Symbol_of_ZVs8fNtGFlRF0sD8.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Gauntlets_of_Clobbering_fUJzBdmO7qqvYdiR.yml
+++ b/src/packs/src/srd-magic-items/Gauntlets_of_Clobbering_fUJzBdmO7qqvYdiR.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Girdle_of_Gender_Switching__belt__cd5VfPfEIHbay9Th.yml
+++ b/src/packs/src/srd-magic-items/Girdle_of_Gender_Switching__belt__cd5VfPfEIHbay9Th.yml
@@ -81,6 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Glandular_Parasite__cloak_mantle__1kveWGIU0E8JtlTz.yml
+++ b/src/packs/src/srd-magic-items/Glandular_Parasite__cloak_mantle__1kveWGIU0E8JtlTz.yml
@@ -83,6 +83,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Glorious_Rally_e2RN5Xm3JjXLevNC.yml
+++ b/src/packs/src/srd-magic-items/Glorious_Rally_e2RN5Xm3JjXLevNC.yml
@@ -77,6 +77,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Glory_8Msy6xQJAQbLSBHW.yml
+++ b/src/packs/src/srd-magic-items/Glory_8Msy6xQJAQbLSBHW.yml
@@ -81,6 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Gloves_of_Mind_Rot_yfeP9xTKJIiSAJd7.yml
+++ b/src/packs/src/srd-magic-items/Gloves_of_Mind_Rot_yfeP9xTKJIiSAJd7.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Godlike_Glory__Holy_Symbol_of_HGI1vgzstqFKWWBP.yml
+++ b/src/packs/src/srd-magic-items/Godlike_Glory__Holy_Symbol_of_HGI1vgzstqFKWWBP.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Great_Low_Sickle___5_weapon__8zbwADDZvq7pkdeB.yml
+++ b/src/packs/src/srd-magic-items/Great_Low_Sickle___5_weapon__8zbwADDZvq7pkdeB.yml
@@ -76,7 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'epic'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Great_Low_Sickle___5_weapon__8zbwADDZvq7pkdeB.yml
+++ b/src/packs/src/srd-magic-items/Great_Low_Sickle___5_weapon__8zbwADDZvq7pkdeB.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Greater_Power__Relic_of_V6Dg6HgF4OLOLUlA.yml
+++ b/src/packs/src/srd-magic-items/Greater_Power__Relic_of_V6Dg6HgF4OLOLUlA.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Greater_Striking__Melee_weapon__cHS9ZxJc27Bd9Ieb.yml
+++ b/src/packs/src/srd-magic-items/Greater_Striking__Melee_weapon__cHS9ZxJc27Bd9Ieb.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Greatsword_of_Utter_Night___3_greatsword__MaPMjKf9ATzy0dz7.yml
+++ b/src/packs/src/srd-magic-items/Greatsword_of_Utter_Night___3_greatsword__MaPMjKf9ATzy0dz7.yml
@@ -83,7 +83,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'epic'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Greatsword_of_Utter_Night___3_greatsword__MaPMjKf9ATzy0dz7.yml
+++ b/src/packs/src/srd-magic-items/Greatsword_of_Utter_Night___3_greatsword__MaPMjKf9ATzy0dz7.yml
@@ -83,6 +83,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Guardian_YbriBPAAQDDEWUrs.yml
+++ b/src/packs/src/srd-magic-items/Guardian_YbriBPAAQDDEWUrs.yml
@@ -81,7 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Guardian_YbriBPAAQDDEWUrs.yml
+++ b/src/packs/src/srd-magic-items/Guardian_YbriBPAAQDDEWUrs.yml
@@ -81,6 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Guardian__One_handed_melee_weapon__k1HykZh0w3iYxcVz.yml
+++ b/src/packs/src/srd-magic-items/Guardian__One_handed_melee_weapon__k1HykZh0w3iYxcVz.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Haughty__Any_weapon__fl5OEX3yRS6AaPoi.yml
+++ b/src/packs/src/srd-magic-items/Haughty__Any_weapon__fl5OEX3yRS6AaPoi.yml
@@ -81,6 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Heedlessness_c99fjccZqXLkqbDo.yml
+++ b/src/packs/src/srd-magic-items/Heedlessness_c99fjccZqXLkqbDo.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Helm_of_Fortunate_Dodging_kaSv0r4UhyanWvDo.yml
+++ b/src/packs/src/srd-magic-items/Helm_of_Fortunate_Dodging_kaSv0r4UhyanWvDo.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Helm_of_Psychic_Armor_0iJ7wXOM9CEa9LCr.yml
+++ b/src/packs/src/srd-magic-items/Helm_of_Psychic_Armor_0iJ7wXOM9CEa9LCr.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Helm_of_Psychic_Retribution_8CeziEW91f8rOY9X.yml
+++ b/src/packs/src/srd-magic-items/Helm_of_Psychic_Retribution_8CeziEW91f8rOY9X.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Helm_of_the_Undaunted_Hero_6kU3lcmoUhLjucCU.yml
+++ b/src/packs/src/srd-magic-items/Helm_of_the_Undaunted_Hero_6kU3lcmoUhLjucCU.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Heroic_Resolve_KrwDOHtCbhK8OOpm.yml
+++ b/src/packs/src/srd-magic-items/Heroic_Resolve_KrwDOHtCbhK8OOpm.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Implanted_Aventail__light_armor__nqpOXNZBqN2AyH2F.yml
+++ b/src/packs/src/srd-magic-items/Implanted_Aventail__light_armor__nqpOXNZBqN2AyH2F.yml
@@ -85,6 +85,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Incomparable_Axe_of_Wyrm_Chopping___3_axe__fnTNvweObrS685hI.yml
+++ b/src/packs/src/srd-magic-items/Incomparable_Axe_of_Wyrm_Chopping___3_axe__fnTNvweObrS685hI.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Incomparable_Axe_of_Wyrm_Chopping___3_axe__fnTNvweObrS685hI.yml
+++ b/src/packs/src/srd-magic-items/Incomparable_Axe_of_Wyrm_Chopping___3_axe__fnTNvweObrS685hI.yml
@@ -80,7 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'epic'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Infighting__Wand_of_wtH7DtEMnAeSAaJ7.yml
+++ b/src/packs/src/srd-magic-items/Infighting__Wand_of_wtH7DtEMnAeSAaJ7.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Inimical__Any_weapon__ItIkLTmXAQxFow5x.yml
+++ b/src/packs/src/srd-magic-items/Inimical__Any_weapon__ItIkLTmXAQxFow5x.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Instant_Vengeance_N8KmxKNx2mN7qMOv.yml
+++ b/src/packs/src/srd-magic-items/Instant_Vengeance_N8KmxKNx2mN7qMOv.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Inviolability_CNYkUCPNyMOsPAHX.yml
+++ b/src/packs/src/srd-magic-items/Inviolability_CNYkUCPNyMOsPAHX.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Inviolability_CNYkUCPNyMOsPAHX.yml
+++ b/src/packs/src/srd-magic-items/Inviolability_CNYkUCPNyMOsPAHX.yml
@@ -79,7 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'epic'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Iron_Grip_qhnLF3b4tfF91NWE.yml
+++ b/src/packs/src/srd-magic-items/Iron_Grip_qhnLF3b4tfF91NWE.yml
@@ -81,6 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Iron_Will_xOn2RSkkodW5xjOx.yml
+++ b/src/packs/src/srd-magic-items/Iron_Will_xOn2RSkkodW5xjOx.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Jack_of_All_Trades_FMRNVAt9SdnCkpx6.yml
+++ b/src/packs/src/srd-magic-items/Jack_of_All_Trades_FMRNVAt9SdnCkpx6.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Jeweled_Glove_8k2ozLkjlIWUFWyR.yml
+++ b/src/packs/src/srd-magic-items/Jeweled_Glove_8k2ozLkjlIWUFWyR.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Keen_3xYjXdTMlo9IslJg.yml
+++ b/src/packs/src/srd-magic-items/Keen_3xYjXdTMlo9IslJg.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Kilt_of_the_Mad_Archmage_RgNXNIcaxZjzLcC5.yml
+++ b/src/packs/src/srd-magic-items/Kilt_of_the_Mad_Archmage_RgNXNIcaxZjzLcC5.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Kilt_of_the_Mad_Archmage_RgNXNIcaxZjzLcC5.yml
+++ b/src/packs/src/srd-magic-items/Kilt_of_the_Mad_Archmage_RgNXNIcaxZjzLcC5.yml
@@ -79,7 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'epic'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Last_Legs_NBUBRhe8sSHoZFs3.yml
+++ b/src/packs/src/srd-magic-items/Last_Legs_NBUBRhe8sSHoZFs3.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Last_Stand__Usually_heavy_armor__daEngbvr6VNMt4mm.yml
+++ b/src/packs/src/srd-magic-items/Last_Stand__Usually_heavy_armor__daEngbvr6VNMt4mm.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Last_Word_sb8RLVGiap8PQkQ5.yml
+++ b/src/packs/src/srd-magic-items/Last_Word_sb8RLVGiap8PQkQ5.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Lethal_Strike_zO8Ubzd36RkPl0gT.yml
+++ b/src/packs/src/srd-magic-items/Lethal_Strike_zO8Ubzd36RkPl0gT.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Liberation__Melee_weapon__ukyNVYoC388jTmX0.yml
+++ b/src/packs/src/srd-magic-items/Liberation__Melee_weapon__ukyNVYoC388jTmX0.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Lifestone_PDDNScgA3qXPqWku.yml
+++ b/src/packs/src/srd-magic-items/Lifestone_PDDNScgA3qXPqWku.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Longbow_of_Fallen_Grace___3_longbow__F68U9ASSTv8aaMwp.yml
+++ b/src/packs/src/srd-magic-items/Longbow_of_Fallen_Grace___3_longbow__F68U9ASSTv8aaMwp.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Longbow_of_Fallen_Grace___3_longbow__F68U9ASSTv8aaMwp.yml
+++ b/src/packs/src/srd-magic-items/Longbow_of_Fallen_Grace___3_longbow__F68U9ASSTv8aaMwp.yml
@@ -80,7 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Lore_Bottle_6J5t2Kehv3gHDbZr.yml
+++ b/src/packs/src/srd-magic-items/Lore_Bottle_6J5t2Kehv3gHDbZr.yml
@@ -87,6 +87,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Lucky_Stray_z5XfAJP41pOJRn1X.yml
+++ b/src/packs/src/srd-magic-items/Lucky_Stray_z5XfAJP41pOJRn1X.yml
@@ -77,6 +77,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Mage_s_Invisible_Aegis__Wand_of_the_J8CmDDNxV6Awfjr6.yml
+++ b/src/packs/src/srd-magic-items/Mage_s_Invisible_Aegis__Wand_of_the_J8CmDDNxV6Awfjr6.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Manual_of_Enlightened_Flesh_J8ME76ItPAXmRDHv.yml
+++ b/src/packs/src/srd-magic-items/Manual_of_Enlightened_Flesh_J8ME76ItPAXmRDHv.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Manual_of_Puissant_Skill_at_Arms__Champion__o0dL6ridD3fOi1rg.yml
+++ b/src/packs/src/srd-magic-items/Manual_of_Puissant_Skill_at_Arms__Champion__o0dL6ridD3fOi1rg.yml
@@ -81,7 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Manual_of_Puissant_Skill_at_Arms__Champion__o0dL6ridD3fOi1rg.yml
+++ b/src/packs/src/srd-magic-items/Manual_of_Puissant_Skill_at_Arms__Champion__o0dL6ridD3fOi1rg.yml
@@ -81,6 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Mauling__Two_handed_melee_weapon__cGKCAMdZRWdV5esY.yml
+++ b/src/packs/src/srd-magic-items/Mauling__Two_handed_melee_weapon__cGKCAMdZRWdV5esY.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Mighty_Stunning__One_handed_blunt_1d6_melee_weapon__yiZUAo5wzEgChTPB.yml
+++ b/src/packs/src/srd-magic-items/Mighty_Stunning__One_handed_blunt_1d6_melee_weapon__yiZUAo5wzEgChTPB.yml
@@ -79,7 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Mighty_Stunning__One_handed_blunt_1d6_melee_weapon__yiZUAo5wzEgChTPB.yml
+++ b/src/packs/src/srd-magic-items/Mighty_Stunning__One_handed_blunt_1d6_melee_weapon__yiZUAo5wzEgChTPB.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Mighty_Swing__Two_handed_melee_weapon__Nn2wQHv2r5PUzbrz.yml
+++ b/src/packs/src/srd-magic-items/Mighty_Swing__Two_handed_melee_weapon__Nn2wQHv2r5PUzbrz.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Mindbending__Wand_of_CzWrbUNJJ6Op3Ce0.yml
+++ b/src/packs/src/srd-magic-items/Mindbending__Wand_of_CzWrbUNJJ6Op3Ce0.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Momentous_Harmony_eCRxf6CzDnyl3Erh.yml
+++ b/src/packs/src/srd-magic-items/Momentous_Harmony_eCRxf6CzDnyl3Erh.yml
@@ -82,6 +82,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Musical_Touch_sqiF03IoEAAFNIpV.yml
+++ b/src/packs/src/srd-magic-items/Musical_Touch_sqiF03IoEAAFNIpV.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Nemesis_7MsRyrWatDr5xldr.yml
+++ b/src/packs/src/srd-magic-items/Nemesis_7MsRyrWatDr5xldr.yml
@@ -82,6 +82,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Neural_Blade__any_bladed_weapon__3c96sLHpZwizzZv2.yml
+++ b/src/packs/src/srd-magic-items/Neural_Blade__any_bladed_weapon__3c96sLHpZwizzZv2.yml
@@ -84,6 +84,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Neural_Whip__light_one_handed_melee_weapon__Gi3GbuD6F7wqmPRW.yml
+++ b/src/packs/src/srd-magic-items/Neural_Whip__light_one_handed_melee_weapon__Gi3GbuD6F7wqmPRW.yml
@@ -85,6 +85,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/No_Mercy__Ranged_weapon__YFlO0uxu5msTRAKl.yml
+++ b/src/packs/src/srd-magic-items/No_Mercy__Ranged_weapon__YFlO0uxu5msTRAKl.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Paragon_e9uNWg0t4AhgLLiK.yml
+++ b/src/packs/src/srd-magic-items/Paragon_e9uNWg0t4AhgLLiK.yml
@@ -81,6 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Perfection__Usually_heavy_armor__YCcABFwjb8nH0w9L.yml
+++ b/src/packs/src/srd-magic-items/Perfection__Usually_heavy_armor__YCcABFwjb8nH0w9L.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Perseverance_r3kIH0Qwjtd089VO.yml
+++ b/src/packs/src/srd-magic-items/Perseverance_r3kIH0Qwjtd089VO.yml
@@ -81,6 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Potion_Belt_pb6vfXEO94s3QBv1.yml
+++ b/src/packs/src/srd-magic-items/Potion_Belt_pb6vfXEO94s3QBv1.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Procrastination_Tome__implement__cOmM6ov5EfMz8Jda.yml
+++ b/src/packs/src/srd-magic-items/Procrastination_Tome__implement__cOmM6ov5EfMz8Jda.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Procrastination_Tome__implement__cOmM6ov5EfMz8Jda.yml
+++ b/src/packs/src/srd-magic-items/Procrastination_Tome__implement__cOmM6ov5EfMz8Jda.yml
@@ -80,7 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'epic'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Protection_IOesLadFnSWY27r1.yml
+++ b/src/packs/src/srd-magic-items/Protection_IOesLadFnSWY27r1.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Protection__Melee_weapon__7nBNJGd6KtOkB2sS.yml
+++ b/src/packs/src/srd-magic-items/Protection__Melee_weapon__7nBNJGd6KtOkB2sS.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Puissance__Melee_weapon__jKgLCGKj4bSUAxtW.yml
+++ b/src/packs/src/srd-magic-items/Puissance__Melee_weapon__jKgLCGKj4bSUAxtW.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Puissance_uXnz3VA9UMXjIonP.yml
+++ b/src/packs/src/srd-magic-items/Puissance_uXnz3VA9UMXjIonP.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Rachis_Girdle__belt__DulzgrmmfsmQEdad.yml
+++ b/src/packs/src/srd-magic-items/Rachis_Girdle__belt__DulzgrmmfsmQEdad.yml
@@ -82,6 +82,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Rasping_Greaves__boots__xdKVoV1R0UeADGDN.yml
+++ b/src/packs/src/srd-magic-items/Rasping_Greaves__boots__xdKVoV1R0UeADGDN.yml
@@ -83,6 +83,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Reckless__Melee_weapon__ghBcazeZrlfioaxh.yml
+++ b/src/packs/src/srd-magic-items/Reckless__Melee_weapon__ghBcazeZrlfioaxh.yml
@@ -81,7 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Reckless__Melee_weapon__ghBcazeZrlfioaxh.yml
+++ b/src/packs/src/srd-magic-items/Reckless__Melee_weapon__ghBcazeZrlfioaxh.yml
@@ -81,6 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Recovery_QRXh3elqSOyup4mV.yml
+++ b/src/packs/src/srd-magic-items/Recovery_QRXh3elqSOyup4mV.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Relentless_Strike_NfolKqLZmVPzTmc6.yml
+++ b/src/packs/src/srd-magic-items/Relentless_Strike_NfolKqLZmVPzTmc6.yml
@@ -81,6 +81,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Resilience_6p95MqX42A0rewzF.yml
+++ b/src/packs/src/srd-magic-items/Resilience_6p95MqX42A0rewzF.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Resilience_wXb7ISKOM8cF3uVa.yml
+++ b/src/packs/src/srd-magic-items/Resilience_wXb7ISKOM8cF3uVa.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Resilience_xtmWW2LPoLeMK8NE.yml
+++ b/src/packs/src/srd-magic-items/Resilience_xtmWW2LPoLeMK8NE.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Resurgence_poHK3xIv3lyuA789.yml
+++ b/src/packs/src/srd-magic-items/Resurgence_poHK3xIv3lyuA789.yml
@@ -79,7 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Resurgence_poHK3xIv3lyuA789.yml
+++ b/src/packs/src/srd-magic-items/Resurgence_poHK3xIv3lyuA789.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Ring_of_Delusion__ring__qBxzX4QlD52YpfZR.yml
+++ b/src/packs/src/srd-magic-items/Ring_of_Delusion__ring__qBxzX4QlD52YpfZR.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Ring_of_Delusion__ring__qBxzX4QlD52YpfZR.yml
+++ b/src/packs/src/srd-magic-items/Ring_of_Delusion__ring__qBxzX4QlD52YpfZR.yml
@@ -80,7 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Rope_of_Entangling_0apwiD13Wu5p05RO.yml
+++ b/src/packs/src/srd-magic-items/Rope_of_Entangling_0apwiD13Wu5p05RO.yml
@@ -85,6 +85,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Sandals_of_Wall_Striding_gbEfRz5XZAQgJ9Wu.yml
+++ b/src/packs/src/srd-magic-items/Sandals_of_Wall_Striding_gbEfRz5XZAQgJ9Wu.yml
@@ -79,7 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Sandals_of_Wall_Striding_gbEfRz5XZAQgJ9Wu.yml
+++ b/src/packs/src/srd-magic-items/Sandals_of_Wall_Striding_gbEfRz5XZAQgJ9Wu.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Sandals_of_the_Slippery_Eel_hxoZ8PhjUYUrKPaa.yml
+++ b/src/packs/src/srd-magic-items/Sandals_of_the_Slippery_Eel_hxoZ8PhjUYUrKPaa.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Sash_of_Suppleness_UvLkklRN3FRoooyu.yml
+++ b/src/packs/src/srd-magic-items/Sash_of_Suppleness_UvLkklRN3FRoooyu.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Sash_of_Suppleness_UvLkklRN3FRoooyu.yml
+++ b/src/packs/src/srd-magic-items/Sash_of_Suppleness_UvLkklRN3FRoooyu.yml
@@ -80,7 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Scroll_of_Seven_Subtle_Serpents_mkxXuFfeLoPHCPVB.yml
+++ b/src/packs/src/srd-magic-items/Scroll_of_Seven_Subtle_Serpents_mkxXuFfeLoPHCPVB.yml
@@ -85,6 +85,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Scroll_of_the_Fortuitous_Outlook_GoDUmXhC7XgaRYij.yml
+++ b/src/packs/src/srd-magic-items/Scroll_of_the_Fortuitous_Outlook_GoDUmXhC7XgaRYij.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Scroll_of_the_Unerring_Shaft_KuEJMhkoSeyJCuDI.yml
+++ b/src/packs/src/srd-magic-items/Scroll_of_the_Unerring_Shaft_KuEJMhkoSeyJCuDI.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Seeking_2v25grBLMFBIX4wT.yml
+++ b/src/packs/src/srd-magic-items/Seeking_2v25grBLMFBIX4wT.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Shelter_XtV4EfVq6qG1grMp.yml
+++ b/src/packs/src/srd-magic-items/Shelter_XtV4EfVq6qG1grMp.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Skin_of_Your_Teeth_9wwGmszdcbaXyHTs.yml
+++ b/src/packs/src/srd-magic-items/Skin_of_Your_Teeth_9wwGmszdcbaXyHTs.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Skullcap_of_Wit_7C2mt83RVqpz619I.yml
+++ b/src/packs/src/srd-magic-items/Skullcap_of_Wit_7C2mt83RVqpz619I.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Slayer_s_Boots_lpTOgnjVMJEdZfxu.yml
+++ b/src/packs/src/srd-magic-items/Slayer_s_Boots_lpTOgnjVMJEdZfxu.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Spiked_krXRkO7WABOLOI9X.yml
+++ b/src/packs/src/srd-magic-items/Spiked_krXRkO7WABOLOI9X.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Splendor_cvpL8U22DK39ImJh.yml
+++ b/src/packs/src/srd-magic-items/Splendor_cvpL8U22DK39ImJh.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Staff_of_Dark_Karma_sx6utMwTQ3cxqaZS.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_Dark_Karma_sx6utMwTQ3cxqaZS.yml
@@ -78,7 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'epic'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Staff_of_Dark_Karma_sx6utMwTQ3cxqaZS.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_Dark_Karma_sx6utMwTQ3cxqaZS.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Staff_of_Health_xZjgHzlEkUxrM2qC.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_Health_xZjgHzlEkUxrM2qC.yml
@@ -79,7 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Staff_of_Health_xZjgHzlEkUxrM2qC.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_Health_xZjgHzlEkUxrM2qC.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Staff_of_Manipulation_duBlPFmbuMkLX2Ys.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_Manipulation_duBlPFmbuMkLX2Ys.yml
@@ -79,7 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Staff_of_Manipulation_duBlPFmbuMkLX2Ys.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_Manipulation_duBlPFmbuMkLX2Ys.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Staff_of_Massacres_6ZcXG9fV9LZ6qKTf.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_Massacres_6ZcXG9fV9LZ6qKTf.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Staff_of_Massacres_6ZcXG9fV9LZ6qKTf.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_Massacres_6ZcXG9fV9LZ6qKTf.yml
@@ -78,7 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Staff_of_the_Diffident_Magician_jYWFQPPM0suuSS89.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_the_Diffident_Magician_jYWFQPPM0suuSS89.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Staff_of_the_Diffident_Magician_jYWFQPPM0suuSS89.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_the_Diffident_Magician_jYWFQPPM0suuSS89.yml
@@ -80,7 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Staff_of_the_God_s_Riches_NTGfwzzq7ujUdQjo.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_the_God_s_Riches_NTGfwzzq7ujUdQjo.yml
@@ -79,7 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Staff_of_the_God_s_Riches_NTGfwzzq7ujUdQjo.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_the_God_s_Riches_NTGfwzzq7ujUdQjo.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Staff_of_the_Imperium_FporgUiMi60viLYg.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_the_Imperium_FporgUiMi60viLYg.yml
@@ -82,7 +82,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'epic'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Staff_of_the_Imperium_FporgUiMi60viLYg.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_the_Imperium_FporgUiMi60viLYg.yml
@@ -82,6 +82,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Staff_of_the_Uncrowned_King_P6PjIItnS1tKAtSm.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_the_Uncrowned_King_P6PjIItnS1tKAtSm.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Staff_of_the_Uncrowned_King_P6PjIItnS1tKAtSm.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_the_Uncrowned_King_P6PjIItnS1tKAtSm.yml
@@ -78,7 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Stalwart_u2Py3bV0v85hUzcl.yml
+++ b/src/packs/src/srd-magic-items/Stalwart_u2Py3bV0v85hUzcl.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Steady__Ranged_weapon__X3QW449dcOMjaQCb.yml
+++ b/src/packs/src/srd-magic-items/Steady__Ranged_weapon__X3QW449dcOMjaQCb.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Stone_Flesh_10OJxfD5NwVUmz6U.yml
+++ b/src/packs/src/srd-magic-items/Stone_Flesh_10OJxfD5NwVUmz6U.yml
@@ -76,6 +76,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Strider_Symbiote__cloak_mantle___champion_tier_item__fxMQ7hN568UaXXHg.yml
+++ b/src/packs/src/srd-magic-items/Strider_Symbiote__cloak_mantle___champion_tier_item__fxMQ7hN568UaXXHg.yml
@@ -86,7 +86,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Strider_Symbiote__cloak_mantle___champion_tier_item__fxMQ7hN568UaXXHg.yml
+++ b/src/packs/src/srd-magic-items/Strider_Symbiote__cloak_mantle___champion_tier_item__fxMQ7hN568UaXXHg.yml
@@ -86,6 +86,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Sure_Fingers_RZWwcpf2RfgqT9nb.yml
+++ b/src/packs/src/srd-magic-items/Sure_Fingers_RZWwcpf2RfgqT9nb.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Sword_of_Relentless_Glory___2_weapon__PaFwgiNT99YsFwn3.yml
+++ b/src/packs/src/srd-magic-items/Sword_of_Relentless_Glory___2_weapon__PaFwgiNT99YsFwn3.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Termination_mmhoLsaJEBJksF8E.yml
+++ b/src/packs/src/srd-magic-items/Termination_mmhoLsaJEBJksF8E.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/The_Gods_and_Goddesses__Gem_of_dNUKzANWniomZsG4.yml
+++ b/src/packs/src/srd-magic-items/The_Gods_and_Goddesses__Gem_of_dNUKzANWniomZsG4.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Thief_s_Eye_nwfbGVjMqGXoNVcI.yml
+++ b/src/packs/src/srd-magic-items/Thief_s_Eye_nwfbGVjMqGXoNVcI.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Tome_of_Arcane_Mysteries__Epic__DORrPedz0G1JvEIM.yml
+++ b/src/packs/src/srd-magic-items/Tome_of_Arcane_Mysteries__Epic__DORrPedz0G1JvEIM.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Tome_of_Arcane_Mysteries__Epic__DORrPedz0G1JvEIM.yml
+++ b/src/packs/src/srd-magic-items/Tome_of_Arcane_Mysteries__Epic__DORrPedz0G1JvEIM.yml
@@ -79,7 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'epic'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Tome_of_Misfortune__implement__g8nUFbIbGqsYsow2.yml
+++ b/src/packs/src/srd-magic-items/Tome_of_Misfortune__implement__g8nUFbIbGqsYsow2.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Tome_of_the_Divinities_and_their_Deeds_YzZ89cSh4rmo7FUb.yml
+++ b/src/packs/src/srd-magic-items/Tome_of_the_Divinities_and_their_Deeds_YzZ89cSh4rmo7FUb.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Tome_of_the_Open_Mind_WuMRnCwDuebSHYPz.yml
+++ b/src/packs/src/srd-magic-items/Tome_of_the_Open_Mind_WuMRnCwDuebSHYPz.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Totem_Kilt_ey0iNirRSygl5RrE.yml
+++ b/src/packs/src/srd-magic-items/Totem_Kilt_ey0iNirRSygl5RrE.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Totem_Kilt_ey0iNirRSygl5RrE.yml
+++ b/src/packs/src/srd-magic-items/Totem_Kilt_ey0iNirRSygl5RrE.yml
@@ -79,7 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'epic'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Treasured_Chest__wondrous_item__hv3pwNEA9Mb9Wa81.yml
+++ b/src/packs/src/srd-magic-items/Treasured_Chest__wondrous_item__hv3pwNEA9Mb9Wa81.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Twin_pNLZK9eFDuHkK6K2.yml
+++ b/src/packs/src/srd-magic-items/Twin_pNLZK9eFDuHkK6K2.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Uncanny__Epic__Im6fVrZDfkclQV6x.yml
+++ b/src/packs/src/srd-magic-items/Uncanny__Epic__Im6fVrZDfkclQV6x.yml
@@ -77,7 +77,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'epic'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Uncanny__Epic__Im6fVrZDfkclQV6x.yml
+++ b/src/packs/src/srd-magic-items/Uncanny__Epic__Im6fVrZDfkclQV6x.yml
@@ -77,6 +77,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Unfettered_Minion__Wand_of_qliKmDVSH4Rd6fkg.yml
+++ b/src/packs/src/srd-magic-items/Unfettered_Minion__Wand_of_qliKmDVSH4Rd6fkg.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Unstinting_Virtue__Melee_weapon__9Op9UpT8ItEvos9y.yml
+++ b/src/packs/src/srd-magic-items/Unstinting_Virtue__Melee_weapon__9Op9UpT8ItEvos9y.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Vanity__Melee_weapon__HPK6UneNjBeMr2vn.yml
+++ b/src/packs/src/srd-magic-items/Vanity__Melee_weapon__HPK6UneNjBeMr2vn.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Vengeance__Melee_weapon__3Sa8quAXxuEOCxe9.yml
+++ b/src/packs/src/srd-magic-items/Vengeance__Melee_weapon__3Sa8quAXxuEOCxe9.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Victory_by_Inches_Jk5A45hN30rnvEZL.yml
+++ b/src/packs/src/srd-magic-items/Victory_by_Inches_Jk5A45hN30rnvEZL.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Vitality_Pn4rgWHGYo7mcxdD.yml
+++ b/src/packs/src/srd-magic-items/Vitality_Pn4rgWHGYo7mcxdD.yml
@@ -78,7 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'epic'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Vitality_Pn4rgWHGYo7mcxdD.yml
+++ b/src/packs/src/srd-magic-items/Vitality_Pn4rgWHGYo7mcxdD.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Vulnerability_tB6vhO2HW8P5FoLG.yml
+++ b/src/packs/src/srd-magic-items/Vulnerability_tB6vhO2HW8P5FoLG.yml
@@ -77,6 +77,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Wand_of_Unerring_Pain_EZpjj8AD5ndgBf4x.yml
+++ b/src/packs/src/srd-magic-items/Wand_of_Unerring_Pain_EZpjj8AD5ndgBf4x.yml
@@ -80,6 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Wand_of_Unerring_Pain_EZpjj8AD5ndgBf4x.yml
+++ b/src/packs/src/srd-magic-items/Wand_of_Unerring_Pain_EZpjj8AD5ndgBf4x.yml
@@ -80,7 +80,7 @@ system:
     cha:
       bonus: 0
   icons: ''
-  tier: 'adventurer'
+  tier: 'champion'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Wand_of_the_Bloodless_Mage___2_implement__lL7D5tzmhIMbjq6m.yml
+++ b/src/packs/src/srd-magic-items/Wand_of_the_Bloodless_Mage___2_implement__lL7D5tzmhIMbjq6m.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Warding_m8110GWgnH0copb6.yml
+++ b/src/packs/src/srd-magic-items/Warding_m8110GWgnH0copb6.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Water_Breathing_tHDhGK1XcxaLdNJP.yml
+++ b/src/packs/src/srd-magic-items/Water_Breathing_tHDhGK1XcxaLdNJP.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Wild_Heart_2JnqRy7SnNNU6irY.yml
+++ b/src/packs/src/srd-magic-items/Wild_Heart_2JnqRy7SnNNU6irY.yml
@@ -79,6 +79,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Wing_clipper_gZdINsdvyr4OJP96.yml
+++ b/src/packs/src/srd-magic-items/Wing_clipper_gZdINsdvyr4OJP96.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Wise_Eyelet_Boots_C9iMetnbXQmnyuYg.yml
+++ b/src/packs/src/srd-magic-items/Wise_Eyelet_Boots_C9iMetnbXQmnyuYg.yml
@@ -78,6 +78,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/packs/src/srd-magic-items/Xenoteros__cloak_mantle__UhGkILf5eHoQoqKp.yml
+++ b/src/packs/src/srd-magic-items/Xenoteros__cloak_mantle__UhGkILf5eHoQoqKp.yml
@@ -84,6 +84,7 @@ system:
     cha:
       bonus: 0
   icons: ''
+  tier: 'adventurer'
   isActive: true
   price:
     value: ''

--- a/src/scss/v2/components/compendium-browser/_compendium-browser.scss
+++ b/src/scss/v2/components/compendium-browser/_compendium-browser.scss
@@ -176,7 +176,7 @@
     }
 
     .equipment-grid {
-      grid-template-columns: auto 100px 60px 60px;
+      grid-template-columns: 75px auto 100px 60px 60px;
     }
 
     .equipment-title {
@@ -184,8 +184,13 @@
       justify-content: flex-start;
     }
 
-    .equipment-bonus {
+    .equipment-tier {
       grid-column-start: 1;
+      justify-content: flex-start;
+    }
+
+    .equipment-bonus {
+      grid-column-start: 2;
       align-items: center;
       justify-content: flex-end;
 
@@ -197,15 +202,15 @@
     }
 
     .equipment-usage {
-      grid-column-start: 2;
-    }
-
-    .equipment-chakra {
       grid-column-start: 3;
     }
 
-    .equipment-recharge {
+    .equipment-chakra {
       grid-column-start: 4;
+    }
+
+    .equipment-recharge {
+      grid-column-start: 5;
     }
 
     &.creature-summary {

--- a/src/template.yaml
+++ b/src/template.yaml
@@ -799,4 +799,5 @@ Item:
       cha:
         bonus: 0
     icons: ''
+    tier: 'adventurer'
     isActive: true

--- a/src/templates/items/item-equipment-sheet.html
+++ b/src/templates/items/item-equipment-sheet.html
@@ -31,6 +31,13 @@
                     </div>
 
                     <div class="settings-group">
+                        <strong class="attribute-name">{{localize 'ARCHMAGE.CHAT.tier'}}</strong>
+                        <select name="system.tier" value="{{system.tier}}">
+                            {{selectOptions tiers selected=system.tier localize=false}}
+                        </select>
+                    </div>
+
+                    <div class="settings-group">
                         <strong class="attribute-name">{{localize 'ARCHMAGE.ITEM.icons'}}</strong>
                         <input class="attribute-name" name="system.icons" type="text" value="{{system.icons}}"
                             data-dtype="String" placeholder="Archmage" />

--- a/src/vue/components/dialogs/compendium-browser/CompendiumBrowserItems.vue
+++ b/src/vue/components/dialogs/compendium-browser/CompendiumBrowserItems.vue
@@ -92,6 +92,9 @@
             </div>
             <!-- Second row is supplemental info. -->
             <div class="grid equipment-grid">
+              <div class="equipment-tier" :data-tooltip="localize('ARCHMAGE.CHAT.tier')">
+                {{ CONFIG.ARCHMAGE.featTiers[equipment.system.tier] }}
+              </div>
               <div class="equipment-bonus flexrow" :data-tooltip="localize('ARCHMAGE.bonuses')" data-tooltip-direction="RIGHT" v-if="equipment.system.attributes">
                 <span class="bonus" v-for="(bonus, bonusProp) in getBonuses(equipment)" :key="bonusProp">
                   <span class="bonus-label">{{localizeEquipmentBonus(bonusProp)}} </span>
@@ -166,6 +169,7 @@ export default {
         { value: 'name', label: game.i18n.localize('ARCHMAGE.name') },
         { value: 'chakra', label: game.i18n.localize('ARCHMAGE.chakra') },
         { value: 'recharge', label: game.i18n.localize('ARCHMAGE.recharge') },
+        { value: 'tier', label: game.i18n.localize('ARCHMAGE.CHAT.tier') },
         { value: 'usage', label: game.i18n.localize('ARCHMAGE.GROUPS.powerUsage') },
       ],
       // Our list of pseudo documents returned from the compendium.
@@ -399,6 +403,8 @@ export default {
             return (a.system?.chackra ?? '').localeCompare((b.system?.chackra ?? ''));
           case 'usage':
             return (a.system?.powerUsage?.value ?? '').localeCompare((b.system?.powerUsage?.value ?? ''));
+          case 'tier':
+            return (a.system?.tier ?? '').localeCompare(b.system?.tier ?? '');
           case 'recharge':
             return (a.system?.recharge?.value ?? 0) - (b.system?.recharge?.value ?? 0);
         }
@@ -421,6 +427,7 @@ export default {
       'archmage.srd-magic-items',
     ], [
       'system.chackra',
+      'system.tier',
       'system.recharge.value',
       'system.powerUsage.value',
       'system.attributes.attack',

--- a/src/vue/components/dialogs/compendium-browser/CompendiumBrowserItems.vue
+++ b/src/vue/components/dialogs/compendium-browser/CompendiumBrowserItems.vue
@@ -57,6 +57,18 @@
       />
     </div>
 
+    <!-- Tier filter. -->
+    <div class="unit unit--input">
+      <h2 class="unit-title" for="compendiumBrowser.tier">{{ localize('ARCHMAGE.CHAT.tier') }}</h2>
+      <Multiselect
+        v-model="tier"
+        mode="tags"
+        :searchable="false"
+        :create-option="false"
+        :options="tierOptions"
+      />
+    </div>
+
     <!-- Usage filter. -->
     <div class="unit unit--input">
       <label class="unit-title" for="compendiumBrowser.powerUsage">{{ localize('ARCHMAGE.GROUPS.powerUsage') }}</label>
@@ -179,6 +191,7 @@ export default {
       chakra: [],
       recharge: [],
       bonuses: [],
+      tier: [],
       powerUsage: [],
     }
   },
@@ -215,6 +228,7 @@ export default {
       this.chakra = [];
       this.recharge = [];
       this.bonuses = [];
+      this.tier = [];
       this.powerUsage = [];
     },
     getBonuses(equipment) {
@@ -313,6 +327,22 @@ export default {
         }
       ]
     },
+    tierOptions() {
+      return [
+        {
+          value: 'adventurer',
+          label: 'Adventurer',
+        },
+        {
+          value: 'champion',
+          label: 'Champion',
+        },
+        {
+          value: 'epic',
+          label: 'Epic',
+        },
+      ]
+    },
     chakraSlots() {
       const result = {};
       for (let [k,v] of Object.entries(CONFIG.ARCHMAGE.chakraSlots)) {
@@ -344,6 +374,9 @@ export default {
       }
       if (Array.isArray(this.powerUsage) && this.powerUsage.length > 0) {
         result = result.filter(entry => this.powerUsage.includes(entry.system?.powerUsage?.value ?? 'other'));
+      }
+      if (Array.isArray(this.tier) && this.tier.length > 0) {
+        result = result.filter(entry => this.tier.includes(entry.system?.tier ?? 'adventurer'));
       }
 
       // Recharge.


### PR DESCRIPTION
Adds a `tier` field to the `equipment` item type, which will be useful in the compendium browser for filtering.

- [x] Add the field to `template.json` with `"adventurer"` as the default
- [x] Add UI for setting it
- [x] Update compendium items with proper values
- [x] Add the field to the compendium browser
  - [x] Display
  - [x] Sort-by
  - [x] Filter group