### PR TITLE
 feature/manualMultiAttacks

### DIFF
--- a/src/module/hooks/preCreateChatMessageHandler.mjs
+++ b/src/module/hooks/preCreateChatMessageHandler.mjs
@@ -182,7 +182,13 @@ export default class preCreateChatMessageHandler {
                 if ((type == "power" && row_text_clean.startsWith(game.i18n.localize("ARCHMAGE.CHAT.target") + ':')) ||
                     (type == "action" && row_text_clean.startsWith(game.i18n.localize("ARCHMAGE.CHAT.attack") + ':'))) {
 
-                    targets = Targeting.getTargetsFromRowText(row_text, $row_self, numTargets);
+                    // targets = Targeting.getTargetsFromRowText(row_text, $row_self, numTargets);
+                    // In case of manual rolls we may have more rolls than targets - replicate targets until we have enough.
+                    var min_targets = Targeting.getTargetsFromRowText(row_text, $row_self, numTargets);
+                    if (targets.length > 0) {
+                      while (min_targets.length < numTargets) min_targets = min_targets.concat(min_targets);
+                    }
+                    targets = min_targets.slice(0, numTargets);
 
                     if (targets.length > 0) {
                         var text = document.createTextNode(" (" + targets.map(x => x.name).join(", ") + ")");

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -471,11 +471,11 @@ export class ItemArchmage extends Item {
     // Replicate attack rolls as needed for attacks
     let numTargets = {targets: 1, rolls: []};
   if (["power", "action"].includes(itemToRender.type)) {
-      let attackLine = ArchmageRolls.addAttackMod(itemToRender);
-      itemToRender.system.attack.value = attackLine;
+      let atk = ArchmageRolls.addAttackMod(itemToRender);
+      itemToRender.system.attack.value = atk.attackLine;
       if (game.settings.get("archmage", "multiTargetAttackRolls")){
         numTargets = await ArchmageRolls.rollItemTargets(itemToRender);
-        itemToRender.system.attack.value = ArchmageRolls.rollItemAdjustAttacks(itemToRender, attackLine, numTargets);
+        itemToRender.system.attack.value = ArchmageRolls.rollItemAdjustAttacks(itemToRender, atk.attackLine, numTargets, atk.numManualAttacks);
         if (numTargets.targetLine) itemToRender.system.target.value = numTargets.targetLine;
       }
     }

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -470,7 +470,7 @@ export class ItemArchmage extends Item {
   async _rollMultiTargets(itemToRender) {
     // Replicate attack rolls as needed for attacks
     let numTargets = {targets: 1, rolls: []};
-    if (itemToRender.type == "power" || itemToRender.type == "action") {
+  if (["power", "action"].includes(itemToRender.type)) {
       let attackLine = ArchmageRolls.addAttackMod(itemToRender);
       itemToRender.system.attack.value = attackLine;
       if (game.settings.get("archmage", "multiTargetAttackRolls")){

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -466,7 +466,6 @@ export class ItemArchmage extends Item {
     return stop;
   }
 
-  // @HERE
   async _rollMultiTargets(itemToRender) {
     // Replicate attack rolls as needed for attacks
     let numTargets = {targets: 1, rolls: []};
@@ -542,7 +541,6 @@ export class ItemArchmage extends Item {
   }
 
   async _rollRender(itemUpdateData, actorUpdateData, itemToRender, rollData, token) {
-
     // Basic template rendering data
     const template = `systems/archmage/templates/chat/${this.type.toLowerCase()}-card.html`
     const templateData = {

--- a/src/module/rolls/ArchmageRolls.mjs
+++ b/src/module/rolls/ArchmageRolls.mjs
@@ -1,3 +1,5 @@
+const INLINE_ROLLS_FILTER = /(\[\[.+?\]\])/g
+
 export default class ArchmageRolls {
 
   static async rollItemTargets(item) {
@@ -90,11 +92,13 @@ export default class ArchmageRolls {
     const actor = item.actor ?? game.user.character;
     let atkMod = actor?.getRollData().atk.mod ?? 0;
     if (atkMod) {
-      let match = /(\[\[.+?\]\])/.exec(attackLine);
-      if (match) {
-        let formula = match[1];
-        let newFormula = formula.replace("]]", "+@atk.mod]]");
-        attackLine = attackLine.replace(formula, newFormula);
+      let matches = [...attackLine.matchAll(INLINE_ROLLS_FILTER)];
+      if (matches) {
+        for (let match of matches) {
+          let formula = match[1];
+          let newFormula = formula.replace("]]", " + @atk.mod]]");
+          attackLine = attackLine.replace(formula, newFormula);
+        }
       }
     }
     return attackLine;

--- a/src/module/rolls/ArchmageRolls.mjs
+++ b/src/module/rolls/ArchmageRolls.mjs
@@ -88,12 +88,14 @@ export default class ArchmageRolls {
 
   static addAttackMod(item) {
     // Add @atk.mod modifier to the first inline roll, if it isn't 0
+    let numAttacks = 0;
     let attackLine = item.system.attack.value;
     const actor = item.actor ?? game.user.character;
     let atkMod = actor?.getRollData().atk.mod ?? 0;
     if (atkMod) {
       let matches = [...attackLine.matchAll(INLINE_ROLLS_FILTER)];
       if (matches) {
+        numAttacks = matches.length;
         for (let match of matches) {
           let formula = match[1];
           let newFormula = formula.replace("]]", " + @atk.mod]]");
@@ -101,10 +103,13 @@ export default class ArchmageRolls {
         }
       }
     }
-    return attackLine;
+    return {attackLine: attackLine, numManualAttacks: numAttacks};
   }
 
-  static rollItemAdjustAttacks(item, newAttackLine, numTargets) {
+  static rollItemAdjustAttacks(item, newAttackLine, numTargets, numManualAttacks) {
+    // If the user manually defined multiple attacks, don't touch anything
+    if (numManualAttacks > 1) return newAttackLine;
+
     // If the user has targeted tokens, limit number of rolls by the lower of
     // selected targets or number listed on the power. If no targets are
     // selected, just use the number listed on the power.


### PR DESCRIPTION
- Do not apply multi-attack logic if multiple attack rolls are manually specified, just do what the user entered.
- In case of manually entered multi-attacks Round-Robin selected targets until *all* attacks have a target.
- Automatically apply actor attack modifier to *all* manually specified attack rolls, not just the first.