### PR TITLE
Remove Errant Recovery Dice Attributes from monsters

### DIFF
--- a/src/packs/src/srd-monsters/Aerial_Spore_YGm0aLYOxYuDLEBF.yml
+++ b/src/packs/src/srd-monsters/Aerial_Spore_YGm0aLYOxYuDLEBF.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Air_Elemental_JDrpfSABC3rrAUAa.yml
+++ b/src/packs/src/srd-monsters/Air_Elemental_JDrpfSABC3rrAUAa.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ancient_Purple_Worm_PfM0Q4bWexZzF5kG.yml
+++ b/src/packs/src/srd-monsters/Ancient_Purple_Worm_PfM0Q4bWexZzF5kG.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Ankheg_kcQCI1bWod0Z5qBH.yml
+++ b/src/packs/src/srd-monsters/Ankheg_kcQCI1bWod0Z5qBH.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Apex_Zorigami_3zO3zi1oItXUS3vN.yml
+++ b/src/packs/src/srd-monsters/Apex_Zorigami_3zO3zi1oItXUS3vN.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Archer_Stirge_ym0fowWROpOZkbM3.yml
+++ b/src/packs/src/srd-monsters/Archer_Stirge_ym0fowWROpOZkbM3.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Avenging_Orb_sMhDYM1KPC23VcZp.yml
+++ b/src/packs/src/srd-monsters/Avenging_Orb_sMhDYM1KPC23VcZp.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Awakened_Trees_ibtWNHE226OXTy9L.yml
+++ b/src/packs/src/srd-monsters/Awakened_Trees_ibtWNHE226OXTy9L.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Azer_Soldier_iuHhXriG1gLeJpjL.yml
+++ b/src/packs/src/srd-monsters/Azer_Soldier_iuHhXriG1gLeJpjL.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Balor__flame_demon__0qv7c4kXhHdKFWUl.yml
+++ b/src/packs/src/srd-monsters/Balor__flame_demon__0qv7c4kXhHdKFWUl.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Barbarous_Bugbear_SFMSruUvPzJvVVvx.yml
+++ b/src/packs/src/srd-monsters/Barbarous_Bugbear_SFMSruUvPzJvVVvx.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Barbed_Devil__Hamatula__Es4CNaaB5E76JxLA.yml
+++ b/src/packs/src/srd-monsters/Barbed_Devil__Hamatula__Es4CNaaB5E76JxLA.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Barbellite_UjSCx3qHeiCzLZYr.yml
+++ b/src/packs/src/srd-monsters/Barbellite_UjSCx3qHeiCzLZYr.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Basilisk_n8esrezVvm0eSBV6.yml
+++ b/src/packs/src/srd-monsters/Basilisk_n8esrezVvm0eSBV6.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Bat_Demon_fsM10X052LBugz52.yml
+++ b/src/packs/src/srd-monsters/Bat_Demon_fsM10X052LBugz52.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Bear_8xTrdlMs5KdLKvxJ.yml
+++ b/src/packs/src/srd-monsters/Bear_8xTrdlMs5KdLKvxJ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Bearded_Devil__Barbazu__9eFvIDQYNWJY8o0r.yml
+++ b/src/packs/src/srd-monsters/Bearded_Devil__Barbazu__9eFvIDQYNWJY8o0r.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Bergship_Raider__Frost__Y1eomXamSryinrMI.yml
+++ b/src/packs/src/srd-monsters/Bergship_Raider__Frost__Y1eomXamSryinrMI.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Big_Air_Elemental_aMJ8Y30BUkdVvAvw.yml
+++ b/src/packs/src/srd-monsters/Big_Air_Elemental_aMJ8Y30BUkdVvAvw.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Big_Earth_Elemental_C5MD7oU7MkKNF9VN.yml
+++ b/src/packs/src/srd-monsters/Big_Earth_Elemental_C5MD7oU7MkKNF9VN.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Big_Fire_Elemental_aqbohmuNvVut8pzW.yml
+++ b/src/packs/src/srd-monsters/Big_Fire_Elemental_aqbohmuNvVut8pzW.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Big_Water_Elemental_wUJXFt0QCBtxcJ5K.yml
+++ b/src/packs/src/srd-monsters/Big_Water_Elemental_wUJXFt0QCBtxcJ5K.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Big_Zombie_IiqizvB3zMlWsmj1.yml
+++ b/src/packs/src/srd-monsters/Big_Zombie_IiqizvB3zMlWsmj1.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Binding_Bride_1efai4ra5C5OQl7c.yml
+++ b/src/packs/src/srd-monsters/Binding_Bride_1efai4ra5C5OQl7c.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Black_Pudding_cFP4zaOlRmaSk6nL.yml
+++ b/src/packs/src/srd-monsters/Black_Pudding_cFP4zaOlRmaSk6nL.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Black_Skull_wZQL8SQxuOCZMB3D.yml
+++ b/src/packs/src/srd-monsters/Black_Skull_wZQL8SQxuOCZMB3D.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Blackamber_Skeletal_Legionnaire_dTWPeDSevoFRFrgC.yml
+++ b/src/packs/src/srd-monsters/Blackamber_Skeletal_Legionnaire_dTWPeDSevoFRFrgC.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Blizzard_Dragon__White__5Vp1aeQc2jQGNgpy.yml
+++ b/src/packs/src/srd-monsters/Blizzard_Dragon__White__5Vp1aeQc2jQGNgpy.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Blood_Rose_3dFpHdddefleCcae.yml
+++ b/src/packs/src/srd-monsters/Blood_Rose_3dFpHdddefleCcae.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Blue_Sorcerer_z61MzDMbczedGDls.yml
+++ b/src/packs/src/srd-monsters/Blue_Sorcerer_z61MzDMbczedGDls.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Bone_Devil__Osyluth__kIMBOvK9yRdLY32D.yml
+++ b/src/packs/src/srd-monsters/Bone_Devil__Osyluth__kIMBOvK9yRdLY32D.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Boombug_cpZE2FJOGUPVcer1.yml
+++ b/src/packs/src/srd-monsters/Boombug_cpZE2FJOGUPVcer1.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Braincap_2ayP8nkrJUfbTKxn.yml
+++ b/src/packs/src/srd-monsters/Braincap_2ayP8nkrJUfbTKxn.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Bronze_Golem_tda4lMHYL8KKDAmp.yml
+++ b/src/packs/src/srd-monsters/Bronze_Golem_tda4lMHYL8KKDAmp.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Bugbear_Schemer_Vfu1rIzPcWUzV48h.yml
+++ b/src/packs/src/srd-monsters/Bugbear_Schemer_Vfu1rIzPcWUzV48h.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Bugbear_Scout_5o1zaDDT6HPt0ixY.yml
+++ b/src/packs/src/srd-monsters/Bugbear_Scout_5o1zaDDT6HPt0ixY.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Bugbear_wsPxNxR7bjqwEp1R.yml
+++ b/src/packs/src/srd-monsters/Bugbear_wsPxNxR7bjqwEp1R.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Bulette_F0sQyvqvg3Sv5iy7.yml
+++ b/src/packs/src/srd-monsters/Bulette_F0sQyvqvg3Sv5iy7.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Cambion_Dirk_SSUTh5xDMEmUQ4Ea.yml
+++ b/src/packs/src/srd-monsters/Cambion_Dirk_SSUTh5xDMEmUQ4Ea.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Cambion_Hellblade_sJFphooMtZVPJKd3.yml
+++ b/src/packs/src/srd-monsters/Cambion_Hellblade_sJFphooMtZVPJKd3.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Cambion_Katar_AVurdV9m5R8LAEkr.yml
+++ b/src/packs/src/srd-monsters/Cambion_Katar_AVurdV9m5R8LAEkr.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Cambion_Sickle_f0gfVhnPlNW1MIOD.yml
+++ b/src/packs/src/srd-monsters/Cambion_Sickle_f0gfVhnPlNW1MIOD.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Catacomb_Dragon__Black__8cTzRPlsPBXxpmiT.yml
+++ b/src/packs/src/srd-monsters/Catacomb_Dragon__Black__8cTzRPlsPBXxpmiT.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Cave_Orc_qfWyLE7l3EwHFwiL.yml
+++ b/src/packs/src/srd-monsters/Cave_Orc_qfWyLE7l3EwHFwiL.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Cenotaph_Dragon__White__jyFDzHVEsQjP2nJ4.yml
+++ b/src/packs/src/srd-monsters/Cenotaph_Dragon__White__jyFDzHVEsQjP2nJ4.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Centaur_Champion_JNbV3Qgpq1Zjr8gJ.yml
+++ b/src/packs/src/srd-monsters/Centaur_Champion_JNbV3Qgpq1Zjr8gJ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Centaur_Lancer_b1TAqwAquBlduSFG.yml
+++ b/src/packs/src/srd-monsters/Centaur_Lancer_b1TAqwAquBlduSFG.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Centaur_Raider_FXvkDsAChdYKJSFe.yml
+++ b/src/packs/src/srd-monsters/Centaur_Raider_FXvkDsAChdYKJSFe.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Centaur_Ranger_7zv0bhbdj3Sy8ypo.yml
+++ b/src/packs/src/srd-monsters/Centaur_Ranger_7zv0bhbdj3Sy8ypo.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Chaos_Beast_W7XwFoQiwLTpMpo1.yml
+++ b/src/packs/src/srd-monsters/Chaos_Beast_W7XwFoQiwLTpMpo1.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Chaos_Behemoth_xOTIyU0eCfGx6gn2.yml
+++ b/src/packs/src/srd-monsters/Chaos_Behemoth_xOTIyU0eCfGx6gn2.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Chaos_Brute_uYjUlrxxdK2c2GSs.yml
+++ b/src/packs/src/srd-monsters/Chaos_Brute_uYjUlrxxdK2c2GSs.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Chaos_Glorp_CwO44w2SdkYGhNCi.yml
+++ b/src/packs/src/srd-monsters/Chaos_Glorp_CwO44w2SdkYGhNCi.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Chimera_ARlH94tHb7INBir8.yml
+++ b/src/packs/src/srd-monsters/Chimera_ARlH94tHb7INBir8.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Chuul_0Pnt7PdeHGEMgpyX.yml
+++ b/src/packs/src/srd-monsters/Chuul_0Pnt7PdeHGEMgpyX.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Chuulish_Slave_SrLdDkYVCPSW8OAL.yml
+++ b/src/packs/src/srd-monsters/Chuulish_Slave_SrLdDkYVCPSW8OAL.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Chuulish_Swarm_1abXzx4IUEgfmOgc.yml
+++ b/src/packs/src/srd-monsters/Chuulish_Swarm_1abXzx4IUEgfmOgc.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Claw_Flower_lj4VWRHTFpy9fTeU.yml
+++ b/src/packs/src/srd-monsters/Claw_Flower_lj4VWRHTFpy9fTeU.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Clay_Golem_hfAhD1HZv3FPxYXA.yml
+++ b/src/packs/src/srd-monsters/Clay_Golem_hfAhD1HZv3FPxYXA.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Cloud_Giant_Magician_zCM6En98e0rcKNSw.yml
+++ b/src/packs/src/srd-monsters/Cloud_Giant_Magician_zCM6En98e0rcKNSw.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Cloud_Giant_Thane_X7X7ul3wPBkjlCqZ.yml
+++ b/src/packs/src/srd-monsters/Cloud_Giant_Thane_X7X7ul3wPBkjlCqZ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Cobbler_Stirge_HrY8fcq7rjtpbQ1J.yml
+++ b/src/packs/src/srd-monsters/Cobbler_Stirge_HrY8fcq7rjtpbQ1J.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Common_Treant_cYnIt3NJH7OO8Wqy.yml
+++ b/src/packs/src/srd-monsters/Common_Treant_cYnIt3NJH7OO8Wqy.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Corpse_Dybbuk_ujYCygji9WkxdQ4e.yml
+++ b/src/packs/src/srd-monsters/Corpse_Dybbuk_ujYCygji9WkxdQ4e.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Couatl_kRT3BxYbtTFr1rn1.yml
+++ b/src/packs/src/srd-monsters/Couatl_kRT3BxYbtTFr1rn1.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Coursing_Manticore_PzQLZfzoDii33JJT.yml
+++ b/src/packs/src/srd-monsters/Coursing_Manticore_PzQLZfzoDii33JJT.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Crimsoncap_qAMkW4I35HKwrbqK.yml
+++ b/src/packs/src/srd-monsters/Crimsoncap_qAMkW4I35HKwrbqK.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Crustycap_PTbAUuN6KqYw0Kab.yml
+++ b/src/packs/src/srd-monsters/Crustycap_PTbAUuN6KqYw0Kab.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Dawn_Zorigami_eDikUkWnx7yJotnj.yml
+++ b/src/packs/src/srd-monsters/Dawn_Zorigami_eDikUkWnx7yJotnj.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Death_Blossom_jqLWn6eaQSVmRPAc.yml
+++ b/src/packs/src/srd-monsters/Death_Blossom_jqLWn6eaQSVmRPAc.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Death_Plague_Orc_Qh2CGKPuUwfYPB0w.yml
+++ b/src/packs/src/srd-monsters/Death_Plague_Orc_Qh2CGKPuUwfYPB0w.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Deathly_Warbanner_CbqHA6AgmgiEm5ae.yml
+++ b/src/packs/src/srd-monsters/Deathly_Warbanner_CbqHA6AgmgiEm5ae.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Decrepit_Skeleton_gFyVNR29nobL9tSx.yml
+++ b/src/packs/src/srd-monsters/Decrepit_Skeleton_gFyVNR29nobL9tSx.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Deep_Bulette_slyMHP5kFkIC6NxQ.yml
+++ b/src/packs/src/srd-monsters/Deep_Bulette_slyMHP5kFkIC6NxQ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Demon_Touched_Human_Ranger_3dlnQkhx8TpCarCt.yml
+++ b/src/packs/src/srd-monsters/Demon_Touched_Human_Ranger_3dlnQkhx8TpCarCt.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Demonic_Ogre_eSxjbNlWKIsQ77Tc.yml
+++ b/src/packs/src/srd-monsters/Demonic_Ogre_eSxjbNlWKIsQ77Tc.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Derro_Maniac_sPBu8zUGj5Ia6J55.yml
+++ b/src/packs/src/srd-monsters/Derro_Maniac_sPBu8zUGj5Ia6J55.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Derro_Sage_W0M2ejIUlD2TxYbx.yml
+++ b/src/packs/src/srd-monsters/Derro_Sage_W0M2ejIUlD2TxYbx.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Despoiler_EmaL5mH7R4EUTg5H.yml
+++ b/src/packs/src/srd-monsters/Despoiler_EmaL5mH7R4EUTg5H.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Despoiler_Mage_nCYamGsCRPItZSI1.yml
+++ b/src/packs/src/srd-monsters/Despoiler_Mage_nCYamGsCRPItZSI1.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Destroying_Sword_44WH5nxugTaJ6Z3b.yml
+++ b/src/packs/src/srd-monsters/Destroying_Sword_44WH5nxugTaJ6Z3b.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Dire_Bear_Diczik9saugCGzYB.yml
+++ b/src/packs/src/srd-monsters/Dire_Bear_Diczik9saugCGzYB.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Dire_Boar_aCX8HjyvuWck0jAg.yml
+++ b/src/packs/src/srd-monsters/Dire_Boar_aCX8HjyvuWck0jAg.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Dire_Rat_5xA4KU43DJLTfLWP.yml
+++ b/src/packs/src/srd-monsters/Dire_Rat_5xA4KU43DJLTfLWP.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Dire_Tiger_DRmwqEMBhL5K5DII.yml
+++ b/src/packs/src/srd-monsters/Dire_Tiger_DRmwqEMBhL5K5DII.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Dire_Wolf_jxaQNMCUhbQsz8z6.yml
+++ b/src/packs/src/srd-monsters/Dire_Wolf_jxaQNMCUhbQsz8z6.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Djinn_AHweCvDlAvWJjZc3.yml
+++ b/src/packs/src/srd-monsters/Djinn_AHweCvDlAvWJjZc3.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Dread_Specter_dhCsJSO9z6fGIO5Z.yml
+++ b/src/packs/src/srd-monsters/Dread_Specter_dhCsJSO9z6fGIO5Z.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Dretch_BgnA5UCONHAlU5Kh.yml
+++ b/src/packs/src/srd-monsters/Dretch_BgnA5UCONHAlU5Kh.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Drider_xeqmCIkBb12jNem7.yml
+++ b/src/packs/src/srd-monsters/Drider_xeqmCIkBb12jNem7.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Drow_Cavalry_xB3JF1GyM5b7u5Fj.yml
+++ b/src/packs/src/srd-monsters/Drow_Cavalry_xB3JF1GyM5b7u5Fj.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Drow_Soldier_z2gt1gtC6YN1uw6T.yml
+++ b/src/packs/src/srd-monsters/Drow_Soldier_z2gt1gtC6YN1uw6T.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Drow_Spider_Mage_a1CPXigDfNc634RD.yml
+++ b/src/packs/src/srd-monsters/Drow_Spider_Mage_a1CPXigDfNc634RD.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Drow_Spider_Sorceress_FxGpvVUgRqFo4yh6.yml
+++ b/src/packs/src/srd-monsters/Drow_Spider_Sorceress_FxGpvVUgRqFo4yh6.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Drow_Sword_Maiden_pH2bYqxtYdMKkooC.yml
+++ b/src/packs/src/srd-monsters/Drow_Sword_Maiden_pH2bYqxtYdMKkooC.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Dusk_Zorigami_txuQ5FWVKX9u4HRk.yml
+++ b/src/packs/src/srd-monsters/Dusk_Zorigami_txuQ5FWVKX9u4HRk.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Earth_Elemental_1Ctzvj8kceqsowbU.yml
+++ b/src/packs/src/srd-monsters/Earth_Elemental_1Ctzvj8kceqsowbU.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Efreet_KZnOoom2nKpBYKeW.yml
+++ b/src/packs/src/srd-monsters/Efreet_KZnOoom2nKpBYKeW.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Elder_Manafang_Naga_rvpic1GaPiPJzfMo.yml
+++ b/src/packs/src/srd-monsters/Elder_Manafang_Naga_rvpic1GaPiPJzfMo.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Elder_Sparkscale_Naga_cfahZzXSitFIPQgs.yml
+++ b/src/packs/src/srd-monsters/Elder_Sparkscale_Naga_cfahZzXSitFIPQgs.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Elder_Spore_RSkN7WrG1bs3oyHd.yml
+++ b/src/packs/src/srd-monsters/Elder_Spore_RSkN7WrG1bs3oyHd.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Elder_Swaysong_Naga_APcsUizHmsMR7tFH.yml
+++ b/src/packs/src/srd-monsters/Elder_Swaysong_Naga_APcsUizHmsMR7tFH.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Elder_Wendigo_CZPQxHUFA7EVNJ2K.yml
+++ b/src/packs/src/srd-monsters/Elder_Wendigo_CZPQxHUFA7EVNJ2K.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Empyrean_Dragon__Black__MT7D2ZQhiio010YI.yml
+++ b/src/packs/src/srd-monsters/Empyrean_Dragon__Black__MT7D2ZQhiio010YI.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Enduring_Shield_pRvk6BaDt3hpMGFn.yml
+++ b/src/packs/src/srd-monsters/Enduring_Shield_pRvk6BaDt3hpMGFn.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Epic_Air_Elemental_7ikZRRXC0chRAch7.yml
+++ b/src/packs/src/srd-monsters/Epic_Air_Elemental_7ikZRRXC0chRAch7.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Epic_Earth_Elemental_7lQkborFfbe5bhia.yml
+++ b/src/packs/src/srd-monsters/Epic_Earth_Elemental_7lQkborFfbe5bhia.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Epic_Fire_Elemental_a4Klpt6gf9DKgzK7.yml
+++ b/src/packs/src/srd-monsters/Epic_Fire_Elemental_a4Klpt6gf9DKgzK7.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Epic_Water_Elemental_M6bS5hZ8wKPwEesy.yml
+++ b/src/packs/src/srd-monsters/Epic_Water_Elemental_M6bS5hZ8wKPwEesy.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ethereal_Dybbuk_inegqMJFhP2AmYVD.yml
+++ b/src/packs/src/srd-monsters/Ethereal_Dybbuk_inegqMJFhP2AmYVD.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ettercap_Acolyte_zu2F2IjGPGL3jObN.yml
+++ b/src/packs/src/srd-monsters/Ettercap_Acolyte_zu2F2IjGPGL3jObN.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ettercap_Hunter_wTE6yodJNOOL7ZM9.yml
+++ b/src/packs/src/srd-monsters/Ettercap_Hunter_wTE6yodJNOOL7ZM9.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ettercap_Keeper_vGoKjhVw0YbIBRGC.yml
+++ b/src/packs/src/srd-monsters/Ettercap_Keeper_vGoKjhVw0YbIBRGC.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ettercap_Supplicant_nCvgaEGi9l1w6jfD.yml
+++ b/src/packs/src/srd-monsters/Ettercap_Supplicant_nCvgaEGi9l1w6jfD.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ettercap_Warrior_Nhkat9IKTYjDDmpA.yml
+++ b/src/packs/src/srd-monsters/Ettercap_Warrior_Nhkat9IKTYjDDmpA.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ettin_mpfOqaO3FDhLPDXW.yml
+++ b/src/packs/src/srd-monsters/Ettin_mpfOqaO3FDhLPDXW.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Fallen_Lammasu_eJLzKl3r89V7ATUR.yml
+++ b/src/packs/src/srd-monsters/Fallen_Lammasu_eJLzKl3r89V7ATUR.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Fang_Devil_zgih0GWcaiDOs7iU.yml
+++ b/src/packs/src/srd-monsters/Fang_Devil_zgih0GWcaiDOs7iU.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Feral_Warbanner_V3dfS90T5aSpJe3T.yml
+++ b/src/packs/src/srd-monsters/Feral_Warbanner_V3dfS90T5aSpJe3T.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Fire_Bat_ysQE2YF4RoQYdhmV.yml
+++ b/src/packs/src/srd-monsters/Fire_Bat_ysQE2YF4RoQYdhmV.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Fire_Elemental_8tB4mhjzjIhwxT9F.yml
+++ b/src/packs/src/srd-monsters/Fire_Elemental_8tB4mhjzjIhwxT9F.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Fire_Giant_Warlord_f0vOJcihqGrqhmGV.yml
+++ b/src/packs/src/srd-monsters/Fire_Giant_Warlord_f0vOJcihqGrqhmGV.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Fire_Giant_m2cAw8ju6JtfAp1W.yml
+++ b/src/packs/src/srd-monsters/Fire_Giant_m2cAw8ju6JtfAp1W.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Five_Headed_Hydra_ZEpelUvJiCTTrnau.yml
+++ b/src/packs/src/srd-monsters/Five_Headed_Hydra_ZEpelUvJiCTTrnau.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Flamewreathed_Dragon__Red__NC2LGEPu81AyTj3X.yml
+++ b/src/packs/src/srd-monsters/Flamewreathed_Dragon__Red__NC2LGEPu81AyTj3X.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Flaming_Skull_YV7RVp2f4ef5fbht.yml
+++ b/src/packs/src/srd-monsters/Flaming_Skull_YV7RVp2f4ef5fbht.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Flesh_Golem_UA5DfEwzN2BrPIfW.yml
+++ b/src/packs/src/srd-monsters/Flesh_Golem_UA5DfEwzN2BrPIfW.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Frenzy_Demon_CGxhEoQh1hHZIeyz.yml
+++ b/src/packs/src/srd-monsters/Frenzy_Demon_CGxhEoQh1hHZIeyz.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Frost_Giant_Adventurer_7EG1WR5a6GMqZrck.yml
+++ b/src/packs/src/srd-monsters/Frost_Giant_Adventurer_7EG1WR5a6GMqZrck.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Frost_Giant_kS97PEiCwJzLUzPB.yml
+++ b/src/packs/src/srd-monsters/Frost_Giant_kS97PEiCwJzLUzPB.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Frost_W_rm_c3k7IotMuSwEEQkA.yml
+++ b/src/packs/src/srd-monsters/Frost_W_rm_c3k7IotMuSwEEQkA.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Fungaloid_Creeper_9Pe00XhaTPLbiGMF.yml
+++ b/src/packs/src/srd-monsters/Fungaloid_Creeper_9Pe00XhaTPLbiGMF.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Fungaloid_Drudge_H9CAjvuSiKWDcehg.yml
+++ b/src/packs/src/srd-monsters/Fungaloid_Drudge_H9CAjvuSiKWDcehg.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Fungaloid_Empress_WC7EFRm4qbrqwcNo.yml
+++ b/src/packs/src/srd-monsters/Fungaloid_Empress_WC7EFRm4qbrqwcNo.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Fungaloid_Monarch_8xzcKhUF6ke727i6.yml
+++ b/src/packs/src/srd-monsters/Fungaloid_Monarch_8xzcKhUF6ke727i6.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Fury_Devil__Erinyes__CrkhTU3AyEm6vnaV.yml
+++ b/src/packs/src/srd-monsters/Fury_Devil__Erinyes__CrkhTU3AyEm6vnaV.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Gargoyle_Vq3qL60t3VHSfCyn.yml
+++ b/src/packs/src/srd-monsters/Gargoyle_Vq3qL60t3VHSfCyn.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Gelatinous_Cubahedron__aka_Cube__mEZbOR2BrCd8hw9j.yml
+++ b/src/packs/src/srd-monsters/Gelatinous_Cubahedron__aka_Cube__mEZbOR2BrCd8hw9j.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Gelatinous_Cube_2ZTQ3LrPDrlhr6in.yml
+++ b/src/packs/src/srd-monsters/Gelatinous_Cube_2ZTQ3LrPDrlhr6in.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Gelatinous_Dodecaedron_XnKTLcGHCMtS2OLr.yml
+++ b/src/packs/src/srd-monsters/Gelatinous_Dodecaedron_XnKTLcGHCMtS2OLr.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Gelatinous_Octahedron_FMx0i9N4bOVCJOmW.yml
+++ b/src/packs/src/srd-monsters/Gelatinous_Octahedron_FMx0i9N4bOVCJOmW.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Gelatinous_Tetrahedron_pZnuvB9d3NyAAePq.yml
+++ b/src/packs/src/srd-monsters/Gelatinous_Tetrahedron_pZnuvB9d3NyAAePq.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ghast_JmUz3WJRrYUGkJ2Q.yml
+++ b/src/packs/src/srd-monsters/Ghast_JmUz3WJRrYUGkJ2Q.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ghoul_4Qjs7wLjwY8ONzyj.yml
+++ b/src/packs/src/srd-monsters/Ghoul_4Qjs7wLjwY8ONzyj.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ghoul_Fleshripper_k3QLAyXdRBN1T7gG.yml
+++ b/src/packs/src/srd-monsters/Ghoul_Fleshripper_k3QLAyXdRBN1T7gG.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ghoul_Licklash_prHmHTXHse0ObRv5.yml
+++ b/src/packs/src/srd-monsters/Ghoul_Licklash_prHmHTXHse0ObRv5.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Ghoul_Pusbuster_2EeMUmZyM7P9RWIM.yml
+++ b/src/packs/src/srd-monsters/Ghoul_Pusbuster_2EeMUmZyM7P9RWIM.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Giant_Ant_VTf5pPTNxSJXVMcx.yml
+++ b/src/packs/src/srd-monsters/Giant_Ant_VTf5pPTNxSJXVMcx.yml
@@ -74,12 +74,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Giant_Praying_Mantis_IhiR0lQWPtggTsDa.yml
+++ b/src/packs/src/srd-monsters/Giant_Praying_Mantis_IhiR0lQWPtggTsDa.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Giant_Scorpion_kIR3vCxcKKYhqfNm.yml
+++ b/src/packs/src/srd-monsters/Giant_Scorpion_kIR3vCxcKKYhqfNm.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Giant_Vrock__vulture_demon__ZxCF0QA5TbMuub3U.yml
+++ b/src/packs/src/srd-monsters/Giant_Vrock__vulture_demon__ZxCF0QA5TbMuub3U.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Giant_Web_Spider_wyYrqm5BJyfSBuIg.yml
+++ b/src/packs/src/srd-monsters/Giant_Web_Spider_wyYrqm5BJyfSBuIg.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Giant_Zombie_GWD2zP1AWpJ2bXtn.yml
+++ b/src/packs/src/srd-monsters/Giant_Zombie_GWD2zP1AWpJ2bXtn.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Glabrezou__pincer_demon__pmT7vKf1VxHXoxA8.yml
+++ b/src/packs/src/srd-monsters/Glabrezou__pincer_demon__pmT7vKf1VxHXoxA8.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Gnoll_Fiendfletch_OJyjJAHLOqeQUsdF.yml
+++ b/src/packs/src/srd-monsters/Gnoll_Fiendfletch_OJyjJAHLOqeQUsdF.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Gnoll_Ranger_dxTwj8RJAtj0khpa.yml
+++ b/src/packs/src/srd-monsters/Gnoll_Ranger_dxTwj8RJAtj0khpa.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Gnoll_Savage_YWV41syd0JbYKyfz.yml
+++ b/src/packs/src/srd-monsters/Gnoll_Savage_YWV41syd0JbYKyfz.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Gnoll_Shredder_h2EYagaLchOWbnvC.yml
+++ b/src/packs/src/srd-monsters/Gnoll_Shredder_h2EYagaLchOWbnvC.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Gnoll_War_Leader_2atghIyBkCS7WZ1F.yml
+++ b/src/packs/src/srd-monsters/Gnoll_War_Leader_2atghIyBkCS7WZ1F.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Goblin_Bat_Mage_Ql6S9QXrnlIETuxL.yml
+++ b/src/packs/src/srd-monsters/Goblin_Bat_Mage_Ql6S9QXrnlIETuxL.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Goblin_Grunt_LEM1INiGQLyu1U05.yml
+++ b/src/packs/src/srd-monsters/Goblin_Grunt_LEM1INiGQLyu1U05.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Goblin_Scum_WXMiBSHV9Kujf46n.yml
+++ b/src/packs/src/srd-monsters/Goblin_Scum_WXMiBSHV9Kujf46n.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Goblin_Shaman_2zDKFIRWNB3QOPUQ.yml
+++ b/src/packs/src/srd-monsters/Goblin_Shaman_2zDKFIRWNB3QOPUQ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Gorge_Dragon__Black__FfG992lOYvyqrjkB.yml
+++ b/src/packs/src/srd-monsters/Gorge_Dragon__Black__FfG992lOYvyqrjkB.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Gravemeat_kCbeSRConIBao6ID.yml
+++ b/src/packs/src/srd-monsters/Gravemeat_kCbeSRConIBao6ID.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Great_Fang_Cadre_dkoyxuCZl9tnNH9S.yml
+++ b/src/packs/src/srd-monsters/Great_Fang_Cadre_dkoyxuCZl9tnNH9S.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Great_Horned_Owlbear_J4f9G9GgZjWAw6jC.yml
+++ b/src/packs/src/srd-monsters/Great_Horned_Owlbear_J4f9G9GgZjWAw6jC.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Greathoard_elder__Red__Yxj7ERaB70RcSYkK.yml
+++ b/src/packs/src/srd-monsters/Greathoard_elder__Red__Yxj7ERaB70RcSYkK.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Green_Bulette_fxfyW7uIHagmiB5z.yml
+++ b/src/packs/src/srd-monsters/Green_Bulette_fxfyW7uIHagmiB5z.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Hag_ogO3HkOmmTKMFJoO.yml
+++ b/src/packs/src/srd-monsters/Hag_ogO3HkOmmTKMFJoO.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Hagunemnon_ep3ZLwDJtMSfLqyZ.yml
+++ b/src/packs/src/srd-monsters/Hagunemnon_ep3ZLwDJtMSfLqyZ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Half_Orc_Commander_kp3CDjGcAGJ1C3RJ.yml
+++ b/src/packs/src/srd-monsters/Half_Orc_Commander_kp3CDjGcAGJ1C3RJ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Half_Orc_Tribal_Champion_c1b0LF2pIJFPlzhm.yml
+++ b/src/packs/src/srd-monsters/Half_Orc_Tribal_Champion_c1b0LF2pIJFPlzhm.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Harpy_taWrEq22pthdVkRZ.yml
+++ b/src/packs/src/srd-monsters/Harpy_taWrEq22pthdVkRZ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Headless_Zombie_TXzNViOwvjgTf2IJ.yml
+++ b/src/packs/src/srd-monsters/Headless_Zombie_TXzNViOwvjgTf2IJ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Hell_Imp_TjHK0EnGKSxUfXvx.yml
+++ b/src/packs/src/srd-monsters/Hell_Imp_TjHK0EnGKSxUfXvx.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Hellhound_XXJpiQImBXZa7OxP.yml
+++ b/src/packs/src/srd-monsters/Hellhound_XXJpiQImBXZa7OxP.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Hellwasp_PfDeh8PVsZmw53Ft.yml
+++ b/src/packs/src/srd-monsters/Hellwasp_PfDeh8PVsZmw53Ft.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Hezrou__toad_demon__S98GOa9Kag5C7UlB.yml
+++ b/src/packs/src/srd-monsters/Hezrou__toad_demon__S98GOa9Kag5C7UlB.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Hill_Giant_qx4dKzHiCKZEI39v.yml
+++ b/src/packs/src/srd-monsters/Hill_Giant_qx4dKzHiCKZEI39v.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Hoard_Spirit__Red__wPq3ZHZwQQtkHlOV.yml
+++ b/src/packs/src/srd-monsters/Hoard_Spirit__Red__wPq3ZHZwQQtkHlOV.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Hoardsong_Dragon__Red__6t1WceFl0n8rOgYp.yml
+++ b/src/packs/src/srd-monsters/Hoardsong_Dragon__Red__6t1WceFl0n8rOgYp.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Hobgoblin_Captain_17aTIyYffIlKbXdQ.yml
+++ b/src/packs/src/srd-monsters/Hobgoblin_Captain_17aTIyYffIlKbXdQ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Hobgoblin_Warmage_XQSuJf2GeX0vgwQD.yml
+++ b/src/packs/src/srd-monsters/Hobgoblin_Warmage_XQSuJf2GeX0vgwQD.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Hobgoblin_Warrior_5pNBcbXM6PTkPHSp.yml
+++ b/src/packs/src/srd-monsters/Hobgoblin_Warrior_5pNBcbXM6PTkPHSp.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Honey_Devil__aka_Slime_Devil_hEGryxs5FdeTMVsH.yml
+++ b/src/packs/src/srd-monsters/Honey_Devil__aka_Slime_Devil_hEGryxs5FdeTMVsH.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Hooded_Devil_erfYruT57tsVWEik.yml
+++ b/src/packs/src/srd-monsters/Hooded_Devil_erfYruT57tsVWEik.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Hook_Scuttler_cYucX28Rm9i86R9j.yml
+++ b/src/packs/src/srd-monsters/Hook_Scuttler_cYucX28Rm9i86R9j.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Hooked_Demon_jw9ZrZW8zmBzSeBv.yml
+++ b/src/packs/src/srd-monsters/Hooked_Demon_jw9ZrZW8zmBzSeBv.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Horned_Devil__Cornugon__3CwHM0sJIkm5ImgA.yml
+++ b/src/packs/src/srd-monsters/Horned_Devil__Cornugon__3CwHM0sJIkm5ImgA.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Huge_Black_Dragon_1j2K3ryrnDWKaKKV.yml
+++ b/src/packs/src/srd-monsters/Huge_Black_Dragon_1j2K3ryrnDWKaKKV.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Huge_Blue_Dragon_RPlCfAz5ypEeo5LH.yml
+++ b/src/packs/src/srd-monsters/Huge_Blue_Dragon_RPlCfAz5ypEeo5LH.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Huge_Brass_Dragon__Metallic__ZNlL3LuF3ASgA6W6.yml
+++ b/src/packs/src/srd-monsters/Huge_Brass_Dragon__Metallic__ZNlL3LuF3ASgA6W6.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Huge_Bronze_Dragon__Metallic__1rxcwrJp1DqNLG8F.yml
+++ b/src/packs/src/srd-monsters/Huge_Bronze_Dragon__Metallic__1rxcwrJp1DqNLG8F.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Huge_Copper_Dragon__Metallic__uhXPwGgX5ZzOKuQn.yml
+++ b/src/packs/src/srd-monsters/Huge_Copper_Dragon__Metallic__uhXPwGgX5ZzOKuQn.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Huge_Gold_Dragon__Metallic__VFls7iXvokI7AeWp.yml
+++ b/src/packs/src/srd-monsters/Huge_Gold_Dragon__Metallic__VFls7iXvokI7AeWp.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Huge_Green_Dragon_EBeb047C5LBIZE7r.yml
+++ b/src/packs/src/srd-monsters/Huge_Green_Dragon_EBeb047C5LBIZE7r.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Huge_Red_Dragon_piVOzj9ljQ2Nc8XA.yml
+++ b/src/packs/src/srd-monsters/Huge_Red_Dragon_piVOzj9ljQ2Nc8XA.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Huge_Silver_Dragon__Metallic__JXu6g20rItl1bGeW.yml
+++ b/src/packs/src/srd-monsters/Huge_Silver_Dragon__Metallic__JXu6g20rItl1bGeW.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Huge_White_Dragon_ouNkVCZEHYF9WJEY.yml
+++ b/src/packs/src/srd-monsters/Huge_White_Dragon_ouNkVCZEHYF9WJEY.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Human_Rabble_vbiGOhGmKykQUBMu.yml
+++ b/src/packs/src/srd-monsters/Human_Rabble_vbiGOhGmKykQUBMu.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Human_Thug_Clo9EA67PN4Nm8M4.yml
+++ b/src/packs/src/srd-monsters/Human_Thug_Clo9EA67PN4Nm8M4.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Human_Zombie_TrKcccXQgE2Eypup.yml
+++ b/src/packs/src/srd-monsters/Human_Zombie_TrKcccXQgE2Eypup.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Hungry_Star_JPmUO0psaGKlpBbM.yml
+++ b/src/packs/src/srd-monsters/Hungry_Star_JPmUO0psaGKlpBbM.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Hunting_Spider_9wLbc3ZzTuFdKZq5.yml
+++ b/src/packs/src/srd-monsters/Hunting_Spider_9wLbc3ZzTuFdKZq5.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ice_Devil__Gelugon__q6t8Q3HR3vX1zKIu.yml
+++ b/src/packs/src/srd-monsters/Ice_Devil__Gelugon__q6t8Q3HR3vX1zKIu.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ice_Sorceress__Frost__jLd4qMUNwXJbzPhl.yml
+++ b/src/packs/src/srd-monsters/Ice_Sorceress__Frost__jLd4qMUNwXJbzPhl.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ice_Zombie_mRBoJt1YmeKCG4BC.yml
+++ b/src/packs/src/srd-monsters/Ice_Zombie_mRBoJt1YmeKCG4BC.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Iconic_Chimera_53Brby12w3L3S1d5.yml
+++ b/src/packs/src/srd-monsters/Iconic_Chimera_53Brby12w3L3S1d5.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Imp_KWbhq0OXT0lENahj.yml
+++ b/src/packs/src/srd-monsters/Imp_KWbhq0OXT0lENahj.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Intellect_Assassin_2btXlpzKn05yfoeJ.yml
+++ b/src/packs/src/srd-monsters/Intellect_Assassin_2btXlpzKn05yfoeJ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Intellect_devourer_i6WPEodUc7I9xujP.yml
+++ b/src/packs/src/srd-monsters/Intellect_devourer_i6WPEodUc7I9xujP.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Iron_Golem_GUj1lMVfQYfY9FWU.yml
+++ b/src/packs/src/srd-monsters/Iron_Golem_GUj1lMVfQYfY9FWU.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Jest_Bones_2hD2ayqAGPW7EkAB.yml
+++ b/src/packs/src/srd-monsters/Jest_Bones_2hD2ayqAGPW7EkAB.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Jotun_Auroch_hfH16sCh4rhMs9zn.yml
+++ b/src/packs/src/srd-monsters/Jotun_Auroch_hfH16sCh4rhMs9zn.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Kobold_Archer_3n01ruWTwsIt8RKr.yml
+++ b/src/packs/src/srd-monsters/Kobold_Archer_3n01ruWTwsIt8RKr.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Kobold_Bravescale_ddC1ps4fD9AXQ4Qm.yml
+++ b/src/packs/src/srd-monsters/Kobold_Bravescale_ddC1ps4fD9AXQ4Qm.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Kobold_Dog_Rider_Jwp222BwKTCReiOD.yml
+++ b/src/packs/src/srd-monsters/Kobold_Dog_Rider_Jwp222BwKTCReiOD.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Kobold_Dragon_Soul_5iE2zJD7k8Nygp6q.yml
+++ b/src/packs/src/srd-monsters/Kobold_Dragon_Soul_5iE2zJD7k8Nygp6q.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Kobold_Dungeon_Shaman_wOVCQBNUhMZSyjqA.yml
+++ b/src/packs/src/srd-monsters/Kobold_Dungeon_Shaman_wOVCQBNUhMZSyjqA.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Kobold_Engineer_tMV2PMekFnM91nxb.yml
+++ b/src/packs/src/srd-monsters/Kobold_Engineer_tMV2PMekFnM91nxb.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Kobold_Grand_Wizard_aI4MSha27QxJonsf.yml
+++ b/src/packs/src/srd-monsters/Kobold_Grand_Wizard_aI4MSha27QxJonsf.yml
@@ -74,12 +74,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Kobold_Hero_VJ1sqwMyR5EAyFJZ.yml
+++ b/src/packs/src/srd-monsters/Kobold_Hero_VJ1sqwMyR5EAyFJZ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Kobold_Shadow_Warrior_vrrOm7z9dJ5x0fby.yml
+++ b/src/packs/src/srd-monsters/Kobold_Shadow_Warrior_vrrOm7z9dJ5x0fby.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Kobold_Skyclaw_uPClx3nOxlMEDIzJ.yml
+++ b/src/packs/src/srd-monsters/Kobold_Skyclaw_uPClx3nOxlMEDIzJ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Kobold_Warrior_sVcsDTsOJmDt4ErL.yml
+++ b/src/packs/src/srd-monsters/Kobold_Warrior_sVcsDTsOJmDt4ErL.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Lammasu_Priest_5PJeAZ421xz26Dft.yml
+++ b/src/packs/src/srd-monsters/Lammasu_Priest_5PJeAZ421xz26Dft.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Lammasu_Warrior_7KIdM2t1qf6DTkk6.yml
+++ b/src/packs/src/srd-monsters/Lammasu_Warrior_7KIdM2t1qf6DTkk6.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Lammasu_Wizard_axFxaEvBkBy9ulkb.yml
+++ b/src/packs/src/srd-monsters/Lammasu_Wizard_axFxaEvBkBy9ulkb.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Large_Black_Dragon_BPIodF4Ja1Fzrq0w.yml
+++ b/src/packs/src/srd-monsters/Large_Black_Dragon_BPIodF4Ja1Fzrq0w.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Large_Blue_Dragon_HY35ul0coNqlTqhH.yml
+++ b/src/packs/src/srd-monsters/Large_Blue_Dragon_HY35ul0coNqlTqhH.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Large_Brass_Dragon__Metallic__6kxxGcBiwqvaKNZ2.yml
+++ b/src/packs/src/srd-monsters/Large_Brass_Dragon__Metallic__6kxxGcBiwqvaKNZ2.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Large_Bronze_Dragon__Metallic__XT9Kp19Tfm1f1iQ4.yml
+++ b/src/packs/src/srd-monsters/Large_Bronze_Dragon__Metallic__XT9Kp19Tfm1f1iQ4.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Large_Copper_Dragon__Metallic__pvCCsyJ9PIt1AgMb.yml
+++ b/src/packs/src/srd-monsters/Large_Copper_Dragon__Metallic__pvCCsyJ9PIt1AgMb.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Large_Gold_Dragon__Metallic__I7EJYb2eB5bArUz1.yml
+++ b/src/packs/src/srd-monsters/Large_Gold_Dragon__Metallic__I7EJYb2eB5bArUz1.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Large_Green_Dragon_1QTA8lvKy6tanrLA.yml
+++ b/src/packs/src/srd-monsters/Large_Green_Dragon_1QTA8lvKy6tanrLA.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Large_Red_Dragon_bJEZdUrLa8vmzaNs.yml
+++ b/src/packs/src/srd-monsters/Large_Red_Dragon_bJEZdUrLa8vmzaNs.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Large_Silver_Dragon__Metallic__4JUQkcWeXyEzbc3y.yml
+++ b/src/packs/src/srd-monsters/Large_Silver_Dragon__Metallic__4JUQkcWeXyEzbc3y.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Large_White_Dragon_T2GpGMD7RmJJFGGh.yml
+++ b/src/packs/src/srd-monsters/Large_White_Dragon_T2GpGMD7RmJJFGGh.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Lemure_lxDotrrIxRrnMFgs.yml
+++ b/src/packs/src/srd-monsters/Lemure_lxDotrrIxRrnMFgs.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Lethal_Lothario_ZJZxMVsEmxMF4Mu7.yml
+++ b/src/packs/src/srd-monsters/Lethal_Lothario_ZJZxMVsEmxMF4Mu7.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Lich_Baroness_0DIRBabTKeTVsMxt.yml
+++ b/src/packs/src/srd-monsters/Lich_Baroness_0DIRBabTKeTVsMxt.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Lich_Count_RRNgcogkrNvkqDdD.yml
+++ b/src/packs/src/srd-monsters/Lich_Count_RRNgcogkrNvkqDdD.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Lich_Flower_Cxj3C6U7rE63sYSW.yml
+++ b/src/packs/src/srd-monsters/Lich_Flower_Cxj3C6U7rE63sYSW.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Lich_Prince_eOzmybMMK6tezfyO.yml
+++ b/src/packs/src/srd-monsters/Lich_Prince_eOzmybMMK6tezfyO.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Lizardman_Savage_aEhO6Ud88riakSpk.yml
+++ b/src/packs/src/srd-monsters/Lizardman_Savage_aEhO6Ud88riakSpk.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Lokkris_D8TLRG83sge5mFJN.yml
+++ b/src/packs/src/srd-monsters/Lokkris_D8TLRG83sge5mFJN.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Lumberland_Dirt_Fisher_QFdtkCZqY8QslGkG.yml
+++ b/src/packs/src/srd-monsters/Lumberland_Dirt_Fisher_QFdtkCZqY8QslGkG.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Magma_Brute_1lSQAyEPJIRDg6hN.yml
+++ b/src/packs/src/srd-monsters/Magma_Brute_1lSQAyEPJIRDg6hN.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Manafang_Naga_qSwaG0siGiYi5pqU.yml
+++ b/src/packs/src/srd-monsters/Manafang_Naga_qSwaG0siGiYi5pqU.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Manticore_6x70u92MuKPvNyGP.yml
+++ b/src/packs/src/srd-monsters/Manticore_6x70u92MuKPvNyGP.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Manticore_Bard_0CzjRDh40QJASsYY.yml
+++ b/src/packs/src/srd-monsters/Manticore_Bard_0CzjRDh40QJASsYY.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Mantikumhar_BnuMJkGA4D5Ozwm3.yml
+++ b/src/packs/src/srd-monsters/Mantikumhar_BnuMJkGA4D5Ozwm3.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Marble_Golem_j05Ko4KXS6V2dZ2l.yml
+++ b/src/packs/src/srd-monsters/Marble_Golem_j05Ko4KXS6V2dZ2l.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Marilith__serpent_demon__Ty3Jq0nPo3fnyrXw.yml
+++ b/src/packs/src/srd-monsters/Marilith__serpent_demon__Ty3Jq0nPo3fnyrXw.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Massive_Mutant_Chuul_GgZFSyhhq261c4Uh.yml
+++ b/src/packs/src/srd-monsters/Massive_Mutant_Chuul_GgZFSyhhq261c4Uh.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Mausoleum_Dragon__White__d9lCDhHgAI0nQraN.yml
+++ b/src/packs/src/srd-monsters/Mausoleum_Dragon__White__d9lCDhHgAI0nQraN.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Medium_Black_Dragon_2IKoP9zzdJEm7PrX.yml
+++ b/src/packs/src/srd-monsters/Medium_Black_Dragon_2IKoP9zzdJEm7PrX.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Medium_Blue_Dragon_k0iGuUowV5eOMdLZ.yml
+++ b/src/packs/src/srd-monsters/Medium_Blue_Dragon_k0iGuUowV5eOMdLZ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Medium_Brass_Dragon__Metallic__5d8L7CnRCOdHb8gj.yml
+++ b/src/packs/src/srd-monsters/Medium_Brass_Dragon__Metallic__5d8L7CnRCOdHb8gj.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Medium_Bronze_Dragon__Metallic__W89BD25m4Zhh5T9Z.yml
+++ b/src/packs/src/srd-monsters/Medium_Bronze_Dragon__Metallic__W89BD25m4Zhh5T9Z.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Medium_Copper_Dragon__Metallic__bCzOAlNtNjnrJ9bx.yml
+++ b/src/packs/src/srd-monsters/Medium_Copper_Dragon__Metallic__bCzOAlNtNjnrJ9bx.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Medium_Gold_Dragon__Metallic__69Dfv726UoabQXq9.yml
+++ b/src/packs/src/srd-monsters/Medium_Gold_Dragon__Metallic__69Dfv726UoabQXq9.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Medium_Green_Dragon_DlH5UCarlFSQOerv.yml
+++ b/src/packs/src/srd-monsters/Medium_Green_Dragon_DlH5UCarlFSQOerv.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Medium_Red_Dragon_L8N9oasC7gVZaPOi.yml
+++ b/src/packs/src/srd-monsters/Medium_Red_Dragon_L8N9oasC7gVZaPOi.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Medium_Silver_Dragon__Metallic__Wl6NK0C7MA3xEWRa.yml
+++ b/src/packs/src/srd-monsters/Medium_Silver_Dragon__Metallic__Wl6NK0C7MA3xEWRa.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Medium_White_Dragon_mZErP6QotjUwZTZq.yml
+++ b/src/packs/src/srd-monsters/Medium_White_Dragon_mZErP6QotjUwZTZq.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Medusa_Noble_J3vbAvRtp6nu7P6K.yml
+++ b/src/packs/src/srd-monsters/Medusa_Noble_J3vbAvRtp6nu7P6K.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Medusa_Outlaw_WDNZWk3KOCm8Logf.yml
+++ b/src/packs/src/srd-monsters/Medusa_Outlaw_WDNZWk3KOCm8Logf.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Minotaur_kihDm8d9NIwdJHRn.yml
+++ b/src/packs/src/srd-monsters/Minotaur_kihDm8d9NIwdJHRn.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Moon_Dragon__White__g9OquqvJoCJ2u9ka.yml
+++ b/src/packs/src/srd-monsters/Moon_Dragon__White__g9OquqvJoCJ2u9ka.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Mummy_937WjQgmUUQA5NS1.yml
+++ b/src/packs/src/srd-monsters/Mummy_937WjQgmUUQA5NS1.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Nalfeshnee__boar_demon__nQT9e80C9Mrd5VgW.yml
+++ b/src/packs/src/srd-monsters/Nalfeshnee__boar_demon__nQT9e80C9Mrd5VgW.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Newly_Risen_Ghoul_WYBGeQDA3qCLyh30.yml
+++ b/src/packs/src/srd-monsters/Newly_Risen_Ghoul_WYBGeQDA3qCLyh30.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ochre_Jelly_0XDHDaPnpfAy9icO.yml
+++ b/src/packs/src/srd-monsters/Ochre_Jelly_0XDHDaPnpfAy9icO.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ogre_Berserker_d5QQS8bM938UyRA9.yml
+++ b/src/packs/src/srd-monsters/Ogre_Berserker_d5QQS8bM938UyRA9.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ogre_Champion_OU4XeKlaZxWoouKp.yml
+++ b/src/packs/src/srd-monsters/Ogre_Champion_OU4XeKlaZxWoouKp.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ogre_Crusader_PxurpqleBwFsBC7z.yml
+++ b/src/packs/src/srd-monsters/Ogre_Crusader_PxurpqleBwFsBC7z.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ogre_Lightning_Mage_PUvvoYStOBXa7dV5.yml
+++ b/src/packs/src/srd-monsters/Ogre_Lightning_Mage_PUvvoYStOBXa7dV5.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ogre_Mage_CPFyQu2s90q5oGsp.yml
+++ b/src/packs/src/srd-monsters/Ogre_Mage_CPFyQu2s90q5oGsp.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ogre_Minion_BHR4rnZKd1qdEf9r.yml
+++ b/src/packs/src/srd-monsters/Ogre_Minion_BHR4rnZKd1qdEf9r.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ogre_Penitent_2i0vAsFnGC1ojS5c.yml
+++ b/src/packs/src/srd-monsters/Ogre_Penitent_2i0vAsFnGC1ojS5c.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ogre_jYuvI6eGSM6n0Wno.yml
+++ b/src/packs/src/srd-monsters/Ogre_jYuvI6eGSM6n0Wno.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Orc_Battle_Screamer_57eUiEVInl6uecB8.yml
+++ b/src/packs/src/srd-monsters/Orc_Battle_Screamer_57eUiEVInl6uecB8.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Orc_Berserker_xYqA6xGNg3pxuNL5.yml
+++ b/src/packs/src/srd-monsters/Orc_Berserker_xYqA6xGNg3pxuNL5.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Orc_Rager_YtnqxLcuPLZzxwQg.yml
+++ b/src/packs/src/srd-monsters/Orc_Rager_YtnqxLcuPLZzxwQg.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Orc_Shaman_wa079BHEqSiFeU5e.yml
+++ b/src/packs/src/srd-monsters/Orc_Shaman_wa079BHEqSiFeU5e.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Orc_Tusker_Z9v4i26ucJvWwtFw.yml
+++ b/src/packs/src/srd-monsters/Orc_Tusker_Z9v4i26ucJvWwtFw.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Orc_Warrior_auY4TXJmRGiF2sQc.yml
+++ b/src/packs/src/srd-monsters/Orc_Warrior_auY4TXJmRGiF2sQc.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Orcish_Archer_9Vc7Yo3n1UW1plLl.yml
+++ b/src/packs/src/srd-monsters/Orcish_Archer_9Vc7Yo3n1UW1plLl.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Otyugh_AnvfSho2tyoRQrd9.yml
+++ b/src/packs/src/srd-monsters/Otyugh_AnvfSho2tyoRQrd9.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Owlbear_04PitHTyBGBPlBOG.yml
+++ b/src/packs/src/srd-monsters/Owlbear_04PitHTyBGBPlBOG.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Parasitic_Dybbuk_zT1X4CLaTCmxo8pn.yml
+++ b/src/packs/src/srd-monsters/Parasitic_Dybbuk_zT1X4CLaTCmxo8pn.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Parasitic_Lightning_Beetle_SSJcpOcSW5NlXJj4.yml
+++ b/src/packs/src/srd-monsters/Parasitic_Lightning_Beetle_SSJcpOcSW5NlXJj4.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Phase_Spider_YWCYezyDe9YgXjMU.yml
+++ b/src/packs/src/srd-monsters/Phase_Spider_YWCYezyDe9YgXjMU.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Pit_Fiend_V3ZmIvLnyRQltYfP.yml
+++ b/src/packs/src/srd-monsters/Pit_Fiend_V3ZmIvLnyRQltYfP.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Pit_Spawn_Orc_fSnz7yck7bwdrdu0.yml
+++ b/src/packs/src/srd-monsters/Pit_Spawn_Orc_fSnz7yck7bwdrdu0.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Pixie_Pod_RyzWdFRVyrDvHDWG.yml
+++ b/src/packs/src/srd-monsters/Pixie_Pod_RyzWdFRVyrDvHDWG.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Pixie_Warrior_r2yfrqSEjfpSPXaS.yml
+++ b/src/packs/src/srd-monsters/Pixie_Warrior_r2yfrqSEjfpSPXaS.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Podling_XXHMDfM6cwaV2ubB.yml
+++ b/src/packs/src/srd-monsters/Podling_XXHMDfM6cwaV2ubB.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Poison_Dandelion_Pmk2onuqSHLiPqa1.yml
+++ b/src/packs/src/srd-monsters/Poison_Dandelion_Pmk2onuqSHLiPqa1.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Prismatic_Ogre_Mage_ym8uVQH29CAoWuTW.yml
+++ b/src/packs/src/srd-monsters/Prismatic_Ogre_Mage_ym8uVQH29CAoWuTW.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Purple_Larva_DycjxxWJKu5oZqdS.yml
+++ b/src/packs/src/srd-monsters/Purple_Larva_DycjxxWJKu5oZqdS.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Purple_Worm_hUz6BaiWWwNjWVOP.yml
+++ b/src/packs/src/srd-monsters/Purple_Worm_hUz6BaiWWwNjWVOP.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Rakshasa_4rD0LAwTfYRLMLVH.yml
+++ b/src/packs/src/srd-monsters/Rakshasa_4rD0LAwTfYRLMLVH.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ravenous_Bumoorah_bHDki0hNmIswpiKb.yml
+++ b/src/packs/src/srd-monsters/Ravenous_Bumoorah_bHDki0hNmIswpiKb.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Ravenous_Cannibal_NUULJmNa9b9ibe5n.yml
+++ b/src/packs/src/srd-monsters/Ravenous_Cannibal_NUULJmNa9b9ibe5n.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Razor_Shark_sCzeJP0e5jLCiZ6h.yml
+++ b/src/packs/src/srd-monsters/Razor_Shark_sCzeJP0e5jLCiZ6h.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Redcap_EwNXkXNTcMycfGYO.yml
+++ b/src/packs/src/srd-monsters/Redcap_EwNXkXNTcMycfGYO.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Remorhaz_Queen_2Epu1Q2NsGWX2CYL.yml
+++ b/src/packs/src/srd-monsters/Remorhaz_Queen_2Epu1Q2NsGWX2CYL.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/River_Devil_Minion_AY4PMtQeSA2li5yX.yml
+++ b/src/packs/src/srd-monsters/River_Devil_Minion_AY4PMtQeSA2li5yX.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/River_Devil_vmCMkLagtejjlM0H.yml
+++ b/src/packs/src/srd-monsters/River_Devil_vmCMkLagtejjlM0H.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Rust_Monster_Obliterator_HMyjkCXU6y3I1EqE.yml
+++ b/src/packs/src/srd-monsters/Rust_Monster_Obliterator_HMyjkCXU6y3I1EqE.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Rust_Monster_Um0alplprcdhHqL3.yml
+++ b/src/packs/src/srd-monsters/Rust_Monster_Um0alplprcdhHqL3.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Sahuagin_Glow_Priest_zfjRGSN658Pz19Bt.yml
+++ b/src/packs/src/srd-monsters/Sahuagin_Glow_Priest_zfjRGSN658Pz19Bt.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Sahuagin_Mutant_FhAUVoO7zhpHmolX.yml
+++ b/src/packs/src/srd-monsters/Sahuagin_Mutant_FhAUVoO7zhpHmolX.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Sahuagin_Raider_V4rmN0dyjXNSw0fx.yml
+++ b/src/packs/src/srd-monsters/Sahuagin_Raider_V4rmN0dyjXNSw0fx.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Sahuagin_qPDnIHgrhRT1tAIJ.yml
+++ b/src/packs/src/srd-monsters/Sahuagin_qPDnIHgrhRT1tAIJ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Screaming_Skull_vXhzlL9fG6zjwvbe.yml
+++ b/src/packs/src/srd-monsters/Screaming_Skull_vXhzlL9fG6zjwvbe.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Sea_Shark_O3uMvUea7p5GdTCn.yml
+++ b/src/packs/src/srd-monsters/Sea_Shark_O3uMvUea7p5GdTCn.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Seven_Headed_Hydra_s2ke2UHFXQZHU2Ud.yml
+++ b/src/packs/src/srd-monsters/Seven_Headed_Hydra_s2ke2UHFXQZHU2Ud.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Shadow_Dragon_2aX994HRJMOg5RRb.yml
+++ b/src/packs/src/srd-monsters/Shadow_Dragon_2aX994HRJMOg5RRb.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Shadow_Thief_iUm1b4A0ImYbnjV9.yml
+++ b/src/packs/src/srd-monsters/Shadow_Thief_iUm1b4A0ImYbnjV9.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Skeletal_Hound_3ufsRZjrzBEnAWEm.yml
+++ b/src/packs/src/srd-monsters/Skeletal_Hound_3ufsRZjrzBEnAWEm.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Skeleton_Archer_PoYewLi15xnGKagd.yml
+++ b/src/packs/src/srd-monsters/Skeleton_Archer_PoYewLi15xnGKagd.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Skeleton_Warrior_nXHiCIwKIN6Ly1G6.yml
+++ b/src/packs/src/srd-monsters/Skeleton_Warrior_nXHiCIwKIN6Ly1G6.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Skin_Devil_M5nyJFcL4b7AGiLC.yml
+++ b/src/packs/src/srd-monsters/Skin_Devil_M5nyJFcL4b7AGiLC.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Skull_of_the_Beast_OQA8kLmcql25PYm9.yml
+++ b/src/packs/src/srd-monsters/Skull_of_the_Beast_OQA8kLmcql25PYm9.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Slime_Skull_bdnU0tvBUnpTFWXy.yml
+++ b/src/packs/src/srd-monsters/Slime_Skull_bdnU0tvBUnpTFWXy.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Small_Air_Elemental_ykSU4aw1oWsISFX6.yml
+++ b/src/packs/src/srd-monsters/Small_Air_Elemental_ykSU4aw1oWsISFX6.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Small_Earth_Elemental_U9c2470ucVHL4kyI.yml
+++ b/src/packs/src/srd-monsters/Small_Earth_Elemental_U9c2470ucVHL4kyI.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Small_Fire_Elemental_QoQzUcya0yoSUiTt.yml
+++ b/src/packs/src/srd-monsters/Small_Fire_Elemental_QoQzUcya0yoSUiTt.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Small_Water_Elemental_SJSeXsNZBdKzgovK.yml
+++ b/src/packs/src/srd-monsters/Small_Water_Elemental_SJSeXsNZBdKzgovK.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Smoke_Minions_AGRquvxUcuAPpv6i.yml
+++ b/src/packs/src/srd-monsters/Smoke_Minions_AGRquvxUcuAPpv6i.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Soul_Flenser_7aZQJ3hIvQT276zZ.yml
+++ b/src/packs/src/srd-monsters/Soul_Flenser_7aZQJ3hIvQT276zZ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Sparkscale_Naga_pQo7rrWALsNGA1C8.yml
+++ b/src/packs/src/srd-monsters/Sparkscale_Naga_pQo7rrWALsNGA1C8.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Spawn_of_the_Master_ufKGy5Zmyj4xHOY7.yml
+++ b/src/packs/src/srd-monsters/Spawn_of_the_Master_ufKGy5Zmyj4xHOY7.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Specter_C8CfGGumssWMBWdA.yml
+++ b/src/packs/src/srd-monsters/Specter_C8CfGGumssWMBWdA.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Spider_Mount_mtvu5NoRia9ZK0zM.yml
+++ b/src/packs/src/srd-monsters/Spider_Mount_mtvu5NoRia9ZK0zM.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Spinneret_Doxy_bkgnATNLIDFvsIEA.yml
+++ b/src/packs/src/srd-monsters/Spinneret_Doxy_bkgnATNLIDFvsIEA.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Splotchcap_1wtlqrrVMnUZXYyh.yml
+++ b/src/packs/src/srd-monsters/Splotchcap_1wtlqrrVMnUZXYyh.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Sporrior_yjmVuGPxS0lkoZ3g.yml
+++ b/src/packs/src/srd-monsters/Sporrior_yjmVuGPxS0lkoZ3g.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Squib_Swarm_BUGhPpkGiTWVhrI5.yml
+++ b/src/packs/src/srd-monsters/Squib_Swarm_BUGhPpkGiTWVhrI5.yml
@@ -74,12 +74,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Stirge_DNHwMQd1AASGQF2V.yml
+++ b/src/packs/src/srd-monsters/Stirge_DNHwMQd1AASGQF2V.yml
@@ -74,12 +74,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Stirgelings_Eh6NWAnhtdODWqzb.yml
+++ b/src/packs/src/srd-monsters/Stirgelings_Eh6NWAnhtdODWqzb.yml
@@ -74,12 +74,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Stone_Giant_SJH4MwRqhQHuYLW9.yml
+++ b/src/packs/src/srd-monsters/Stone_Giant_SJH4MwRqhQHuYLW9.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Stone_Golem_bHj1BM922d78837Z.yml
+++ b/src/packs/src/srd-monsters/Stone_Golem_bHj1BM922d78837Z.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Storm_Giant_uxjA1AhJuPrRN8GD.yml
+++ b/src/packs/src/srd-monsters/Storm_Giant_uxjA1AhJuPrRN8GD.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Swarm_Prince_BCD5OYYBgE1bkSoL.yml
+++ b/src/packs/src/srd-monsters/Swarm_Prince_BCD5OYYBgE1bkSoL.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Swarm_of_Bats_oaLiCg02ealzuDT1.yml
+++ b/src/packs/src/srd-monsters/Swarm_of_Bats_oaLiCg02ealzuDT1.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Swarming_Maw_mntgZykhzIoW7RJU.yml
+++ b/src/packs/src/srd-monsters/Swarming_Maw_mntgZykhzIoW7RJU.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Swaysong_Naga_7MoQ3girqcUVr8Em.yml
+++ b/src/packs/src/srd-monsters/Swaysong_Naga_7MoQ3girqcUVr8Em.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Tarrasque_zLKJGIgmDtRCCVvo.yml
+++ b/src/packs/src/srd-monsters/Tarrasque_zLKJGIgmDtRCCVvo.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/The_Final_Devil_7kXZN2Rn9woTDlWi.yml
+++ b/src/packs/src/srd-monsters/The_Final_Devil_7kXZN2Rn9woTDlWi.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/The_Flensed_GdfiSMk0aqujTrPO.yml
+++ b/src/packs/src/srd-monsters/The_Flensed_GdfiSMk0aqujTrPO.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/The_Woven_DEUVhpefVn0nCKqt.yml
+++ b/src/packs/src/srd-monsters/The_Woven_DEUVhpefVn0nCKqt.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Thunder_Bat_Bxh0GsESuDXjPLav.yml
+++ b/src/packs/src/srd-monsters/Thunder_Bat_Bxh0GsESuDXjPLav.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Treant_Titan_ek0KnUuduPgaNsZ5.yml
+++ b/src/packs/src/srd-monsters/Treant_Titan_ek0KnUuduPgaNsZ5.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Trog_0WPg8a97BRBbjWi2.yml
+++ b/src/packs/src/srd-monsters/Trog_0WPg8a97BRBbjWi2.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Trog_Chanter_dYAbELUYbXWsmJL8.yml
+++ b/src/packs/src/srd-monsters/Trog_Chanter_dYAbELUYbXWsmJL8.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Trog_Underling_J4iozu7sjOaogmbK.yml
+++ b/src/packs/src/srd-monsters/Trog_Underling_J4iozu7sjOaogmbK.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Troll_tdbQR7Lc3IZInESe.yml
+++ b/src/packs/src/srd-monsters/Troll_tdbQR7Lc3IZInESe.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Umluppuk_26AsMqRWb4hhU1uR.yml
+++ b/src/packs/src/srd-monsters/Umluppuk_26AsMqRWb4hhU1uR.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Vampire_RvLmLtl6CskfOkyf.yml
+++ b/src/packs/src/srd-monsters/Vampire_RvLmLtl6CskfOkyf.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Vampire_Spawn_EAkaJFZZEiiLZUv0.yml
+++ b/src/packs/src/srd-monsters/Vampire_Spawn_EAkaJFZZEiiLZUv0.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Vicious_Warbanner_YlcIhsZunTFwe5ol.yml
+++ b/src/packs/src/srd-monsters/Vicious_Warbanner_YlcIhsZunTFwe5ol.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Void_Dragon__Black__0IweiCnXWspTLEAg.yml
+++ b/src/packs/src/srd-monsters/Void_Dragon__Black__0IweiCnXWspTLEAg.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Volcano_Dragon__Red__GyXxuQTzrOygYw12.yml
+++ b/src/packs/src/srd-monsters/Volcano_Dragon__Red__GyXxuQTzrOygYw12.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Vrock__vulture_demon__LfZDqEaXQbpXw4lM.yml
+++ b/src/packs/src/srd-monsters/Vrock__vulture_demon__LfZDqEaXQbpXw4lM.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Warped_Beast_SuoDdY1M7vBRTPx8.yml
+++ b/src/packs/src/srd-monsters/Warped_Beast_SuoDdY1M7vBRTPx8.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Watch_Skull_oAEMq1TPWP4krDgZ.yml
+++ b/src/packs/src/srd-monsters/Watch_Skull_oAEMq1TPWP4krDgZ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Water_Elemental_7rknyBVT8dJulnLr.yml
+++ b/src/packs/src/srd-monsters/Water_Elemental_7rknyBVT8dJulnLr.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Weaver_Swarm_PFehhaZ26BLOYbcz.yml
+++ b/src/packs/src/srd-monsters/Weaver_Swarm_PFehhaZ26BLOYbcz.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Wendigo_Spirit_ffHA1fJWGbIB44Kz.yml
+++ b/src/packs/src/srd-monsters/Wendigo_Spirit_ffHA1fJWGbIB44Kz.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Werebear_MpFCDLedOFfdrXho.yml
+++ b/src/packs/src/srd-monsters/Werebear_MpFCDLedOFfdrXho.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Wereboar_KuBJcAZF0V608T2e.yml
+++ b/src/packs/src/srd-monsters/Wereboar_KuBJcAZF0V608T2e.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Wererat_cnTkM0fnAWW1k9Vy.yml
+++ b/src/packs/src/srd-monsters/Wererat_cnTkM0fnAWW1k9Vy.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Weretiger_yN6unx7RLeCZddoy.yml
+++ b/src/packs/src/srd-monsters/Weretiger_yN6unx7RLeCZddoy.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Werewolf_CNo8unEjBtRuQxvx.yml
+++ b/src/packs/src/srd-monsters/Werewolf_CNo8unEjBtRuQxvx.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Whispering_Prophet_hl450KWioG8D2lmK.yml
+++ b/src/packs/src/srd-monsters/Whispering_Prophet_hl450KWioG8D2lmK.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/White_Dragon_Hatchling_3nhRHjjPCsQjkQEq.yml
+++ b/src/packs/src/srd-monsters/White_Dragon_Hatchling_3nhRHjjPCsQjkQEq.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Wibble_KmDGXmA1yaxPLe9k.yml
+++ b/src/packs/src/srd-monsters/Wibble_KmDGXmA1yaxPLe9k.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Wight_Jxopr3OiwFFG01hg.yml
+++ b/src/packs/src/srd-monsters/Wight_Jxopr3OiwFFG01hg.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Winter_Beast_gKVXn7zkjJSMSPJn.yml
+++ b/src/packs/src/srd-monsters/Winter_Beast_gKVXn7zkjJSMSPJn.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Wolf_AYfuSTVBS8sGfkkZ.yml
+++ b/src/packs/src/srd-monsters/Wolf_AYfuSTVBS8sGfkkZ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Wraith_Bat_KvNIvmKGuwaHzMEB.yml
+++ b/src/packs/src/srd-monsters/Wraith_Bat_KvNIvmKGuwaHzMEB.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Wraith_cOYS238VnRYYfMx8.yml
+++ b/src/packs/src/srd-monsters/Wraith_cOYS238VnRYYfMx8.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Wyvern_YL2AyRNNEsKUdVhT.yml
+++ b/src/packs/src/srd-monsters/Wyvern_YL2AyRNNEsKUdVhT.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Zealous_Warbanner_YWUMZ29u82zpOHMi.yml
+++ b/src/packs/src/srd-monsters/Zealous_Warbanner_YWUMZ29u82zpOHMi.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
       base: 8
       automatic: true
     escalation:

--- a/src/packs/src/srd-monsters/Zombie_Beast_gHpvxvGb5DIUPhgE.yml
+++ b/src/packs/src/srd-monsters/Zombie_Beast_gHpvxvGb5DIUPhgE.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Zombie_Shuffler_0pKCCcW92wqXpUJP.yml
+++ b/src/packs/src/srd-monsters/Zombie_Shuffler_0pKCCcW92wqXpUJP.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:

--- a/src/packs/src/srd-monsters/Zombie_of_the_Silver_Rose_luBNIwOxHVc0GsOZ.yml
+++ b/src/packs/src/srd-monsters/Zombie_of_the_Silver_Rose_luBNIwOxHVc0GsOZ.yml
@@ -75,12 +75,6 @@ system:
           - false
           - false
           - false
-    recoveries:
-      type: Number
-      label: Recoveries
-      value: 8
-      max: 8
-      dice: d8
     escalation:
       value: 6
   details:


### PR DESCRIPTION
Removes the recoveries attributes from the yml files for all of the actors in /srd-monsters that had it. 

This is intended to alleviate the issue of Recoveries showing up for actors that do not have them when using add-on modules that don't support different configurations for Player and NPC Actors.