### PR TITLE
Release 1.34.0

### DIFF
--- a/release-notes/1.34.0.md
+++ b/release-notes/1.34.0.md
@@ -1,0 +1,35 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.34.0/system.json
+
+## Compatible Foundry versions
+
+![Foundry v12.331](https://img.shields.io/badge/Foundry-v12.331-green)
+
+## Localization Improvements
+Added new localization strings to replace previously hardcoded english text:
+- Power usage and type
+- Power sheet tabs
+- Config strings
+- AE sheet
+- Equipment sheet
+- Inline rolls hint vue component
+
+See https://github.com/asacolips-projects/13th-age/pull/541 for the list of changes in detail.
+
+## Features
+- Added new **Lifecycle Macros** fields to the settings tab of character sheets. These macros
+  fire at the start of turn and end of turn for the user who is assigned to that character if
+  they're currently logged in. Lifecycle Macros support the following arguments: `this`,
+  `speaker`, `actor`, and `archmage`.
+
+## Bug Fixes
+- Fixed edge case error when rolling some powers to chat.
+
+## Changelog
+
+Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.33.0...1.34.0
+
+## Contributors
+
+@ben, @LegoFed3

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -1,7 +1,7 @@
 name: archmage
 id: archmage
 title: 13th Age
-version: "1.33.0"
+version: "1.34.0"
 authors:
   - name: Matt Smith
     discord: asacolips
@@ -279,7 +279,7 @@ languages:
 socket: true
 url: https://github.com/asacolips-projects/13th-age
 manifest: https://asacolips-artifacts.s3.amazonaws.com/archmage/latest/system.json
-download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.32.2/archmage.zip
+download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.34.0/archmage.zip
 changelog: https://github.com/asacolips-projects/13th-age/releases
 initiative: 1d20 + (@abilities?.dex.mod || 0) + @attributes.init.value + @attributes.level.value
 grid:


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.34.0/system.json

## Compatible Foundry versions

![Foundry v12.331](https://img.shields.io/badge/Foundry-v12.331-green)

## Localization Improvements
Added new localization strings to replace previously hardcoded english text:
- Power usage and type
- Power sheet tabs
- Config strings
- AE sheet
- Equipment sheet
- Inline rolls hint vue component

See https://github.com/asacolips-projects/13th-age/pull/541 for the list of changes in detail.

## Features
- Added new **Lifecycle Macros** fields to the settings tab of character sheets. These macros
  fire at the start of turn and end of turn for the user who is assigned to that character if
  they're currently logged in. Lifecycle Macros support the following arguments: `this`,
  `speaker`, `actor`, and `archmage`.

## Bug Fixes
- Fixed edge case error when rolling some powers to chat.

## Changelog

Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.33.0...1.34.0

## Contributors

ben, LegoFed3
