### PR TITLE
PC lifecycle macros

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -255,7 +255,7 @@ ARCHMAGE:
     enableOngoingEffectsMessagesHint: Enable chat messages for ongoing effects on actors at the start and end of their turns.
     lifecycleHooks:
       title: Lifecycle Hooks
-      hint: These macros will run on this character's owner's client. If that player is not logged in, they will not be executed.
+      hint: <p>These macros will run on this character's owner's client. If that player is not logged in, they will not be executed.</p><p>In the body, <code>this</code> is set to the actor, and no other arguments are passed.</p>
       startOfTurn: Start of Turn
       endOfTurn: End of Turn
   AUTOLEVEL:

--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -253,6 +253,11 @@ ARCHMAGE:
     UnboundEscDieName: Unlimited Escalation Die
     enableOngoingEffectsMessagesName: Enable ongoing effects messages
     enableOngoingEffectsMessagesHint: Enable chat messages for ongoing effects on actors at the start and end of their turns.
+    lifecycleHooks:
+      title: Lifecycle Hooks
+      hint: These macros will run on this character's owner's client. If that player is not logged in, they will not be executed.
+      startOfTurn: Start of Turn
+      endOfTurn: End of Turn
   AUTOLEVEL:
     confirm: Confirm (create duplicate)
     help: Use this form to create a copy of this actor with its stats (including attacks) adjusted to the new level.

--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -275,7 +275,7 @@ ARCHMAGE:
     enableOngoingEffectsMessagesHint: Enable chat messages for ongoing effects on actors at the start and end of their turns.
     lifecycleHooks:
       title: Lifecycle Hooks
-      hint: <p>These macros will run on this character's owner's client. If that player is not logged in, they will not be executed.</p><p>In the body, <code>this</code> is set to the actor, and no other arguments are passed.</p>
+      hint: <p>These macros will run on this character's owner's client. If that player is not logged in, they will not be executed.</p><p>In the body, available arguments are <code>this</code>, <code>speaker</code>, <code>actor</code>, and <code>archmage</code>.</p>
       startOfTurn: Start of Turn
       endOfTurn: End of Turn
   AUTOLEVEL:

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -19,7 +19,7 @@ import { ActorHelpersV2 } from './actor/helpers/actor-helpers-v2.js';
 import { EffectArchmageSheet } from "./active-effects/effect-sheet.js";
 import { registerModuleArt } from './setup/register-module-art.js';
 import { TokenArchmage } from './actor/token.js';
-import {combatRound, combatTurn, preDeleteCombat} from "./hooks/combat.mjs";
+import {combatRound, combatStart, combatTurn, preDeleteCombat} from "./hooks/combat.mjs";
 import { ArchmageCompendiumBrowserApplication } from './applications/compendium-browser.js';
 
 Hooks.once('init', async function() {
@@ -1816,6 +1816,10 @@ Hooks.on('updateCombat', (async (combat, update) => {
     }
   }
 }));
+
+/* -------------------------------------------- */
+
+Hooks.on('combatStart', combatStart);
 
 /* -------------------------------------------- */
 

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -1696,13 +1696,18 @@ function _handleActorLifecycleHook({actorId, hookName}) {
   // Can't run if you can't run
   if (!game.user.hasPermission("MACRO_SCRIPT")) return;
 
+  const speaker = ChatMessage.implementation.getSpeaker();
+  const macroData = {
+      // TODO: ???
+  };
+
   const hookBody = actor.system.lifecycleHooks?.[hookName]?.trim();
   if (!hookBody) return;
 
   const AsyncFunction = async function () {}.constructor;
   try {
-      const fn = new AsyncFunction(hookBody);
-      return fn.call(actor);
+      const fn = new AsyncFunction("speaker", "actor", "archmage", hookBody);
+      return fn.call(this, speaker, actor, macroData);
   } catch (ex) {
       ui.notifications.error(game.i18n.localize('ARCHMAGE.UI.errMacroSyntax'));
       console.error(`Lifecycle hook '${actor.name}' / ${hookName} failed with: ${ex}`, ex);

--- a/src/module/hooks/combat.mjs
+++ b/src/module/hooks/combat.mjs
@@ -285,11 +285,17 @@ async function renderOngoingEffectsCard(title, combatant, effectData) {
 }
 
 async function executeLifecycleMacro(combatant, hookName) {
+    // If this isn't the actor's player, emit a socket request for that player to execute the hook
+    if (game.user?.character?.id !== combatant.actor.id) {
+        return game.socket.emit('system.archmage', {
+            type: 'actorLifecycleHook',
+            actorId: combatant.actor.id,
+            hookName
+        });
+    }
+
     const hookBody = combatant?.actor?.system?.lifecycleHooks?.[hookName]?.trim();
     if (!hookBody) return;
-
-    // Only execute if this is running in the actor's owner's client
-    if (game.user?.character?.id !== combatant.actor.id) return;
 
     // Can't run if you can't run
     if (!game.user.hasPermission("MACRO_SCRIPT")) return;

--- a/src/module/hooks/combat.mjs
+++ b/src/module/hooks/combat.mjs
@@ -294,6 +294,12 @@ async function executeLifecycleMacro(combatant, hookName) {
         });
     }
 
+    const speaker = ChatMessage.implementation.getSpeaker();
+    const actor = game.user.character;
+    const macroData = {
+        // TODO: ???
+    };
+
     const hookBody = combatant?.actor?.system?.lifecycleHooks?.[hookName]?.trim();
     if (!hookBody) return;
 
@@ -303,8 +309,8 @@ async function executeLifecycleMacro(combatant, hookName) {
     // Run our own function to bypass macro parameters limitations - based on Foundry's _executeScript
     const AsyncFunction = async function () {}.constructor;
     try {
-        const fn = new AsyncFunction(hookBody);
-        await fn.call(combatant.actor);
+        const fn = new AsyncFunction("speaker", "actor", "archmage", hookBody);
+        await fn.call(this, speaker, actor, macroData);
     } catch (ex) {
         ui.notifications.error(game.i18n.localize('ARCHMAGE.UI.errMacroSyntax'));
         console.error(`Lifecycle hook '${combatant.actor.name}' / ${hookName} failed with: ${ex}`, ex);

--- a/src/scss/v2/components/character/_settings.scss
+++ b/src/scss/v2/components/character/_settings.scss
@@ -14,7 +14,8 @@
 
   .unit--backgrounds,
   .unit--icons,
-  .unit--resources {
+  .unit--resources,
+  .unit--hooks {
     display: flex;
     flex-direction: column;
     justify-content: flex-start;

--- a/src/template.yaml
+++ b/src/template.yaml
@@ -440,6 +440,9 @@ Actor:
       gold: 0
       silver: 0
       copper: 0
+    lifecycleHooks:
+      startOfTurn: ''
+      endOfTurn: ''
   npc:
     templates:
       - standard

--- a/src/vue/components/actor/character/main/CharSettings.vue
+++ b/src/vue/components/actor/character/main/CharSettings.vue
@@ -156,15 +156,15 @@
           {{localize('ARCHMAGE.SETTINGS.lifecycleHooks.title')}}
           <InfoBubble :tooltip="localize('ARCHMAGE.SETTINGS.lifecycleHooks.hint')"/>
         </h3>
-        <div class="flexrow">
-          <div class="flexcol" style="grid-column: 1 / 3;">
+        <div class="flexrow form-group stacked">
+          <div class="flexcol field">
             <label style="flex-grow: 0;">{{localize('ARCHMAGE.SETTINGS.lifecycleHooks.startOfTurn')}}</label>
             <CodemirrorWrapper class="attribute-value"
               name="system.lifecycleHooks.startOfTurn"
               :value="actor.system.lifecycleHooks.startOfTurn"
               :disable-paste-parsing="true" />
           </div>
-          <div class="flexcol" style="grid-column: 4 / 6;">
+          <div class="flexcol field">
             <label style="flex-grow: 0;">{{localize('ARCHMAGE.SETTINGS.lifecycleHooks.endOfTurn')}}</label>
             <CodemirrorWrapper class="attribute-value"
               name="system.lifecycleHooks.endOfTurn"

--- a/src/vue/components/actor/character/main/CharSettings.vue
+++ b/src/vue/components/actor/character/main/CharSettings.vue
@@ -150,15 +150,41 @@
           <strong class="unit-subtitle">{{localize(concat('ARCHMAGE.CHARACTER.RESOURCES.', r))}}</strong>
         </div>
       </div>
+
+      <div class="flexcol unit unit--hooks" style="grid-column-end: span 6">
+        <h3>
+          {{localize('ARCHMAGE.SETTINGS.lifecycleHooks.title')}}
+          <InfoBubble :tooltip="localize('ARCHMAGE.SETTINGS.lifecycleHooks.hint')"/>
+        </h3>
+        <div class="flexrow">
+          <div class="flexcol" style="grid-column: 1 / 3;">
+            <label style="flex-grow: 0;">{{localize('ARCHMAGE.SETTINGS.lifecycleHooks.startOfTurn')}}</label>
+            <CodemirrorWrapper class="attribute-value"
+              name="system.lifecycleHooks.startOfTurn"
+              :value="actor.system.lifecycleHooks.startOfTurn"
+              :disable-paste-parsing="true" />
+          </div>
+          <div class="flexcol" style="grid-column: 4 / 6;">
+            <label style="flex-grow: 0;">{{localize('ARCHMAGE.SETTINGS.lifecycleHooks.endOfTurn')}}</label>
+            <CodemirrorWrapper class="attribute-value"
+              name="system.lifecycleHooks.endOfTurn"
+              :value="actor.system.lifecycleHooks.endOfTurn"
+              :disable-paste-parsing="true" />
+          </div>
+        </div>
+      </div>
     </section>
   </section>
 </template>
 
 <script>
 import { concat, localize } from '@/methods/Helpers';
+import { CodemirrorWrapper, InfoBubble } from '@/components';
+
 export default {
   name: 'CharSettings',
   props: ['actor', 'owner', 'tab'],
+  components: { CodemirrorWrapper, InfoBubble },
   setup() {
     return {
       concat,

--- a/src/vue/components/index.js
+++ b/src/vue/components/index.js
@@ -1,20 +1,3 @@
-export { default as CharHeader } from '@/components/actor/character/top/CharHeader.vue';
-export { default as CharAttributes } from '@/components/actor/character/top/CharAttributes.vue';
-
-export { default as CharAbilities } from '@/components/actor/character/sidebar/CharAbilities.vue';
-export { default as CharBackgrounds } from '@/components/actor/character/sidebar/CharBackgrounds.vue';
-export { default as CharInitiative } from '@/components/actor/character/sidebar/CharInitiative.vue';
-export { default as CharIconRelationships } from '@/components/actor/character/sidebar/CharIconRelationships.vue';
-export { default as CharOut } from '@/components/actor/character/sidebar/CharOut.vue';
-export { default as CharIncrementals } from '@/components/actor/character/sidebar/CharIncrementals.vue';
-
-export { default as CharResources } from '@/components/actor/character/main/CharResources.vue';
-export { default as CharDetails } from '@/components/actor/character/main/CharDetails.vue';
-export { default as CharPowers } from '@/components/actor/character/main/CharPowers.vue';
-export { default as CharInventory } from '@/components/actor/character/main/CharInventory.vue';
-export { default as CharEffects } from '@/components/actor/character/main/CharEffects.vue';
-export { default as CharSettings } from '@/components/actor/character/main/CharSettings.vue';
-
 export { default as Power } from '@/components/parts/Power.vue';
 export { default as Rollable } from '@/components/parts/Rollable.vue';
 export { default as Equipment } from '@/components/parts/Equipment.vue';
@@ -37,3 +20,21 @@ export { default as PowerFeats } from '@/components/item/power/PowerFeats.vue';
 
 export { default as ActionDetails } from '@/components/item/action/ActionDetails.vue';
 export { default as ActionAttack } from '@/components/item/action/ActionAttack.vue';
+
+export { default as CharHeader } from '@/components/actor/character/top/CharHeader.vue';
+export { default as CharAttributes } from '@/components/actor/character/top/CharAttributes.vue';
+
+export { default as CharAbilities } from '@/components/actor/character/sidebar/CharAbilities.vue';
+export { default as CharBackgrounds } from '@/components/actor/character/sidebar/CharBackgrounds.vue';
+export { default as CharInitiative } from '@/components/actor/character/sidebar/CharInitiative.vue';
+export { default as CharIconRelationships } from '@/components/actor/character/sidebar/CharIconRelationships.vue';
+export { default as CharOut } from '@/components/actor/character/sidebar/CharOut.vue';
+export { default as CharIncrementals } from '@/components/actor/character/sidebar/CharIncrementals.vue';
+
+export { default as CharResources } from '@/components/actor/character/main/CharResources.vue';
+export { default as CharDetails } from '@/components/actor/character/main/CharDetails.vue';
+export { default as CharPowers } from '@/components/actor/character/main/CharPowers.vue';
+export { default as CharInventory } from '@/components/actor/character/main/CharInventory.vue';
+export { default as CharEffects } from '@/components/actor/character/main/CharEffects.vue';
+export { default as CharSettings } from '@/components/actor/character/main/CharSettings.vue';
+

--- a/src/vue/components/index.js
+++ b/src/vue/components/index.js
@@ -38,21 +38,3 @@ export { default as PowerFeats } from '@/components/item/power/PowerFeats.vue';
 
 export { default as ActionDetails } from '@/components/item/action/ActionDetails.vue';
 export { default as ActionAttack } from '@/components/item/action/ActionAttack.vue';
-
-export { default as CharHeader } from '@/components/actor/character/top/CharHeader.vue';
-export { default as CharAttributes } from '@/components/actor/character/top/CharAttributes.vue';
-
-export { default as CharAbilities } from '@/components/actor/character/sidebar/CharAbilities.vue';
-export { default as CharBackgrounds } from '@/components/actor/character/sidebar/CharBackgrounds.vue';
-export { default as CharInitiative } from '@/components/actor/character/sidebar/CharInitiative.vue';
-export { default as CharIconRelationships } from '@/components/actor/character/sidebar/CharIconRelationships.vue';
-export { default as CharOut } from '@/components/actor/character/sidebar/CharOut.vue';
-export { default as CharIncrementals } from '@/components/actor/character/sidebar/CharIncrementals.vue';
-
-export { default as CharResources } from '@/components/actor/character/main/CharResources.vue';
-export { default as CharDetails } from '@/components/actor/character/main/CharDetails.vue';
-export { default as CharPowers } from '@/components/actor/character/main/CharPowers.vue';
-export { default as CharInventory } from '@/components/actor/character/main/CharInventory.vue';
-export { default as CharEffects } from '@/components/actor/character/main/CharEffects.vue';
-export { default as CharSettings } from '@/components/actor/character/main/CharSettings.vue';
-

--- a/src/vue/components/index.js
+++ b/src/vue/components/index.js
@@ -1,21 +1,3 @@
-export { default as CharHeader } from '@/components/actor/character/top/CharHeader.vue';
-export { default as CharAttributes } from '@/components/actor/character/top/CharAttributes.vue';
-
-export { default as CharAbilities } from '@/components/actor/character/sidebar/CharAbilities.vue';
-export { default as CharBackgrounds } from '@/components/actor/character/sidebar/CharBackgrounds.vue';
-export { default as CharInitiative } from '@/components/actor/character/sidebar/CharInitiative.vue';
-export { default as CharIconRelationships } from '@/components/actor/character/sidebar/CharIconRelationships.vue';
-export { default as CharOut } from '@/components/actor/character/sidebar/CharOut.vue';
-export { default as CharIncrementals } from '@/components/actor/character/sidebar/CharIncrementals.vue';
-
-export { default as CharResources } from '@/components/actor/character/main/CharResources.vue';
-export { default as CharDetails } from '@/components/actor/character/main/CharDetails.vue';
-export { default as CharPowers } from '@/components/actor/character/main/CharPowers.vue';
-export { default as CharTriggers } from '@/components/actor/character/main/CharTriggers.vue';
-export { default as CharInventory } from '@/components/actor/character/main/CharInventory.vue';
-export { default as CharEffects } from '@/components/actor/character/main/CharEffects.vue';
-export { default as CharSettings } from '@/components/actor/character/main/CharSettings.vue';
-
 export { default as Power } from '@/components/parts/Power.vue';
 export { default as Rollable } from '@/components/parts/Rollable.vue';
 export { default as Equipment } from '@/components/parts/Equipment.vue';
@@ -38,3 +20,21 @@ export { default as PowerFeats } from '@/components/item/power/PowerFeats.vue';
 
 export { default as ActionDetails } from '@/components/item/action/ActionDetails.vue';
 export { default as ActionAttack } from '@/components/item/action/ActionAttack.vue';
+
+export { default as CharHeader } from '@/components/actor/character/top/CharHeader.vue';
+export { default as CharAttributes } from '@/components/actor/character/top/CharAttributes.vue';
+
+export { default as CharAbilities } from '@/components/actor/character/sidebar/CharAbilities.vue';
+export { default as CharBackgrounds } from '@/components/actor/character/sidebar/CharBackgrounds.vue';
+export { default as CharInitiative } from '@/components/actor/character/sidebar/CharInitiative.vue';
+export { default as CharIconRelationships } from '@/components/actor/character/sidebar/CharIconRelationships.vue';
+export { default as CharOut } from '@/components/actor/character/sidebar/CharOut.vue';
+export { default as CharIncrementals } from '@/components/actor/character/sidebar/CharIncrementals.vue';
+
+export { default as CharResources } from '@/components/actor/character/main/CharResources.vue';
+export { default as CharDetails } from '@/components/actor/character/main/CharDetails.vue';
+export { default as CharPowers } from '@/components/actor/character/main/CharPowers.vue';
+export { default as CharTriggers } from '@/components/actor/character/main/CharTriggers.vue';
+export { default as CharInventory } from '@/components/actor/character/main/CharInventory.vue';
+export { default as CharEffects } from '@/components/actor/character/main/CharEffects.vue';
+export { default as CharSettings } from '@/components/actor/character/main/CharSettings.vue';


### PR DESCRIPTION
This adds start-of-turn and end-of-turn macros to the PC sheet, which will execute when a character's combat turn starts and ends.

- [x] Template update for macro body storage
- [x] Basic UI for editing macros
- [x] Execute macros at the appropriate moments
  - [x] Somehow arrange for the owner's client to execute the macro
- [x] Make the UI look and work better