### PR TITLE
Fix paste bug

### DIFF
--- a/src/module/setup/utility-classes.js
+++ b/src/module/setup/utility-classes.js
@@ -533,7 +533,8 @@ export class ArchmageUtility {
       options.damage = true;
     }
     // Remove unnecessary newlines common to PDFs.
-    let parsedText = pastedText.replace(/[\r\n][^\.]/g, ' ');
+    let parsedText = pastedText.replace(/-[\r\n]+([^.])/g, '-$1'); // Hyphens get collapsed
+    parsedText = pastedText.replace(/[\r\n]+([^.])/g, ' $1'); // Other newlines get replaced with spaces
     // Do a pass to turn rolls like "Natural 16+" or "Easy Save, 6+" into
     // "Natural __16__" and "Easy Save, __6__". It's messy, but it
     // prevents false positives in later steps.


### PR DESCRIPTION
This fixes the bug with parse-on-paste that would remove the first character of the joined line, and enhances it to handle end-of-line hyphens better.

Original text copied from the PDF:

```
More dangerous zombies
preferentially attack any hero that has been
knocked unconscious, attacking or coup-de-
grace-ing them until they’re dead (brains
eaten). If you want to teach your players how
to use the “retreat” rules. . . .
```

Result before:

> More dangerous zombies referentially attack any hero that has been nocked *unconscious*, attacking or coup-de- race-ing them until they’re *dead* (brains aten). If you want to teach your players how o use the “retreat” rules. . . .

Note `nocked` and `race` and `aten`, etc.

Result after:

> More dangerous zombies preferentially attack any hero that has been knocked *unconscious*, attacking or coup-de-grace-ing them until they’re *dead* (brains eaten). If you want to teach your players how to use the “retreat” rules. . . .