### PR TITLE
fix/stackingAEBonuses

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -636,6 +636,8 @@ ARCHMAGE:
     toHitBonus: To-Hit Bonus
     saveBonus: Save Bonus
     saveBonusHPTreshold: Save Bonus HP Threshold
+    stackingBehavior: Stacking Behavior
+    stacksAlways: Bonus always stacks
     usesMax: Maximum Uses
     usesMaxHint: Number of uses per battle/day, usually 1
     usesRemaining: Uses Remaining

--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -637,7 +637,7 @@ ARCHMAGE:
     saveBonus: Save Bonus
     saveBonusHPTreshold: Save Bonus HP Threshold
     stackingBehavior: Stacking Behavior
-    stacksAlways: Bonus always stacks
+    stacksAlways: Always stacks
     usesMax: Maximum Uses
     usesMaxHint: Number of uses per battle/day, usually 1
     usesRemaining: Uses Remaining

--- a/src/module/active-effects/effect-sheet.js
+++ b/src/module/active-effects/effect-sheet.js
@@ -51,6 +51,7 @@ export class EffectArchmageSheet extends ActiveEffectConfig {
     context.ongoingDamage = context.effect.flags.archmage?.ongoingDamage || 0;
     context.ongoingDamageType = context.effect.flags.archmage?.ongoingDamageType || "";
     context.ongoingDamageCrit = context.effect.flags.archmage?.ongoingDamageCrit || false;
+    context.stacksAlways = context.effect.flags.archmage?.stacksAlways || false;
 
     return context;
   }
@@ -93,6 +94,7 @@ export class EffectArchmageSheet extends ActiveEffectConfig {
       ongoingDamage: formData.ongoingDamage,
       ongoingDamageType: formData.ongoingDamageType,
       ongoingDamageCrit: formData.ongoingDamageCrit,
+      stacksAlways: formData.stacksAlways,
     };
 
     // Retrieve the existing effects.

--- a/src/templates/active-effects/effect.html
+++ b/src/templates/active-effects/effect.html
@@ -202,6 +202,15 @@
                         <strong class="attribute-name">{{localize 'ARCHMAGE.ITEM.ongoingDamageCrit'}}</strong>
                         <input class="attribute-input" name="ongoingDamageCrit" type="checkbox" {{checked ongoingDamageCrit}}/>
                     </div>
+
+                    <div class="settings-group form-group" style="padding-top: 10px;">
+                        <label>{{localize 'ARCHMAGE.ITEM.stackingBehavior'}}</label>
+                    </div>
+
+                    <div class="settings-group">
+                        <strong class="attribute-name">{{localize 'ARCHMAGE.ITEM.stacksAlways'}}</strong>
+                        <input class="attribute-input" name="stacksAlways" type="checkbox" {{checked stacksAlways}}/>
+                    </div>
                 </section>
             </div>
         </section>


### PR DESCRIPTION
- Rework AE ADD rules for bonuses to actually allow stacking of bonuses from different sources as per the rules.
- Add an `Always stacks` flag to the system AE sheet and logic to back it, to support monsters with special rules.