### PR TITLE
Release 1.32.0

### DIFF
--- a/release-notes/1.32.0.md
+++ b/release-notes/1.32.0.md
@@ -18,12 +18,12 @@ All new, Vue-based, *much* better looking (and better organized) sheets for powe
 - a `hide` flag for each power level to avoid printing lower-level bonuses in chat for powers that don't require it (e.g. most damaging spells - these are now pre-set in powers that ship with the system),
 - a `critMod` field (with inline roll support) for custom crit modifiers, such as 2e dragon breaths adding Stoke (NPCs) or the E.D. (PCs) to crit range.
 
-[screenshot]
+![Screenshot of new item sheets](https://mattsmithin-files.s3.us-east-1.amazonaws.com/screenshots/new-item-sheets.png)
 
 ## Embedded Active Effects in Items
 PC powers, NPC actions, and other kinds of items now allow you to define Active Effects that are rendered at the bottom of their chat card. When these effects are rendered to the chat card, you can drag them on top of tokens (if you have permission to drop stuff on the canvas, e.g. you're the GM) or your own character sheet. This, in conjunction with the recently implemented (and expanded) AE durations allows users to automate a large number of temporary bonuses. We also included a bunch of pre-made AEs on character powers and consumables that benefit from this new feature.
 
-[screenshot]
+![Screenshot of active effects tab](https://mattsmithin-files.s3.us-east-1.amazonaws.com/screenshots/active-effect-tab.png)
 
 ## Stoked for Custom Resources for NPCs
 NPC actors now support custom resources and related inline rolls short-hands just like characters. In addition, we implemented a `Stoke` custom resource for 2e dragons that automatically increments each round. This can then be tied into the new `critMod` field on NPC actions to automate crit range increases for dragon breath.
@@ -37,7 +37,7 @@ This feature can also be applied to an entire power/action sheet by clicking the
 
 Finally, this feature was intended to work with the text as the book presents it. For example, if you paste `Strength + Level vs. AC` into an attack line, it will assume the `vs. AC` part means you actually want `[[d20+@str.mod+@std]] vs. AC`. If something doesn't paste cleanly from the book, let us know!
 
-[screenshot]
+![Screenshot of the dice parser](https://mattsmithin-files.s3.us-east-1.amazonaws.com/screenshots/paste-parsing.png)
 
 ## Other Additions:
 - Added option on the apply effect dialog to set ongoing damage to half its damage (such as with resistance) or note that it was a crit. Halving it will reduce the ongoing damage in half when creating the effect, while setting it as a crit will only double it the first time it's applied to the actor.
@@ -65,8 +65,6 @@ Finally, this feature was intended to work with the text as the book presents it
 - Added support for flashing dynamic token rings: red when damaged or green when healed.
 - Increased options in disengage dialog to range from +2 to -9.
 
-[screenshot]
-
 ## Bug Fixes
 - Updated active effect sheet to not close when changes are submitted, which caused some UX annoyances. Also updated it to submit on change.
 - Updated active effect sheet to save durations.
@@ -92,7 +90,7 @@ Finally, this feature was intended to work with the text as the book presents it
 
 ## Changelog
 
-Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.31.0...6a71a82dae580e2013ca3b73ba62ed3780fcceb1
+Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.31.0...1.32.0
 
 ## Contributors
 

--- a/release-notes/1.32.0.md
+++ b/release-notes/1.32.0.md
@@ -6,7 +6,7 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.32.0/syste
 
 ![Foundry v12.331](https://img.shields.io/badge/Foundry-v12.331-green)
 
-**Note**: This release *requires Foundry v12.
+**Note**: This release *requires* Foundry v12.
 
 This is a *very* large release, with lots of additions big and small.
 
@@ -26,7 +26,7 @@ PC powers, NPC actions, and other kinds of items now allow you to define Active 
 [screenshot]
 
 ## Stoked for Custom Resources for NPCs
-NPC actors now support custom resources and related inline rolls short-hands just like characters. In addition, we implemented a `Stoke` custom resource for 2e dragons that automatically increments each round. This can then be tied into the new `critMod` field on NPC actions (see "New Item Sheets" below) to automate crit range increases for dragon breath.
+NPC actors now support custom resources and related inline rolls short-hands just like characters. In addition, we implemented a `Stoke` custom resource for 2e dragons that automatically increments each round. This can then be tied into the new `critMod` field on NPC actions to automate crit range increases for dragon breath.
 
 ## Regex Parsing on Paste
 ⚠️ EXPERIMENTAL ⚠️
@@ -39,7 +39,7 @@ Finally, this feature was intended to work with the text as the book presents it
 
 [screenshot]
 
-## Minor Additions:
+## Other Additions:
 - Added option on the apply effect dialog to set ongoing damage to half its damage (such as with resistance) or note that it was a crit. Halving it will reduce the ongoing damage in half when creating the effect, while setting it as a crit will only double it the first time it's applied to the actor.
 - Added a `CONFIG.ARCHMAGE.is2e` constant based on the secondEdition system setting that's initialized during the ready hook.
 - Updated both the character and NPC sheets to use container queries, allowing them to scale down to much smaller sizes. This is mostly useful for scaling down character sheets to smaller sizes within Foundry, but if you combine it with the Sheet Only module, you can have pretty decent support for running a sheet on mobile devices. The new breakpoints are essentially:

--- a/release-notes/1.32.0.md
+++ b/release-notes/1.32.0.md
@@ -1,0 +1,99 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.32.0/system.json
+
+## Compatible Foundry versions
+
+![Foundry v12.331](https://img.shields.io/badge/Foundry-v12.331-green)
+
+**Note**: This release *requires Foundry v12.
+
+This is a *very* large release, with lots of additions big and small.
+
+## Improved Gamma Packet Support
+This release implements a number of behind-the-scenes changes to support the upcoming 13th Age 2nd edition gamma backer module, and in particular integrates it into the power importer and compendium browser. Keep an eye out for updates to that project soon if you were a backer!
+
+## New Item Sheets
+All new, Vue-based, *much* better looking (and better organized) sheets for powers and actions. These also include new fields:
+- a `hide` flag for each power level to avoid printing lower-level bonuses in chat for powers that don't require it (e.g. most damaging spells - these are now pre-set in powers that ship with the system),
+- a `critMod` field (with inline roll support) for custom crit modifiers, such as 2e dragon breaths adding Stoke (NPCs) or the E.D. (PCs) to crit range.
+
+[screenshot]
+
+## Embedded Active Effects in Items
+PC powers, NPC actions, and other kinds of items now allow you to define Active Effects that are rendered at the bottom of their chat card. When these effects are rendered to the chat card, you can drag them on top of tokens (if you have permission to drop stuff on the canvas, e.g. you're the GM) or your own character sheet. This, in conjunction with the recently implemented (and expanded) AE durations allows users to automate a large number of temporary bonuses. We also included a bunch of pre-made AEs on character powers and consumables that benefit from this new feature.
+
+[screenshot]
+
+## Stoked for Custom Resources for NPCs
+NPC actors now support custom resources and related inline rolls short-hands just like characters. In addition, we implemented a `Stoke` custom resource for 2e dragons that automatically increments each round. This can then be tied into the new `critMod` field on NPC actions (see "New Item Sheets" below) to automate crit range increases for dragon breath.
+
+## Regex Parsing on Paste
+⚠️ EXPERIMENTAL ⚠️
+
+The system now includes an optional (disabled by default) feature to try and automatically parse text for inline rolls when you paste it into fields on the power and action sheets. The reason it's disabled by default is that parsing text automatically is one of the harder things to do reliably, so go ahead and try out the paste parser feature if you want to, but be sure to report any bugs you find. If you do turn it on, you can skip the paste parsing by holding `shift` on your keyboard while pasting into a field.
+
+This feature can also be applied to an entire power/action sheet by clicking the 3 dots in the sheet's title bar and clicking the "Parse Dice Rolls" action.
+
+Finally, this feature was intended to work with the text as the book presents it. For example, if you paste `Strength + Level vs. AC` into an attack line, it will assume the `vs. AC` part means you actually want `[[d20+@str.mod+@std]] vs. AC`. If something doesn't paste cleanly from the book, let us know!
+
+[screenshot]
+
+## Minor Additions:
+- Added option on the apply effect dialog to set ongoing damage to half its damage (such as with resistance) or note that it was a crit. Halving it will reduce the ongoing damage in half when creating the effect, while setting it as a crit will only double it the first time it's applied to the actor.
+- Added a `CONFIG.ARCHMAGE.is2e` constant based on the secondEdition system setting that's initialized during the ready hook.
+- Updated both the character and NPC sheets to use container queries, allowing them to scale down to much smaller sizes. This is mostly useful for scaling down character sheets to smaller sizes within Foundry, but if you combine it with the Sheet Only module, you can have pretty decent support for running a sheet on mobile devices. The new breakpoints are essentially:
+    - 1024px or less (width): Scale down a few problem areas like attributes, but keep the layout mostly the same.
+    - 600px or less (height): Make the sheet itself scrollable rather than having nested scrolling regions (backgrounds and powers).
+    - 600px or less (width): Completely reflows the layout of the sheet to a more mobile-friendly design.
+- Added 1/4x multiplier option to damage applicator context menu
+- Updated icon rolls logic to be more 2e compliant: 5s and 6s are both just benefits (+), can set certainly complicated advantages (~)
+- Added a new per-client setting to display the natural d20 roll next to each attack roll.
+- Improved formatting of NPC sheet headers (size, type, role, etc.) to better match the Gamma packet format.
+- Moved grabbed from the extended conditions list to the standard conditions list and added journal entries for it.
+- Added `@skulls` to character roll data.
+- Added support for negative ongoing damage (a.k.a. healing)
+- Added new `EndofArc` AE duration for the rare effects that last until the next full heal up
+- Added new `EndOfRound` AE duration
+- Added new `Recharge/Desperate` usage pattern for powers and equipment (for that *one* 2e feat that requires it...)
+- Added a `tier` field to the equipment item type, which is useful in the compendium browser for filtering
+- Support manually-entered multi attack: if a power or action has multiple attack rolls defined, the system will disable its own logic and do exactly what the user entered.
+    - In case of manually entered multi-attacks Round-Robin selected targets until all attacks have a target - useful for e.g. the 2e Two-Weapon Technique or certain monster attacks
+- Add publication source to monsters along with a filter for it on the Compendium Browser.
+- Added striped overlay for powers with 0 uses remaining to better indicate they have no uses remaining.
+- Added an initiative bonus field to the active effects sheet.
+- Added support for flashing dynamic token rings: red when damaged or green when healed.
+- Increased options in disengage dialog to range from +2 to -9.
+
+[screenshot]
+
+## Bug Fixes
+- Updated active effect sheet to not close when changes are submitted, which caused some UX annoyances. Also updated it to submit on change.
+- Updated active effect sheet to save durations.
+- Minor styling improvements for the description field on the effect sheet.
+- Fixed bug in Firefox where the NPC details field group (size, initiative, type, etc.) collapsed every time you changed it.
+- Fixed a bug in all browsers where you couldn't always reopen the details field group after closing it.
+- Fixed a bug where character powers and NPC actions were being created with the wrong type due to an old reference to data instead of system.
+- Fixed a bug where dropping a hampered effect on an actor with the 2e setting enabled would cause a fatal error.
+- Fixed a bug where dropping a built-in condition on an actor would create a similar effect rather than the actual condition status.
+- Fixed high level recovery incremental adding wrong values.
+- Updated implacable flag naming for 2e.
+- Fixed parsing of expanded inline rolls in damage applicator only extracting the first number instead of the total.
+- Fixed light system macro not working in Foundry v12.
+- Fixed a bug that prevented items from being rollable if their embedded macro included invalid JavaScript.
+- Fixed the deny ED AE flag not being persisted.
+- Fixed `@ed` and `@std` AE overrides non being applied correctly.
+- Fixed a v12 compatibility issue that prevented animated dice from working and outcomes to be saved to the actor for saves, Icon rolls, and Command Point rolls.
+- Fixed a large number of deprecation warnings.
+- Fixed AE durations not having additional data applied in certain situations (fixes `StartOfNextSourceTurn` and `EndOfNextSourceTurn` durations).
+- Apply actor attack modifier to all manually specified attack rolls, not just the first.
+- Added missing entry in weapon rune rolltable.
+- Adjusted import dialog for async text rendering.
+
+## Changelog
+
+Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.31.0...6a71a82dae580e2013ca3b73ba62ed3780fcceb1
+
+## Contributors
+
+legofed3, ben, and asacolips

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -1,7 +1,7 @@
 name: archmage
 id: archmage
 title: 13th Age
-version: "1.31.0"
+version: "1.32.0"
 authors:
   - name: Matt Smith
     discord: asacolips
@@ -279,7 +279,7 @@ languages:
 socket: true
 url: https://github.com/asacolips-projects/13th-age
 manifest: https://asacolips-artifacts.s3.amazonaws.com/archmage/latest/system.json
-download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.31.0/archmage.zip
+download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.32.0/archmage.zip
 changelog: https://github.com/asacolips-projects/13th-age/releases
 initiative: 1d20 + (@abilities?.dex.mod || 0) + @attributes.init.value + @attributes.level.value
 grid:

--- a/src/vue/components/dialogs/compendium-browser/CompendiumBrowserCreatures.vue
+++ b/src/vue/components/dialogs/compendium-browser/CompendiumBrowserCreatures.vue
@@ -312,10 +312,10 @@ export default {
   async created() {
     console.log("Creating compendium browser creatures tab...");
 
-    const packIds = game.modules.get('13th-age-core-2e')?.active ? [
+    const packIds = game.modules.get('13th-age-core-2e-gamma')?.active ? [
       'archmage.srd-Monsters',
-      '13th-age-core-2e.monsters-2e',
-      '13th-age-core-2e.companions-2e',
+      '13th-age-core-2e-gamma.monsters-2e',
+      '13th-age-core-2e-gamma.companions-2e',
       'archmage.necromancer-summons',
     ] : [
       'archmage.srd-Monsters',

--- a/src/vue/components/dialogs/compendium-browser/CompendiumBrowserItems.vue
+++ b/src/vue/components/dialogs/compendium-browser/CompendiumBrowserItems.vue
@@ -456,8 +456,8 @@ export default {
     console.log("Creating compendium browser magic items tab...");
 
     const packIds = [
-      game.modules.get('13th-age-core-2e')?.active
-        ? '13th-age-core-2e.magic-items-2e'
+      game.modules.get('13th-age-core-2e-gamma')?.active
+        ? '13th-age-core-2e-gamma.magic-items-2e'
         : 'archmage.srd-magic-items'
     ];
 

--- a/src/vue/components/dialogs/compendium-browser/CompendiumBrowserPowers.vue
+++ b/src/vue/components/dialogs/compendium-browser/CompendiumBrowserPowers.vue
@@ -353,18 +353,18 @@ export default {
   async created() {
     console.log("Creating compendium browser powers tab...");
     // Handle packs.
-    const packIds = game.modules.get('13th-age-core-2e')?.active ? [
-      '13th-age-core-2e.barbarian-2e',
-      '13th-age-core-2e.bard-2e',
-      '13th-age-core-2e.cleric-2e',
-      '13th-age-core-2e.fighter-2e',
-      '13th-age-core-2e.paladin-2e',
-      '13th-age-core-2e.ranger-2e',
-      '13th-age-core-2e.rogue-2e',
-      '13th-age-core-2e.sorcerer-2e',
-      '13th-age-core-2e.wizard-2e',
-      '13th-age-core-2e.kin-powers-2e',
-      '13th-age-core-2e.universal-feats-2e',
+    const packIds = game.modules.get('13th-age-core-2e-gamma')?.active ? [
+      '13th-age-core-2e-gamma.barbarian-2e',
+      '13th-age-core-2e-gamma.bard-2e',
+      '13th-age-core-2e-gamma.cleric-2e',
+      '13th-age-core-2e-gamma.fighter-2e',
+      '13th-age-core-2e-gamma.paladin-2e',
+      '13th-age-core-2e-gamma.ranger-2e',
+      '13th-age-core-2e-gamma.rogue-2e',
+      '13th-age-core-2e-gamma.sorcerer-2e',
+      '13th-age-core-2e-gamma.wizard-2e',
+      '13th-age-core-2e-gamma.kin-powers-2e',
+      '13th-age-core-2e-gamma.universal-feats-2e',
       'archmage.chaosmage',
       'archmage.commander',
       'archmage.druid',


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.32.0/system.json

## Compatible Foundry versions

![Foundry v12.331](https://img.shields.io/badge/Foundry-v12.331-green)

**Note**: This release *requires* Foundry v12.

This is a *very* large release, with lots of additions big and small.

## Improved Gamma Packet Support
This release implements a number of behind-the-scenes changes to support the upcoming 13th Age 2nd edition gamma backer module, and in particular integrates it into the power importer and compendium browser. Keep an eye out for updates to that project soon if you were a backer!

## New Item Sheets
All new, Vue-based, *much* better looking (and better organized) sheets for powers and actions. These also include new fields:
- a `hide` flag for each power level to avoid printing lower-level bonuses in chat for powers that don't require it (e.g. most damaging spells - these are now pre-set in powers that ship with the system),
- a `critMod` field (with inline roll support) for custom crit modifiers, such as 2e dragon breaths adding Stoke (NPCs) or the E.D. (PCs) to crit range.

![Screenshot of new item sheets](https://mattsmithin-files.s3.us-east-1.amazonaws.com/screenshots/new-item-sheets.png)

## Embedded Active Effects in Items
PC powers, NPC actions, and other kinds of items now allow you to define Active Effects that are rendered at the bottom of their chat card. When these effects are rendered to the chat card, you can drag them on top of tokens (if you have permission to drop stuff on the canvas, e.g. you're the GM) or your own character sheet. This, in conjunction with the recently implemented (and expanded) AE durations allows users to automate a large number of temporary bonuses. We also included a bunch of pre-made AEs on character powers and consumables that benefit from this new feature.

![Screenshot of active effects tab](https://mattsmithin-files.s3.us-east-1.amazonaws.com/screenshots/active-effect-tab.png)

## Stoked for Custom Resources for NPCs
NPC actors now support custom resources and related inline rolls short-hands just like characters. In addition, we implemented a `Stoke` custom resource for 2e dragons that automatically increments each round. This can then be tied into the new `critMod` field on NPC actions to automate crit range increases for dragon breath.

## Regex Parsing on Paste
⚠️ EXPERIMENTAL ⚠️

The system now includes an optional (disabled by default) feature to try and automatically parse text for inline rolls when you paste it into fields on the power and action sheets. The reason it's disabled by default is that parsing text automatically is one of the harder things to do reliably, so go ahead and try out the paste parser feature if you want to, but be sure to report any bugs you find. If you do turn it on, you can skip the paste parsing by holding `shift` on your keyboard while pasting into a field.

This feature can also be applied to an entire power/action sheet by clicking the 3 dots in the sheet's title bar and clicking the "Parse Dice Rolls" action.

Finally, this feature was intended to work with the text as the book presents it. For example, if you paste `Strength + Level vs. AC` into an attack line, it will assume the `vs. AC` part means you actually want `[[d20+@str.mod+@std]] vs. AC`. If something doesn't paste cleanly from the book, let us know!

![Screenshot of the dice parser](https://mattsmithin-files.s3.us-east-1.amazonaws.com/screenshots/paste-parsing.png)

## Other Additions:
- Added option on the apply effect dialog to set ongoing damage to half its damage (such as with resistance) or note that it was a crit. Halving it will reduce the ongoing damage in half when creating the effect, while setting it as a crit will only double it the first time it's applied to the actor.
- Added a `CONFIG.ARCHMAGE.is2e` constant based on the secondEdition system setting that's initialized during the ready hook.
- Updated both the character and NPC sheets to use container queries, allowing them to scale down to much smaller sizes. This is mostly useful for scaling down character sheets to smaller sizes within Foundry, but if you combine it with the Sheet Only module, you can have pretty decent support for running a sheet on mobile devices. The new breakpoints are essentially:
    - 1024px or less (width): Scale down a few problem areas like attributes, but keep the layout mostly the same.
    - 600px or less (height): Make the sheet itself scrollable rather than having nested scrolling regions (backgrounds and powers).
    - 600px or less (width): Completely reflows the layout of the sheet to a more mobile-friendly design.
- Added 1/4x multiplier option to damage applicator context menu
- Updated icon rolls logic to be more 2e compliant: 5s and 6s are both just benefits (+), can set certainly complicated advantages (~)
- Added a new per-client setting to display the natural d20 roll next to each attack roll.
- Improved formatting of NPC sheet headers (size, type, role, etc.) to better match the Gamma packet format.
- Moved grabbed from the extended conditions list to the standard conditions list and added journal entries for it.
- Added `@skulls` to character roll data.
- Added support for negative ongoing damage (a.k.a. healing)
- Added new `EndofArc` AE duration for the rare effects that last until the next full heal up
- Added new `EndOfRound` AE duration
- Added new `Recharge/Desperate` usage pattern for powers and equipment (for that *one* 2e feat that requires it...)
- Added a `tier` field to the equipment item type, which is useful in the compendium browser for filtering
- Support manually-entered multi attack: if a power or action has multiple attack rolls defined, the system will disable its own logic and do exactly what the user entered.
    - In case of manually entered multi-attacks Round-Robin selected targets until all attacks have a target - useful for e.g. the 2e Two-Weapon Technique or certain monster attacks
- Add publication source to monsters along with a filter for it on the Compendium Browser.
- Added striped overlay for powers with 0 uses remaining to better indicate they have no uses remaining.
- Added an initiative bonus field to the active effects sheet.
- Added support for flashing dynamic token rings: red when damaged or green when healed.
- Increased options in disengage dialog to range from +2 to -9.

## Bug Fixes
- Updated active effect sheet to not close when changes are submitted, which caused some UX annoyances. Also updated it to submit on change.
- Updated active effect sheet to save durations.
- Minor styling improvements for the description field on the effect sheet.
- Fixed bug in Firefox where the NPC details field group (size, initiative, type, etc.) collapsed every time you changed it.
- Fixed a bug in all browsers where you couldn't always reopen the details field group after closing it.
- Fixed a bug where character powers and NPC actions were being created with the wrong type due to an old reference to data instead of system.
- Fixed a bug where dropping a hampered effect on an actor with the 2e setting enabled would cause a fatal error.
- Fixed a bug where dropping a built-in condition on an actor would create a similar effect rather than the actual condition status.
- Fixed high level recovery incremental adding wrong values.
- Updated implacable flag naming for 2e.
- Fixed parsing of expanded inline rolls in damage applicator only extracting the first number instead of the total.
- Fixed light system macro not working in Foundry v12.
- Fixed a bug that prevented items from being rollable if their embedded macro included invalid JavaScript.
- Fixed the deny ED AE flag not being persisted.
- Fixed `@ed` and `@std` AE overrides non being applied correctly.
- Fixed a v12 compatibility issue that prevented animated dice from working and outcomes to be saved to the actor for saves, Icon rolls, and Command Point rolls.
- Fixed a large number of deprecation warnings.
- Fixed AE durations not having additional data applied in certain situations (fixes `StartOfNextSourceTurn` and `EndOfNextSourceTurn` durations).
- Apply actor attack modifier to all manually specified attack rolls, not just the first.
- Added missing entry in weapon rune rolltable.
- Adjusted import dialog for async text rendering.

## Changelog

Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.31.0...1.32.0

## Contributors

legofed3, ben, and asacolips
