### PR TITLE
PC sheet: triggers tab

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -182,7 +182,7 @@ ARCHMAGE:
   tool: Tool
   trait: Trait
   traits: Traits
-  triggersShort: TRG
+  triggers: Triggers
   type: Type
   uses: Uses
   vulnerability: Vulnerability

--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -182,6 +182,7 @@ ARCHMAGE:
   tool: Tool
   trait: Trait
   traits: Traits
+  triggersShort: TRG
   type: Type
   uses: Uses
   vulnerability: Vulnerability
@@ -745,7 +746,6 @@ ARCHMAGE:
     targetTitle: Targets for this power, such as "[[1d3]] nearby enemies", determines how many attacks are rolled
     tier: Tier
     trigger: Trigger
-    triggers: Triggers
     triggerPlaceholder: Natural even miss
     triggerTitle: Trigger for this power, such as 'Natural even miss'
     triggerVsRegex: "(\\[\\[.+?\\]\\]).*(vs.*)"

--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -745,6 +745,7 @@ ARCHMAGE:
     targetTitle: Targets for this power, such as "[[1d3]] nearby enemies", determines how many attacks are rolled
     tier: Tier
     trigger: Trigger
+    triggers: Triggers
     triggerPlaceholder: Natural even miss
     triggerTitle: Trigger for this power, such as 'Natural even miss'
     triggerVsRegex: "(\\[\\[.+?\\]\\]).*(vs.*)"

--- a/src/languages/es.yaml
+++ b/src/languages/es.yaml
@@ -143,7 +143,7 @@ ARCHMAGE.size: Tamaño
 ARCHMAGE.role: Papel
 ARCHMAGE.actions: Acciones
 ARCHMAGE.traits: Ventajas
-ARCHMAGE.triggersShort: ACT
+ARCHMAGE.triggers: Activaciónes
 ARCHMAGE.nastierSpecials: Propiedades especiales peligrosas
 # Item sheets
 ARCHMAGE.description: Descripción

--- a/src/languages/es.yaml
+++ b/src/languages/es.yaml
@@ -168,6 +168,7 @@ ARCHMAGE.CHAT.powerLevel: Nivel
 ARCHMAGE.CHAT.range: Alcance
 ARCHMAGE.CHAT.recharge: Recarga
 ARCHMAGE.CHAT.trigger: Activación
+ARCHMAGE.CHAT.triggers: Activaciónes
 ARCHMAGE.CHAT.target: Objetivo
 ARCHMAGE.CHAT.always: Siempre
 ARCHMAGE.CHAT.attack: Ataque

--- a/src/languages/es.yaml
+++ b/src/languages/es.yaml
@@ -143,6 +143,7 @@ ARCHMAGE.size: Tamaño
 ARCHMAGE.role: Papel
 ARCHMAGE.actions: Acciones
 ARCHMAGE.traits: Ventajas
+ARCHMAGE.triggersShort: ACT
 ARCHMAGE.nastierSpecials: Propiedades especiales peligrosas
 # Item sheets
 ARCHMAGE.description: Descripción
@@ -168,7 +169,6 @@ ARCHMAGE.CHAT.powerLevel: Nivel
 ARCHMAGE.CHAT.range: Alcance
 ARCHMAGE.CHAT.recharge: Recarga
 ARCHMAGE.CHAT.trigger: Activación
-ARCHMAGE.CHAT.triggers: Activaciónes
 ARCHMAGE.CHAT.target: Objetivo
 ARCHMAGE.CHAT.always: Siempre
 ARCHMAGE.CHAT.attack: Ataque

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -2144,8 +2144,7 @@ export class ActorArchmage extends Actor {
       data.system.attributes.weapon.melee.dice = `d${mWpn}`;
     }
 
-    else if (changes.system.details !== undefined
-      && changes.system.details.class !== undefined) {
+    else if (changes.system.details?.class !== undefined) {
       // Here we received an update of the class name for a character
 
       let matchedClasses = ArchmageUtility.detectClasses(data.system.details.class.value);
@@ -2302,6 +2301,11 @@ export class ActorArchmage extends Actor {
             this._setUpCustomResources(data, CONFIG.ARCHMAGE.classResources[cl], busyResources);
           }
         }
+
+        // Enable the triggers tab for certain classes
+        data.flags ||= {}
+        data.flags.archmage ||= {}
+        data.flags.archmage.showTriggersTab = matchedClasses.some(x => ["bard", "commander", "occultist"].includes(x));
       }
       // Store matched classes for future reference
       data.system.details.detectedClasses = matchedClasses;

--- a/src/module/setup/config.js
+++ b/src/module/setup/config.js
@@ -487,7 +487,7 @@ ARCHMAGE.tierMultPerLevel2e = [0, 1, 1, 1, 1, 2, 2, 2, 4, 4, 4, 4];
 // Animal companion data
 ARCHMAGE.animalCompanion = {
   attack: [5, 6, 7, 9, 10, 11, 13, 14, 15, 17, 18, 19, 20],
-  damage: ["2d8", "3d8", "4d6", " 4d8", "4d10", "6d10", "40", "50", "66", "80", "100", "130", "160"]  
+  damage: ["2d8", "3d8", "4d6", " 4d8", "4d10", "6d10", "40", "50", "66", "80", "100", "130", "160"]
 };
 
 // Power Settings
@@ -1220,6 +1220,12 @@ FLAGS.characterFlags = {
   "hideEmptyPowerGroups": {
     name: "Hide empty Power groups",
     hint: "Hide empty Power groups on the sheet (besides the default one).",
+    section: "Sheet",
+    type: Boolean
+  },
+  "showTriggersTab": {
+    name: "Show Triggers tab",
+    hint: "Show the trigger-centric powers tab.",
     section: "Sheet",
     type: Boolean
   },

--- a/src/vue/ArchmageCharacterSheet.vue
+++ b/src/vue/ArchmageCharacterSheet.vue
@@ -146,7 +146,7 @@ export default {
           },
           triggers: {
             key: 'triggers',
-            label: localize('ARCHMAGE.CHAT.triggers'),
+            label: localize('ARCHMAGE.triggersShort'),
             active: false,
             hidden: false // TODO: via setting
           },

--- a/src/vue/ArchmageCharacterSheet.vue
+++ b/src/vue/ArchmageCharacterSheet.vue
@@ -32,12 +32,12 @@
       <!-- Main content -->
       <Tab group="mobile" :tab="tabs.mobile.combat">
         <section class="section section--main flexcol">
-  
+
           <!-- Class resources -->
           <CharResources :actor="actor"/>
           <!-- Tabs -->
           <Tabs :actor="actor" group="primary" :tabs="tabs.primary" :flags="flags"/>
-  
+
           <!-- Tabs content -->
           <section class="section section--tabs-content flexcol">
             <!-- Details tab -->
@@ -47,6 +47,10 @@
             <!-- Powers tab -->
             <Tab group="primary" :tab="tabs.primary.powers">
               <CharPowers :actor="actor" :context="context" :tab="tabs.primary.powers" :flags="flags"/>
+            </Tab>
+            <!-- Triggers tab -->
+            <Tab group="primary" :tab="tabs.primary.triggers">
+              <CharTriggers :actor="actor" :context="context" :tab="tabs.primary.powers" :flags="flags"/>
             </Tab>
             <!-- Inventory tab -->
             <Tab group="primary" :tab="tabs.primary.inventory">
@@ -62,7 +66,7 @@
             </Tab>
           </section>
           <!-- /Tabs content -->
-  
+
         </section>
       </Tab>
       <!-- /Main content -->
@@ -92,6 +96,7 @@ import {
   CharResources,
   // CharDetails,
   CharPowers,
+  CharTriggers,
   CharInventory,
   CharEffects,
   CharSettings
@@ -114,6 +119,7 @@ export default {
     CharResources,
     CharDetails,
     CharPowers,
+    CharTriggers,
     CharInventory,
     CharEffects,
     CharSettings,
@@ -137,6 +143,12 @@ export default {
             key: 'powers',
             label: localize('ARCHMAGE.powers'),
             active: true
+          },
+          triggers: {
+            key: 'triggers',
+            label: localize('ARCHMAGE.CHAT.triggers'),
+            active: false,
+            hidden: false // TODO: via setting
           },
           inventory: {
             key: 'inventory',

--- a/src/vue/ArchmageCharacterSheet.vue
+++ b/src/vue/ArchmageCharacterSheet.vue
@@ -146,8 +146,10 @@ export default {
           },
           triggers: {
             key: 'triggers',
-            label: localize('ARCHMAGE.triggersShort'),
+            label: localize('ARCHMAGE.triggers'),
             active: false,
+            icon: 'fa-caret-right',
+            hideLabel: true,
             hidden: !this.actor.flags?.archmage?.showTriggersTab
           },
           inventory: {
@@ -162,7 +164,7 @@ export default {
           },
           settings: {
             key: 'settings',
-            label: localize('ARCHMAGE.settings'),
+            label: localize('ARCHMAGE.CHARACTERSETTINGS.settings'),
             active: false,
             icon: 'fa-cogs',
             hideLabel: true,

--- a/src/vue/ArchmageCharacterSheet.vue
+++ b/src/vue/ArchmageCharacterSheet.vue
@@ -148,7 +148,7 @@ export default {
             key: 'triggers',
             label: localize('ARCHMAGE.triggersShort'),
             active: false,
-            hidden: false // TODO: via setting
+            hidden: !this.actor.flags?.archmage?.showTriggersTab
           },
           inventory: {
             key: 'inventory',

--- a/src/vue/ArchmageCharacterSheet.vue
+++ b/src/vue/ArchmageCharacterSheet.vue
@@ -150,6 +150,7 @@ export default {
             key: 'triggers',
             label: localize('ARCHMAGE.triggers'),
             active: false,
+            componentClass: markRaw(CharTriggers),
             icon: 'fa-caret-right',
             hideLabel: true,
             hidden: !this.actor.flags?.archmage?.showTriggersTab

--- a/src/vue/components/actor/character/main/CharTriggers.vue
+++ b/src/vue/components/actor/character/main/CharTriggers.vue
@@ -1,9 +1,21 @@
 <template>
 	<section class="section section--triggers flexcol">
-
+		<div v-for="power in powersWithTriggers">
+			{{ power.name }}
+		</div>
 	</section>
 </template>
 
 <script setup>
+import { computed } from 'vue';
+import Power from '@/components/parts/Power.vue';
+import Rollable from '@/components/parts/Rollable.vue';
 
+const props = defineProps(['actor', 'context', 'tab', 'flags'])
+
+const powersWithTriggers = computed(() =>
+	props.actor.items
+		.filter(x => x.type === 'power')
+		.filter(x => x.system.trigger?.value)
+)
 </script>

--- a/src/vue/components/actor/character/main/CharTriggers.vue
+++ b/src/vue/components/actor/character/main/CharTriggers.vue
@@ -1,9 +1,9 @@
 <template>
 	<section class="section section--powers flexcol">
-		<header :class="$style.grid" class="power-header-labels">
-			<div></div>
-			<div>Power</div>
-			<div>Trigger</div>
+		<header :class="$style.grid" class="power-header-title">
+			<h2></h2>
+			<h2>Power</h2>
+			<h2>Trigger</h2>
 		</header>
 
 		<div class="power-group-content flexcol">

--- a/src/vue/components/actor/character/main/CharTriggers.vue
+++ b/src/vue/components/actor/character/main/CharTriggers.vue
@@ -1,23 +1,32 @@
 <template>
-	<section class="section section--triggers flexcol">
+	<section class="section section--powers flexcol">
 		<header :class="$style.grid" class="power-header-labels">
 			<div></div>
 			<div>Power</div>
 			<div>Trigger</div>
 		</header>
 
-		<div v-for="power in powersWithTriggers" :key="power._id" :class="$style.grid">
+		<div v-for="power in powersWithTriggers" :key="power._id"
+			:class="[$style.grid, powerUsageClass(power), powerAvailabilityClass(power)]" class="power-summary">
 			<Rollable name="item" :hide-icon="true" type="item" :opt="power._id">
 				<img :src="power.img" alt="Power icon" class="power-icon" />
 			</Rollable>
-			<div>{{ power.name }}</div>
-			<div>{{ power.system.trigger.value }}</div>
+			<a class="power-name" @click="expandedPowers[power._id] = !expandedPowers[power._id]">
+				<h3 class="power-title unit-subtitle" :class="$style.nowrap"> {{ power.name }} </h3>
+			</a>
+			<p style="margin: 0" :class="$style.nowrap">{{ power.system.trigger.value }}</p>
+			<div class="power-content" :class="[expandedPowers[power._id] ? 'active' : '', $style.fullwidth]">
+				<Transition name="slide-fade">
+					<Power v-if="expandedPowers[power._id]" :actor="actor" :power="power" :context="context" :flags="flags"
+						:ref="`power--${power._id}`" />
+				</Transition>
+			</div>
 		</div>
 	</section>
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import Power from '@/components/parts/Power.vue';
 import Rollable from '@/components/parts/Rollable.vue';
 
@@ -28,12 +37,46 @@ const powersWithTriggers = computed(() =>
 		.filter(x => x.type === 'power')
 		.filter(x => x.system.trigger?.value)
 )
+
+const expandedPowers = ref({});
+
+/**
+ * Compute CSS class to assign based on special usage
+ */
+function powerUsageClass(power) {
+	let use = power.system.powerUsage.value ? power.system.powerUsage.value : 'other';
+	if (['daily', 'daily-desperate'].includes(use)) use = 'daily';
+	if (['recharge', 'recharge-desperate'].includes(use)) use = 'recharge';
+	else if (use == 'cyclic') {
+		if (this.actor.system.attributes.escalation.value > 0
+			&& this.actor.system.attributes.escalation.value % 2 == 0) {
+			use = 'at-will cyclic';
+		} else use = 'once-per-battle cyclic';
+	}
+	return use;
+}
+
+function powerAvailabilityClass(power) {
+	return power.system?.quantity?.value === 0 ? 'unavailable' : '';
+}
+
 </script>
 
-<style module>
+<style module lang="scss">
 .grid {
 	display: grid;
-	grid-template-columns: 32px 250px auto;
+	padding: 0;
+	grid-template-columns: 32px 175px auto;
 	grid-gap: 0.5rem;
+	align-items: center;
+}
+
+.fullwidth {
+	grid-column: 1 / -1;
+}
+
+.nowrap {
+	overflow-x: hidden;
+	white-space: nowrap;
 }
 </style>

--- a/src/vue/components/actor/character/main/CharTriggers.vue
+++ b/src/vue/components/actor/character/main/CharTriggers.vue
@@ -1,0 +1,9 @@
+<template>
+	<section class="section section--triggers flexcol">
+
+	</section>
+</template>
+
+<script setup>
+
+</script>

--- a/src/vue/components/actor/character/main/CharTriggers.vue
+++ b/src/vue/components/actor/character/main/CharTriggers.vue
@@ -16,7 +16,7 @@
 					<a class="power-name" @click="row.expanded = !row.expanded">
 						<h3 class="power-title unit-subtitle" :class="$style.nowrap"> {{ row.power.name }} </h3>
 					</a>
-					<p style="margin: 0" :class="$style.nowrap">{{ row.power.system.trigger.value }}</p>
+					<a :class="$style.nowrap" @click="row.expanded = !row.expanded">{{ row.power.system.trigger.value }}</a>
 				</div>
 				<div class="power-content" :class="[$style.fullwidth, row.expanded ? 'active' : '']">
 					<Transition name="slide-fade">

--- a/src/vue/components/actor/character/main/CharTriggers.vue
+++ b/src/vue/components/actor/character/main/CharTriggers.vue
@@ -1,10 +1,10 @@
 <template>
 	<section class="section section--powers flexcol">
-		<header class="power-filters flexrow">
+		<header class="power-filters flexrow" style="margin-bottom: 1em;">
 			<input type="hidden" v-model="useCustomGroups" name="flags.archmage.sheetDisplay.triggers.customGroups.value">
-			<input type="checkbox" name="use-custom-groups" v-model="useCustomGroups">
-			<label for="use-custom-groups">
-				<span>Custom Groups</span>
+			<label :class="$style.label">
+				<input type="checkbox" v-model="useCustomGroups">
+				Custom Groups
 			</label>
 		</header>
 
@@ -114,6 +114,11 @@ function powerAvailabilityClass(power) {
 </script>
 
 <style module lang="scss">
+.label {
+	display: flex !important;
+	align-items: center;
+}
+
 .grid {
 	display: grid;
 	padding: 0;

--- a/src/vue/components/actor/character/main/CharTriggers.vue
+++ b/src/vue/components/actor/character/main/CharTriggers.vue
@@ -1,7 +1,17 @@
 <template>
 	<section class="section section--triggers flexcol">
-		<div v-for="power in powersWithTriggers">
-			{{ power.name }}
+		<header :class="$style.grid" class="power-header-labels">
+			<div></div>
+			<div>Power</div>
+			<div>Trigger</div>
+		</header>
+
+		<div v-for="power in powersWithTriggers" :key="power._id" :class="$style.grid">
+			<Rollable name="item" :hide-icon="true" type="item" :opt="power._id">
+				<img :src="power.img" alt="Power icon" class="power-icon" />
+			</Rollable>
+			<div>{{ power.name }}</div>
+			<div>{{ power.system.trigger.value }}</div>
 		</div>
 	</section>
 </template>
@@ -19,3 +29,11 @@ const powersWithTriggers = computed(() =>
 		.filter(x => x.system.trigger?.value)
 )
 </script>
+
+<style module>
+.grid {
+	display: grid;
+	grid-template-columns: 32px 250px auto;
+	grid-gap: 0.5rem;
+}
+</style>

--- a/src/vue/components/actor/character/main/CharTriggers.vue
+++ b/src/vue/components/actor/character/main/CharTriggers.vue
@@ -6,27 +6,31 @@
 			<div>Trigger</div>
 		</header>
 
-		<div v-for="power in powersWithTriggers" :key="power._id"
-			:class="[$style.grid, powerUsageClass(power), powerAvailabilityClass(power)]" class="power-summary">
-			<Rollable name="item" :hide-icon="true" type="item" :opt="power._id">
-				<img :src="power.img" alt="Power icon" class="power-icon" />
-			</Rollable>
-			<a class="power-name" @click="expandedPowers[power._id] = !expandedPowers[power._id]">
-				<h3 class="power-title unit-subtitle" :class="$style.nowrap"> {{ power.name }} </h3>
-			</a>
-			<p style="margin: 0" :class="$style.nowrap">{{ power.system.trigger.value }}</p>
-			<div class="power-content" :class="[expandedPowers[power._id] ? 'active' : '', $style.fullwidth]">
-				<Transition name="slide-fade">
-					<Power v-if="expandedPowers[power._id]" :actor="actor" :power="power" :context="context" :flags="flags"
-						:ref="`power--${power._id}`" />
-				</Transition>
+		<div class="power-group-content flexcol">
+			<div v-for="row in powerRows" :key="row.power._id" class="item power-item" :class="`power-item--${row.power._id}`"
+				:data-item-id="row.power._id" data-document-class="Item" data-draggable="true" draggable="true">
+				<div :class="[$style.grid, ...row.classes]" class="power-summary">
+					<Rollable name="item" :hide-icon="true" type="item" :opt="row.power._id" class="flexrow">
+						<img :src="row.power.img" class="power-icon" />
+					</Rollable>
+					<a class="power-name" @click="row.expanded = !row.expanded">
+						<h3 class="power-title unit-subtitle" :class="$style.nowrap"> {{ row.power.name }} </h3>
+					</a>
+					<p style="margin: 0" :class="$style.nowrap">{{ row.power.system.trigger.value }}</p>
+				</div>
+				<div class="power-content" :class="[$style.fullwidth, row.expanded ? 'active' : '']">
+					<Transition name="slide-fade">
+						<Power v-if="row.expanded" :actor="actor" :power="row.power" :context="context" :flags="flags"
+							:ref="`power--${row.power._id}`" />
+					</Transition>
+				</div>
 			</div>
 		</div>
 	</section>
 </template>
 
 <script setup>
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import Power from '@/components/parts/Power.vue';
 import Rollable from '@/components/parts/Rollable.vue';
 
@@ -38,7 +42,14 @@ const powersWithTriggers = computed(() =>
 		.filter(x => x.system.trigger?.value)
 )
 
-const expandedPowers = ref({});
+const powerRows = ref([]);
+watch(powersWithTriggers, (newPowers) => {
+	powerRows.value = newPowers.map(power => ({
+		power,
+		expanded: false,
+		classes: [powerUsageClass(power), powerAvailabilityClass(power)]
+	}))
+}, { immediate: true })
 
 /**
  * Compute CSS class to assign based on special usage
@@ -59,7 +70,6 @@ function powerUsageClass(power) {
 function powerAvailabilityClass(power) {
 	return power.system?.quantity?.value === 0 ? 'unavailable' : '';
 }
-
 </script>
 
 <style module lang="scss">

--- a/src/vue/components/index.js
+++ b/src/vue/components/index.js
@@ -11,6 +11,7 @@ export { default as CharIncrementals } from '@/components/actor/character/sideba
 export { default as CharResources } from '@/components/actor/character/main/CharResources.vue';
 export { default as CharDetails } from '@/components/actor/character/main/CharDetails.vue';
 export { default as CharPowers } from '@/components/actor/character/main/CharPowers.vue';
+export { default as CharTriggers } from '@/components/actor/character/main/CharTriggers.vue';
 export { default as CharInventory } from '@/components/actor/character/main/CharInventory.vue';
 export { default as CharEffects } from '@/components/actor/character/main/CharEffects.vue';
 export { default as CharSettings } from '@/components/actor/character/main/CharSettings.vue';

--- a/src/vue/components/parts/Tabs.vue
+++ b/src/vue/components/parts/Tabs.vue
@@ -6,13 +6,13 @@
     </button>
     <nav :class="`sheet-tabs tabs tabs--${group}`" :data-group="group">
       <template v-if="noSpan">
-        <a v-for="(tab, tabKey) in tabs" :key="`tab-${group}-${tabKey}`" @click="changeTab" :class="getTabClass(tab, tabKey)" :data-tab="tabKey">
+        <a v-for="(tab, tabKey) in tabs" :key="`tab-${group}-${tabKey}`" @click="changeTab" :class="getTabClass(tab, tabKey)" :data-tab="tabKey" :data-tooltip="tab.hideLabel ? tab.label : undefined" data-tooltip-direction="UP">
           <i v-if="tab.icon" :class="concat('fas ', tab.icon)"></i>
           <span v-if="!tab.hideLabel">{{tab.label}}</span>
         </a>
       </template>
       <template v-else>
-        <span v-for="(tab, tabKey) in tabs" :key="`tab-${group}-${tabKey}`">
+        <span v-for="(tab, tabKey) in tabs" :key="`tab-${group}-${tabKey}`" :data-tooltip="tab.hideLabel ? tab.label : undefined" data-tooltip-direction="UP">
           <a @click="changeTab" :class="getTabClass(tab, tabKey)" :data-tab="tabKey" v-if="!tab.hidden">
             <i v-if="tab.icon" :class="concat('fas ', tab.icon)"></i>
             <span v-if="!tab.hideLabel">{{tab.label}}</span>


### PR DESCRIPTION
This adds an optional new tab to the PC character sheet so that trigger-intensive classes can see all their triggered powers at once, instead of needing to hover over powers to reveal triggers one at a time. An example from a level-4 occultist's sheet:

![CleanShot 2024-12-09 at 06 48 59](https://github.com/user-attachments/assets/b987879b-7771-4793-9e44-f6dbc78310f4)


- [x] New tab which displays powers and their triggers
  - [x] Rollable
  - [x] Expandable power details
- [x] Only show if a setting is turned on
  - [x] Enable the setting by default for bards, commanders, andoccultists (any others?)
- [x] Drag-and-drop reordering
- [x] Option to group by the `group` field
- [x] #534 will probably merge first, rebase and add support for this new tab