### PR TITLE
Release 1.33.0

### DIFF
--- a/release-notes/1.33.0.md
+++ b/release-notes/1.33.0.md
@@ -9,23 +9,17 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.33.0/syste
 **Note**: This release *requires* Foundry v12.
 
 ## Features
-- Added new **Triggers** tab to character sheets. This is an optional tab that can be
-  enabled in the character's sheet settings tab and will display powers that have
-  triggers to make them easier to find. Certain classes like the bard, commander, and
-  occultist will have it enabled by default when the class is added to a new character.
-- Added ability to pop out tabs on character sheets by right-clicking them. This does
-  not pop them out of the Foundry browser tab, but it does let you view those tabs as
-  separate sheets within Foundry. It's especially handy for the new Triggers tab!
-- Added description for the Shocked condition
+- Added new **Triggers** tab to character sheets. This is an optional tab that can be enabled in the character's sheet settings tab and will display powers that have triggers to make them easier to find. Certain classes like the bard, commander, and occultist will have it enabled by default when the class is added to a new character.
+- Added ability to pop out tabs on character sheets by right-clicking them. This does not pop them out of the Foundry browser tab, but it does let you view those tabs as separate sheets within Foundry. It's especially handy for the new Triggers tab!
 
 ## Bug Fixes
-- Fixed bug with prototype token defaults not being enabled correctly for new characters.
-  Those include the following:
+- Fixed bug with prototype token defaults not being enabled correctly for new characters. Those include the following:
   - Actor link
   - Friendly disposition
   - Enabled vision
 - Added missing recharge value for the commander's "Scramble" tactic.
 - Fixed the monk's "Star Joins as Ally (Spiral Path)" form attack.
+- Added description for the Shocked condition.
 
 ## Screenshots
 **Triggers Tab**  

--- a/release-notes/1.33.0.md
+++ b/release-notes/1.33.0.md
@@ -1,0 +1,43 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.33.0/system.json
+
+## Compatible Foundry versions
+
+![Foundry v12.331](https://img.shields.io/badge/Foundry-v12.331-green)
+
+**Note**: This release *requires* Foundry v12.
+
+## Features
+- Added new **Triggers** tab to character sheets. This is an optional tab that can be
+  enabled in the character's sheet settings tab and will display powers that have
+  triggers to make them easier to find. Certain classes like the bard, commander, and
+  occultist will have it enabled by default when the class is added to a new character.
+- Added ability to pop out tabs on character sheets by right-clicking them. This does
+  not pop them out of the Foundry browser tab, but it does let you view those tabs as
+  separate sheets within Foundry. It's especially handy for the new Triggers tab!
+- Added description for the Shocked condition
+
+## Bug Fixes
+- Fixed bug with prototype token defaults not being enabled correctly for new characters.
+  Those include the following:
+  - Actor link
+  - Friendly disposition
+  - Enabled vision
+- Added missing recharge value for the commander's "Scramble" tactic.
+- Fixed the monk's "Star Joins as Ally (Spiral Path)" form attack.
+
+## Screenshots
+**Triggers Tab**  
+[Screenshot of triggers tab]
+
+**Pop Out Tabs**  
+[Screenshot of pop out tabs]
+
+## Changelog
+
+Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.32.2...1.33.0
+
+## Contributors
+
+@ben, @LegoFed3

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -1,7 +1,7 @@
 name: archmage
 id: archmage
 title: 13th Age
-version: "1.32.2"
+version: "1.33.0"
 authors:
   - name: Matt Smith
     discord: asacolips


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.33.0/system.json

## Compatible Foundry versions

![Foundry v12.331](https://img.shields.io/badge/Foundry-v12.331-green)

**Note**: This release *requires* Foundry v12.

## Features
- Added new **Triggers** tab to character sheets. This is an optional tab that can be enabled in the character's sheet settings tab and will display powers that have triggers to make them easier to find. Certain classes like the bard, commander, and occultist will have it enabled by default when the class is added to a new character.
- Added ability to pop out tabs on character sheets by right-clicking them. This does not pop them out of the Foundry browser tab, but it does let you view those tabs as separate sheets within Foundry. It's especially handy for the new Triggers tab!

## Bug Fixes
- Fixed bug with prototype token defaults not being enabled correctly for new characters. Those include the following:
  - Actor link
  - Friendly disposition
  - Enabled vision
- Added missing recharge value for the commander's "Scramble" tactic.
- Fixed the monk's "Star Joins as Ally (Spiral Path)" form attack.
- Added description for the Shocked condition.

## Screenshots
**Triggers Tab**  
![image](https://github.com/user-attachments/assets/1eccbf83-5646-4730-8953-8f74fe6cad4b)

**Pop Out Tabs**  
![image](https://github.com/user-attachments/assets/18459102-1c56-4dbd-b953-45807b5fb197)

## Changelog

Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.32.2...1.33.0

## Contributors

ben, LegoFed3
