### PR TITLE
Compendium browser: allow all packs

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -105,6 +105,7 @@ ARCHMAGE:
   kin: Kin
   level: Level
   levelFormat: "{level} level"
+  location: Location
   loot: Loot
   lvl: Lvl
   magicItems: Magic Items

--- a/src/vue/components/dialogs/compendium-browser/CompendiumBrowserCreatures.vue
+++ b/src/vue/components/dialogs/compendium-browser/CompendiumBrowserCreatures.vue
@@ -312,16 +312,14 @@ export default {
   async created() {
     console.log("Creating compendium browser creatures tab...");
 
-    const packIds = game.modules.get('13th-age-core-2e-gamma')?.active ? [
-      'archmage.srd-Monsters',
-      '13th-age-core-2e-gamma.monsters-2e',
-      '13th-age-core-2e-gamma.companions-2e',
-      'archmage.necromancer-summons',
-    ] : [
-      'archmage.srd-Monsters',
-      'archmage.animal-companions',
-      'archmage.necromancer-summons',
-    ];
+    let packIds = game.packs.contents
+      .filter(pack => pack.documentName === 'Actor')
+      .map(pack => pack.collection);
+
+    // If the 2e gamma module is active, remove the animal-companion pack that it replaces.
+    if (game.modules.get('13th-age-core-2e-gamma')?.active) {
+      packIds.splice(packIds.indexOf('archmage.animal-companions'), 1);
+    }
 
     // Load the pack index with the fields we need.
     getPackIndex(packIds, [
@@ -335,6 +333,11 @@ export default {
       'system.details.size.value',
       'system.details.type.value'
     ]).then(packIndex => {
+      // Ensure all entries are "monster" type
+      packIndex = packIndex.filter(entry => {
+        return entry.type === 'npc';
+      });
+
       // Restore the pack art.
       if (game.archmage.system?.moduleArt?.map?.size > 0) {
         for (let record of packIndex) {

--- a/src/vue/components/dialogs/compendium-browser/CompendiumBrowserCreatures.vue
+++ b/src/vue/components/dialogs/compendium-browser/CompendiumBrowserCreatures.vue
@@ -73,6 +73,18 @@
       />
     </div>
 
+    <!-- Location filter. -->
+    <div class="unit unit--input">
+      <label class="unit-title" for="compendiumBrowser.location">{{ localize('ARCHMAGE.location') }}</label>
+      <Multiselect
+        v-model="location"
+        mode="tags"
+        :searchable="false"
+        :create-option="false"
+        :options="locationNames"
+      />
+    </div>
+
     <!-- Reset. -->
     <div class="unit unit--input flexrow">
       <button type="reset" @click="resetFilters()">{{ localize('Reset') }}</button>
@@ -179,6 +191,7 @@ export default {
       role: [],
       size: [],
       source: [],
+      location: [],
     }
   },
   methods: {
@@ -264,6 +277,9 @@ export default {
       if (Array.isArray(this.source) && this.source.length > 0) {
         result = result.filter(entry => this.source.includes(entry.system.publicationSource));
       }
+      if (Array.isArray(this.location) && this.location.length > 0) {
+        result = result.filter(entry => this.location.includes(entry.compendiumTitle));
+      }
 
       // Reflow pager.
       if (result.length > this.pager.perPage) {
@@ -306,6 +322,11 @@ export default {
       }
       return Array.from(sources).sort();
     },
+    locationNames() {
+      // List of locations from the selected entries
+      const locations = new Set(this.packIndex.map(entry => entry.compendiumTitle));
+      return Array.from(locations).sort();
+    }
   },
   watch: {},
   // Handle created hook.

--- a/src/vue/components/dialogs/compendium-browser/CompendiumBrowserCreatures.vue
+++ b/src/vue/components/dialogs/compendium-browser/CompendiumBrowserCreatures.vue
@@ -339,7 +339,10 @@ export default {
 
     // If the 2e gamma module is active, remove the animal-companion pack that it replaces.
     if (game.modules.get('13th-age-core-2e-gamma')?.active) {
-      packIds.splice(packIds.indexOf('archmage.animal-companions'), 1);
+      const index = packIds.indexOf('archmage.animal-companions');
+      if (index > -1) {
+        packIds.splice(index, 1);
+      }
     }
 
     // Load the pack index with the fields we need.

--- a/src/vue/components/dialogs/compendium-browser/CompendiumBrowserItems.vue
+++ b/src/vue/components/dialogs/compendium-browser/CompendiumBrowserItems.vue
@@ -81,6 +81,18 @@
       />
     </div>
 
+    <!-- Location filter. -->
+    <div class="unit unit--input">
+      <label class="unit-title" for="compendiumBrowser.location">{{ localize('ARCHMAGE.location') }}</label>
+      <Multiselect
+        v-model="location"
+        mode="tags"
+        :searchable="false"
+        :create-option="false"
+        :options="locationNames"
+      />
+    </div>
+
     <!-- Reset. -->
     <div class="unit unit--input flexrow">
       <button type="reset" @click="resetFilters()">{{ localize('Reset') }}</button>
@@ -193,6 +205,7 @@ export default {
       bonuses: [],
       tier: [],
       powerUsage: [],
+      location: [],
     }
   },
   methods: {
@@ -350,6 +363,11 @@ export default {
       }
       return result;
     },
+    locationNames() {
+      // List of locations from the selected entries
+      const locations = new Set(this.packIndex.map(entry => entry.compendiumTitle));
+      return Array.from(locations).sort();
+    },
     nightmode() {
       return game.settings.get("archmage", "nightmode") ? 'nightmode' : '';
     },
@@ -377,6 +395,9 @@ export default {
       }
       if (Array.isArray(this.tier) && this.tier.length > 0) {
         result = result.filter(entry => this.tier.includes(entry.system?.tier ?? 'adventurer'));
+      }
+      if (Array.isArray(this.location) && this.location.length > 0) {
+        result = result.filter(entry => this.location.includes(entry.compendiumTitle));
       }
 
       // Recharge.

--- a/src/vue/components/dialogs/compendium-browser/CompendiumBrowserItems.vue
+++ b/src/vue/components/dialogs/compendium-browser/CompendiumBrowserItems.vue
@@ -480,14 +480,6 @@ export default {
       .filter(p => p.documentName === 'Item')
       .map(p => p.collection);
 
-    // If the 2e gamma module is active, remove the magic items pack it replaces
-    if (game.modules.get('13th-age-core-2e-gamma')?.active) {
-      const index = packIds.indexOf('archmage.srd-magic-items');
-      if (index > -1) {
-        packIds.splice(index, 1);
-      }
-    }
-
     // Load the pack index with the fields we need.
     getPackIndex(packIds, [
       'system.chackra',

--- a/src/vue/components/dialogs/compendium-browser/CompendiumBrowserItems.vue
+++ b/src/vue/components/dialogs/compendium-browser/CompendiumBrowserItems.vue
@@ -455,11 +455,17 @@ export default {
   async created() {
     console.log("Creating compendium browser magic items tab...");
 
-    const packIds = [
-      game.modules.get('13th-age-core-2e-gamma')?.active
-        ? '13th-age-core-2e-gamma.magic-items-2e'
-        : 'archmage.srd-magic-items'
-    ];
+    const packIds = game.packs.contents
+      .filter(p => p.documentName === 'Item')
+      .map(p => p.collection);
+
+    // If the 2e gamma module is active, remove the magic items pack it replaces
+    if (game.modules.get('13th-age-core-2e-gamma')?.active) {
+      const index = packIds.indexOf('archmage.srd-magic-items');
+      if (index > -1) {
+        packIds.splice(index, 1);
+      }
+    }
 
     // Load the pack index with the fields we need.
     getPackIndex(packIds, [
@@ -476,7 +482,10 @@ export default {
       'system.attributes.save',
       'system.attributes.disengage',
     ]).then(packIndex => {
-      this.packIndex = packIndex;
+      // Filter out non-magic-item entries.
+      this.packIndex = packIndex.filter(entry => {
+        return entry.type === 'equipment' || entry.type === 'loot';
+      });
       this.loaded = true;
     });
 

--- a/src/vue/components/dialogs/compendium-browser/CompendiumBrowserPowers.vue
+++ b/src/vue/components/dialogs/compendium-browser/CompendiumBrowserPowers.vue
@@ -74,6 +74,18 @@
       <input type="text" name="compendiumBrowser.trigger" v-model="trigger" placeholder="Even hit"/>
     </div>
 
+    <!-- Location filter. -->
+    <div class="unit unit--input">
+      <label class="unit-title" for="compendiumBrowser.location">{{ localize('ARCHMAGE.location') }}</label>
+      <Multiselect
+        v-model="location"
+        mode="tags"
+        :searchable="false"
+        :create-option="false"
+        :options="locationNames"
+      />
+    </div>
+
     <!-- Reset. -->
     <div class="unit unit--input flexrow">
       <button type="reset" @click="resetFilters()">{{ localize('Reset') }}</button>
@@ -180,6 +192,7 @@ export default {
       powerSourceName: '',
       powerUsage: [],
       trigger: '',
+      location: [],
     }
   },
   methods: {
@@ -266,6 +279,11 @@ export default {
     },
   },
   computed: {
+    locationNames() {
+      // List of locations from the selected entries
+      const locations = new Set(this.packIndex.map(entry => entry.compendiumTitle));
+      return Array.from(locations).sort();
+    },
     nightmode() {
       return game.settings.get("archmage", "nightmode") ? 'nightmode' : '';
     },
@@ -312,6 +330,9 @@ export default {
       }
       if (Array.isArray(this.actionType) && this.actionType.length > 0) {
         result = result.filter(entry => this.actionType.includes(entry.system.actionType.value));
+      }
+      if (Array.isArray(this.location) && this.location.length > 0) {
+        result = result.filter(entry => this.location.includes(entry.compendiumTitle));
       }
 
       // Reflow pager.

--- a/src/vue/components/dialogs/compendium-browser/CompendiumBrowserPowers.vue
+++ b/src/vue/components/dialogs/compendium-browser/CompendiumBrowserPowers.vue
@@ -353,42 +353,31 @@ export default {
   async created() {
     console.log("Creating compendium browser powers tab...");
     // Handle packs.
-    const packIds = game.modules.get('13th-age-core-2e-gamma')?.active ? [
-      '13th-age-core-2e-gamma.barbarian-2e',
-      '13th-age-core-2e-gamma.bard-2e',
-      '13th-age-core-2e-gamma.cleric-2e',
-      '13th-age-core-2e-gamma.fighter-2e',
-      '13th-age-core-2e-gamma.paladin-2e',
-      '13th-age-core-2e-gamma.ranger-2e',
-      '13th-age-core-2e-gamma.rogue-2e',
-      '13th-age-core-2e-gamma.sorcerer-2e',
-      '13th-age-core-2e-gamma.wizard-2e',
-      '13th-age-core-2e-gamma.kin-powers-2e',
-      '13th-age-core-2e-gamma.universal-feats-2e',
-      'archmage.chaosmage',
-      'archmage.commander',
-      'archmage.druid',
-      'archmage.monk',
-      'archmage.necromancer',
-      'archmage.occultist',
-    ] : [
-      'archmage.barbarian',
-      'archmage.bard',
-      'archmage.cleric',
-      'archmage.fighter',
-      'archmage.paladin',
-      'archmage.ranger',
-      'archmage.animal-companion',
-      'archmage.rogue',
-      'archmage.sorcerer',
-      'archmage.wizard',
-      'archmage.chaosmage',
-      'archmage.commander',
-      'archmage.druid',
-      'archmage.monk',
-      'archmage.necromancer',
-      'archmage.occultist',
-    ];
+    const packIds = game.packs.contents
+      .filter(pack => pack.documentName === 'Item')
+      .map(pack => pack.collection);
+
+    // If the 2e gamma module is active, remove the packs that it replaces.
+    if (game.modules.get('13th-age-core-2e-gamma')?.active) {
+      const gammaReplacedPacks = [
+        'archmage.barbarian',
+        'archmage.bard',
+        'archmage.cleric',
+        'archmage.fighter',
+        'archmage.paladin',
+        'archmage.ranger',
+        'archmage.animal-companion',
+        'archmage.rogue',
+        'archmage.sorcerer',
+        'archmage.wizard',
+      ]
+      for (const packId of gammaReplacedPacks) {
+        const index = packIds.indexOf(packId);
+        if (index > -1) {
+          packIds.splice(index, 1);
+        }
+      }
+    }
 
     // Load the pack index with the fields we need.
     getPackIndex(packIds, [
@@ -401,7 +390,7 @@ export default {
       'system.trigger.value',
       'system.feats'
     ]).then(packIndex => {
-      this.packIndex = packIndex;
+      this.packIndex = packIndex.filter(x => x.type === 'power');
       this.loaded = true;
     });
 

--- a/src/vue/methods/Helpers.js
+++ b/src/vue/methods/Helpers.js
@@ -381,7 +381,7 @@ export async function getPackIndex(packNames = [], fields = []) {
   for (let packName of packNames) {
     const pack = game.packs.get(packName);
     const packIndex = await pack.getIndex({fields: fields});
-    packs = packs.concat(packIndex.contents);
+    packs = packs.concat(packIndex.contents.map(x => ({...x, compendiumTitle: pack.title})));
   }
 
   return packs;

--- a/src/vue/methods/Helpers.js
+++ b/src/vue/methods/Helpers.js
@@ -376,14 +376,18 @@ export async function getPackIndex(packNames = [], fields = []) {
   if (!packNames) return;
   if (!fields || fields.length < 1) return;
 
-  let packs = [];
-
-  for (let packName of packNames) {
+  const promises = packNames.map(async packName => {
     const pack = game.packs.get(packName);
-    const packIndex = await pack.getIndex({fields: fields});
-    packs = packs.concat(packIndex.contents.map(x => ({...x, compendiumTitle: pack.title})));
-  }
+    if (!pack) return [];
+    const index = await pack.getIndex({ fields: fields });
+    return index.contents.map(x => ({ ...x, compendiumTitle: pack.title }));
+  });
+  const results = await Promise.all(promises);
 
+  let packs = [];
+  for (const result of results) {
+    packs = packs.concat(result);
+  }
   return packs;
 }
 


### PR DESCRIPTION
This allows content from all compendia in the compendium browser.

- [x] Load all packs into the browser
  - [x] Creatures
  - [x] Magic items
  - [x] Powers
- [x] Add a "location" filter control
  - [x] Creatures
  - [x] Magic items
  - [x] Powers
- [x] Parallelize compendium loads for speeeeed
