### PR TITLE
Fix parsing of multi-attack actions

### DIFF
--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -474,7 +474,9 @@ export class ItemArchmage extends Item {
       itemToRender.system.attack.value = atk.attackLine;
       if (game.settings.get("archmage", "multiTargetAttackRolls")){
         numTargets = await ArchmageRolls.rollItemTargets(itemToRender);
-        itemToRender.system.attack.value = ArchmageRolls.rollItemAdjustAttacks(itemToRender, atk.attackLine, numTargets, atk.numManualAttacks);
+        let adj = ArchmageRolls.rollItemAdjustAttacks(itemToRender, atk.attackLine, numTargets, atk.numManualAttacks);
+        itemToRender.system.attack.value = adj.line;
+        numTargets.targets = adj.atks;
         if (numTargets.targetLine) itemToRender.system.target.value = numTargets.targetLine;
       }
     }

--- a/src/module/rolls/ArchmageRolls.mjs
+++ b/src/module/rolls/ArchmageRolls.mjs
@@ -1,4 +1,4 @@
-const INLINE_ROLLS_FILTER = /(\[\[.+?\]\])/g
+const INLINE_ATTACK_ROLLS_FILTER = /(\[\[.*?d20.+?\]\])/g
 
 export default class ArchmageRolls {
 
@@ -91,7 +91,7 @@ export default class ArchmageRolls {
     let numAttacks = 0;
     let attackLine = item.system.attack.value;
     const actor = item.actor ?? game.user.character;
-    let matches = [...attackLine.matchAll(INLINE_ROLLS_FILTER)];
+    let matches = [...attackLine.matchAll(INLINE_ATTACK_ROLLS_FILTER)];
     if (matches) {
       numAttacks = matches.length;
       let atkMod = actor?.getRollData().atk.mod ?? 0;

--- a/src/module/rolls/ArchmageRolls.mjs
+++ b/src/module/rolls/ArchmageRolls.mjs
@@ -108,7 +108,7 @@ export default class ArchmageRolls {
 
   static rollItemAdjustAttacks(item, newAttackLine, numTargets, numManualAttacks) {
     // If the user manually defined multiple attacks, don't touch anything
-    if (numManualAttacks > 1) return newAttackLine;
+    if (numManualAttacks > 1) return {line: newAttackLine, atks: numManualAttacks};
 
     // If the user has targeted tokens, limit number of rolls by the lower of
     // selected targets or number listed on the power. If no targets are
@@ -142,7 +142,7 @@ export default class ArchmageRolls {
       }
       newAttackLine += " " + vs;
     }
-    return newAttackLine;
+    return {line: newAttackLine, atks: targetsCount};
   }
 
   static _handleCrescendo(newAttackLine) {


### PR DESCRIPTION
- Fix multi-attack actions being wrongly interpreted as manually entered multi-attacks when defining the number of targets with an inline roll
- Fix number of rolls generated and targets selected edge cases