### PR TITLE
Fix and extend PC prototype token settings

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -1769,9 +1769,13 @@ export class ActorArchmage extends Actor {
       await this.update({img: CONFIG.ARCHMAGE.defaultMonsterTokens['default-toolkit']});
     }
 
-    // For characters only default to linked token
+    // For characters only, set some defaults
     if (this.type == "character") {
-      await this.update({token: {actorLink: true}});
+      await this.update({prototypeToken: {
+        actorLink: true,
+        disposition: 1, // friendly
+        sight: {enabled: true}
+      }});
     }
   }
 


### PR DESCRIPTION
The current character token defaults don't work, because doing `update({token: {...}})` has been left behind in v12. This new method should also work in v11.

- [ ] Fix the current setting of `actorLink`
- [ ] Set disposition to "friendly"
- [ ] Set the token to have vision enabled