### PR TITLE
Adjust import dialog for async text rendering

### DIFF
--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -142,7 +142,7 @@ export class ItemArchmage extends Item {
       targets: [...game.user.targets.map(t => t.document.uuid)],
       numTargets: targets,
     };
-    
+
     return await game.archmage.ArchmageUtility.createChatMessage(chatData);
   }
 
@@ -549,7 +549,7 @@ export class ItemArchmage extends Item {
       actor: this.itemActor,
       tokenId: null, //token ? `${token.scene.id}.${token.id}` : null,
       item: itemToRender,
-      data: itemToRender.getChatData({ rollData: rollData }, true),
+      data: await itemToRender.getChatData({ rollData: rollData }, true),
       usageClass: this._getUsageClass(itemToRender)
     };
 
@@ -911,11 +911,13 @@ export class ItemArchmage extends Item {
   /*  Chat Card Data
   /* -------------------------------------------- */
 
-  getChatData(htmlOptions, skipInlineRolls) {
+  async getChatData(htmlOptions, skipInlineRolls) {
     const data = this[`_${this.type}ChatData`]();
     if (!skipInlineRolls) {
       htmlOptions = foundry.utils.mergeObject(htmlOptions ?? {}, { async: false});
-      data.description.value = data.description.value !== undefined ? TextEditor.enrichHTML(data.description.value, htmlOptions) : '';
+      data.description.value = data.description.value !== undefined
+        ? (await TextEditor.enrichHTML(data.description.value, htmlOptions))
+        : '';
     }
     return data;
   }


### PR DESCRIPTION
Found a visual glitch in the power importer:

![image](https://github.com/user-attachments/assets/37905b44-dee5-48ab-b730-1f656bddb680)

Turns out this is an artifact of `TextEditor.enrichHTML` going async, so we just have to await it through like 3 levels of calls. Before:

![image](https://github.com/user-attachments/assets/1b7311fd-0c9c-4c00-b036-e2d6567832f2)

After:

![CleanShot 2024-10-06 at 10 24 17](https://github.com/user-attachments/assets/6db57342-c742-4421-b86d-503d4259b150)
