### PR TITLE
Add sequencer support to the AppV2 item sheet

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -694,6 +694,7 @@ ARCHMAGE:
     removeEffect: Remove Effect
     Rest: Rest
     Rests: Rests
+    sequencer: Sequencer
     sequencerDesc: Configure a sequencer animation.
     sequencerTarget: Sequencer File (Target)
     sequencerRay: Sequencer File (Ray)

--- a/src/module/item/action-sheet-v2.js
+++ b/src/module/item/action-sheet-v2.js
@@ -78,6 +78,8 @@ export class ArchmageActionSheetV2 extends VueRenderingMixin(ArchmageBaseItemShe
       rollData: this.actor?.getRollData() ?? {},
       // Adding a pointer to CONFIG.ARCHMAGE
       config: CONFIG.ARCHMAGE,
+      // Sequencer (module) support.
+      sequencerEnabled: game.modules.get("sequencer")?.active,
       // Force re-renders. Defined in the vue mixin.
       _renderKey: this._renderKey ?? 0,
       // @todo add this after switching to DataModel

--- a/src/module/item/power-sheet-v2.js
+++ b/src/module/item/power-sheet-v2.js
@@ -68,6 +68,7 @@ export class ArchmagePowerSheetV2 extends VueRenderingMixin(ArchmageBaseItemShee
 
   /** @override */
   async _prepareContext(options) {
+
     const context = {
       // Validates both permissions and compendium status
       editable: this.isEditable,
@@ -83,6 +84,8 @@ export class ArchmagePowerSheetV2 extends VueRenderingMixin(ArchmageBaseItemShee
       rollData: this.actor?.getRollData() ?? {},
       // Adding a pointer to CONFIG.ARCHMAGE
       config: CONFIG.ARCHMAGE,
+      // Sequencer (module) support.
+      sequencerEnabled: game.modules.get("sequencer")?.active,
       // Add tabs:
       tabs: {
         primary: {

--- a/src/template.yaml
+++ b/src/template.yaml
@@ -519,11 +519,18 @@ Item:
         type: String
         label: Embedded Macro
         value: ''
+    supportsSequencer:
+      sequencer:
+        ray: ''
+        self: ''
+        target: ''
+        reversed: false
   power:
     templates:
       - standard
       - usable
       - supportsMacro
+      - supportsSequencer
     group:
       type: String
       label: Group
@@ -707,6 +714,7 @@ Item:
     templates:
       - standard
       - supportsMacro
+      - supportsSequencer
     group:
       type: String
       label: Group

--- a/src/vue/components/item/action/ActionDetails.vue
+++ b/src/vue/components/item/action/ActionDetails.vue
@@ -60,6 +60,51 @@
       </div>
     </div>
   </fieldset>
+
+  <fieldset class="fieldset-sequencer" v-if="context.sequencerEnabled">
+    <legend>{{ game.i18n.localize('ARCHMAGE.CHAT.sequencer') }}</legend>
+    <p class="hint">{{ game.i18n.localize('ARCHMAGE.CHAT.sequencerDesc') }}</p>
+
+    <div class="form-group stacked">
+      <label>{{game.i18n.localize('ARCHMAGE.CHAT.sequencerSelf')}}</label>
+      <div class="field">
+        <input type="text" name="system.sequencer.self"
+          v-model="item.system.sequencer.self"
+          placeholder="Ex: modules/JB2A_DnD5e/Library/Generic/UI/IconSnowflake_01_Regular_Blue_200x200.webm"
+        />
+      </div>
+    </div>
+
+    <div class="form-group stacked">
+      <label>{{game.i18n.localize('ARCHMAGE.CHAT.sequencerRay')}}</label>
+      <div class="field">
+        <input type="text" name="system.sequencer.ray"
+          v-model="item.system.sequencer.ray"
+          placeholder="Ex: modules/JB2A_DnD5e/Library/Cantrip/Ray_Of_Frost/RayOfFrost_01_Regular_Blue_30ft_1600x400.webm"
+        />
+      </div>
+    </div>
+
+    <div class="form-group stacked">
+      <label>{{game.i18n.localize('ARCHMAGE.CHAT.sequencerTarget')}}</label>
+      <div class="field">
+        <input type="text" name="system.sequencer.target"
+          v-model="item.system.sequencer.target"
+          placeholder="Ex: modules/JB2A_DnD5e/Library/Generic/Explosion/Explosion_04_Regular_Blue_400x400.webm"
+        />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>{{game.i18n.localize('ARCHMAGE.CHAT.sequencerReverse')}}</label>
+      <div class="field">
+        <input type="checkbox" name="system.sequencer.reversed"
+          v-model="item.system.sequencer.reversed"
+        />
+      </div>
+    </div>
+  </fieldset>
+
 </template>
 
 <script setup>

--- a/src/vue/components/item/power/PowerDetails.vue
+++ b/src/vue/components/item/power/PowerDetails.vue
@@ -181,6 +181,50 @@
       </div>
     </div>
   </fieldset>
+
+  <fieldset class="fieldset-sequencer" v-if="context.sequencerEnabled">
+    <legend>{{ game.i18n.localize('ARCHMAGE.CHAT.sequencer') }}</legend>
+    <p class="hint">{{ game.i18n.localize('ARCHMAGE.CHAT.sequencerDesc') }}</p>
+
+    <div class="form-group stacked">
+      <label>{{game.i18n.localize('ARCHMAGE.CHAT.sequencerSelf')}}</label>
+      <div class="field">
+        <input type="text" name="system.sequencer.self"
+          v-model="item.system.sequencer.self"
+          placeholder="Ex: modules/JB2A_DnD5e/Library/Generic/UI/IconSnowflake_01_Regular_Blue_200x200.webm"
+        />
+      </div>
+    </div>
+
+    <div class="form-group stacked">
+      <label>{{game.i18n.localize('ARCHMAGE.CHAT.sequencerRay')}}</label>
+      <div class="field">
+        <input type="text" name="system.sequencer.ray"
+          v-model="item.system.sequencer.ray"
+          placeholder="Ex: modules/JB2A_DnD5e/Library/Cantrip/Ray_Of_Frost/RayOfFrost_01_Regular_Blue_30ft_1600x400.webm"
+        />
+      </div>
+    </div>
+
+    <div class="form-group stacked">
+      <label>{{game.i18n.localize('ARCHMAGE.CHAT.sequencerTarget')}}</label>
+      <div class="field">
+        <input type="text" name="system.sequencer.target"
+          v-model="item.system.sequencer.target"
+          placeholder="Ex: modules/JB2A_DnD5e/Library/Generic/Explosion/Explosion_04_Regular_Blue_400x400.webm"
+        />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>{{game.i18n.localize('ARCHMAGE.CHAT.sequencerReverse')}}</label>
+      <div class="field">
+        <input type="checkbox" name="system.sequencer.reversed"
+          v-model="item.system.sequencer.reversed"
+        />
+      </div>
+    </div>
+  </fieldset>
 </template>
 
 <script setup>


### PR DESCRIPTION
- Adds a new `supportsSequencer` template to `template.yaml` so that actions and powers can have a consistent sequencer data structure.
- Adds sequencer fields to the Action and Power appV2 sheets.