### PR TITLE
Fix issue with monster art when the PF2e token module isn't enabled

### DIFF
--- a/src/module/setup/register-module-art.js
+++ b/src/module/setup/register-module-art.js
@@ -20,7 +20,7 @@ async function registerModuleArt() {
   // Iterate over each module and check to see if there's a map.
   for (const [moduleKey, foundryModule] of activeModules) {
     // If the pf2e token pack isn't enabled, skip the system map.
-    if (moduleKey == 'archmage' && !game.modules.get('pf2e-tokens-bestiaries')?.active) {
+    if (['archmage', '13th-age-core-2e-gamma'].includes(moduleKey) && !game.modules.get('pf2e-tokens-bestiaries')?.active) {
       continue;
     }
     // We can skip the pf2e-tokens-bestiaries map since we've provided our own in the


### PR DESCRIPTION
Fixed a bug where module art was causing a 404 error for images when the PF2e token module wasn't enabled.