### PR TITLE
Add a macro for the 2e "Flaming" weapon

### DIFF
--- a/src/module/setup/macros.js
+++ b/src/module/setup/macros.js
@@ -358,7 +358,7 @@ export class ArchmageMacros {
       icon: archmage.item.img,
       changes: [{
         key: "system.attributes.weapon.melee.dice",
-        value: `+${rollData.lvl}-${rollData.atk.m.bonus}`,
+        value: `+${rollData.lvl}-${rollData.atk.m.bonus}`, // replace item bonus with level
         mode: CONST.ACTIVE_EFFECT_MODES.ADD
       }]
     };

--- a/src/module/setup/macros.js
+++ b/src/module/setup/macros.js
@@ -341,4 +341,28 @@ export class ArchmageMacros {
       archmage.suppressMessage = true;
     }
   }
+
+  ////////////////////////////////////////////////
+  /**
+   * Item Macros.
+   */
+  ////////////////////////////////////////////////
+
+  /**
+   * "Flaming" weapon (2e).
+   */
+  static async flamingWeapon(speaker, actor, token, character, archmage) {
+    const rollData = actor.getRollData();
+    const effectData = {
+      label: archmage.item.name,
+      icon: archmage.item.img,
+      changes: [{
+        key: "system.attributes.weapon.melee.dice",
+        value: `+${rollData.lvl}-${rollData.atk.m.bonus}`,
+        mode: CONST.ACTIVE_EFFECT_MODES.ADD
+      }]
+    };
+    game.archmage.MacroUtils.setDuration(effectData, CONFIG.ARCHMAGE.effectDurationTypes.EndOfCombat);
+    actor.createEmbeddedDocuments("ActiveEffect", [effectData]);
+  }
 }


### PR DESCRIPTION
The 2e flaming weapon reads:

> Instead of dealing +1 damage with this weapon, add fire damage equal to your level.

It's not possible to set the melee damage bonus to `+@lvl-@atk.m.bonus` inside an active effect using the UI, because those values aren't available when it's being evaluated.

So this patch adds a macro that can be used as an item macro, which evaluates those terms when it's run and adds an AE to do that thing.