### PR TITLE
Release 1.32.2

### DIFF
--- a/release-notes/1.32.2.md
+++ b/release-notes/1.32.2.md
@@ -1,0 +1,20 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.32.2/system.json
+
+## Compatible Foundry versions
+
+![Foundry v12.331](https://img.shields.io/badge/Foundry-v12.331-green)
+
+**Note**: This release *requires* Foundry v12.
+
+## Bug Fixes
+- Fixed an issue where module art for monsters was loading incorrectly in some situations.
+
+## Changelog
+
+Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.32.1...1.32.2
+
+## Contributors
+
+Asacolips

--- a/release-notes/1.32.2.md
+++ b/release-notes/1.32.2.md
@@ -17,4 +17,4 @@ Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.32.1...
 
 ## Contributors
 
-Asacolips
+@asacolips

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -1,7 +1,7 @@
 name: archmage
 id: archmage
 title: 13th Age
-version: "1.32.1"
+version: "1.32.2"
 authors:
   - name: Matt Smith
     discord: asacolips
@@ -279,7 +279,7 @@ languages:
 socket: true
 url: https://github.com/asacolips-projects/13th-age
 manifest: https://asacolips-artifacts.s3.amazonaws.com/archmage/latest/system.json
-download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.32.1/archmage.zip
+download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.32.2/archmage.zip
 changelog: https://github.com/asacolips-projects/13th-age/releases
 initiative: 1d20 + (@abilities?.dex.mod || 0) + @attributes.init.value + @attributes.level.value
 grid:


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.32.2/system.json

## Compatible Foundry versions

![Foundry v12.331](https://img.shields.io/badge/Foundry-v12.331-green)

**Note**: This release *requires* Foundry v12.

## Bug Fixes
- Fixed an issue where module art for monsters was loading incorrectly in some situations.

## Changelog

Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.32.1...1.32.2

## Contributors

Asacolips
