### PR TITLE
Publication source for equipment

### DIFF
--- a/src/packs/src/srd-magic-items/Abandon__Melee_weapon__1eq1BAT2e6dPzlvR.yml
+++ b/src/packs/src/srd-magic-items/Abandon__Melee_weapon__1eq1BAT2e6dPzlvR.yml
@@ -14,6 +14,7 @@ system:
 
       <p>Quirk: Blurts out obscenities. (For decorum&rsquo;s sake, use
       euphemisms when speaking in character.)</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Acrobat_s_Stick__staff__Y6K5ZsUP3boBtYos.yml
+++ b/src/packs/src/srd-magic-items/Acrobat_s_Stick__staff__Y6K5ZsUP3boBtYos.yml
@@ -16,6 +16,7 @@ system:
       that ability, but whenever you roll a natural 1 or 2 with any d20 roll,
       the staff flings you into danger (you take [[2d6]] damage and possibly
       provoke opportunity attacks in battle).</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Adaptation_RIrHa5AFQSgRrHd0.yml
+++ b/src/packs/src/srd-magic-items/Adaptation_RIrHa5AFQSgRrHd0.yml
@@ -15,6 +15,7 @@ system:
       battle.</p>
 
       <p>Quirk: Takes on mannerisms of those around them.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Adroit_Avoidance_H6VyBmHoGWsD8RVX.yml
+++ b/src/packs/src/srd-magic-items/Adroit_Avoidance_H6VyBmHoGWsD8RVX.yml
@@ -13,6 +13,7 @@ system:
       a save ends, you can roll an immediate save against it.</p>
 
       <p>Quirk: Doesn&rsquo;t notice social slights or insults.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Ambidexterity_cffgDnU4sbIrfgcS.yml
+++ b/src/packs/src/srd-magic-items/Ambidexterity_cffgDnU4sbIrfgcS.yml
@@ -16,6 +16,7 @@ system:
 
       <p>Quirk: Writes with both hands at the same time on different parts of
       the page. It freaks people out.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Anger_Armor__heavy_armor__IOhq6MqTnpbqXps9.yml
+++ b/src/packs/src/srd-magic-items/Anger_Armor__heavy_armor__IOhq6MqTnpbqXps9.yml
@@ -15,6 +15,7 @@ system:
       and the escalation die is odd, roll a save; on a failure, you are enraged
       until the start of your next turn and take a &ndash;4 penalty to all
       defenses.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Arcane_Contact_oUL3GUwP7bpYFsNc.yml
+++ b/src/packs/src/srd-magic-items/Arcane_Contact_oUL3GUwP7bpYFsNc.yml
@@ -18,6 +18,7 @@ system:
       touching an artifact might usher into your soul.</p>
 
       <p>Quirk: Always cracks knuckles.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Archer_s_Gauntlets_OX8Ym1H6Y4GJUnAn.yml
+++ b/src/packs/src/srd-magic-items/Archer_s_Gauntlets_OX8Ym1H6Y4GJUnAn.yml
@@ -13,6 +13,7 @@ system:
       using +10 as your attack bonus (champion: +15; epic: +20).</p>
 
       <p>Quirk: You&rsquo;re quiet. Too quiet. Say something.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Axe_of_Bloody_Vengeance___3_weapon__N0XveL9X1L9F3J6T.yml
+++ b/src/packs/src/srd-magic-items/Axe_of_Bloody_Vengeance___3_weapon__N0XveL9X1L9F3J6T.yml
@@ -11,6 +11,7 @@ system:
     value: |-
       <p>You cannot rally during a battle.</p>
       <p>Quirk: Carves patterns into own skin with fingernails.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Backbiter_Bow__bow__96OPIT2cN2Hcs3b2.yml
+++ b/src/packs/src/srd-magic-items/Backbiter_Bow__bow__96OPIT2cN2Hcs3b2.yml
@@ -15,6 +15,7 @@ system:
       <p>Always: Bonus to attacks and damage: +2 (adventurer). In addition, when
       you miss with an attack and the escalation die is odd, roll a save; on a
       failure, you instead hit yourself with the attack.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Bait_Breastplate__any_armor__tyYgYwFC1p47aH2L.yml
+++ b/src/packs/src/srd-magic-items/Bait_Breastplate__any_armor__tyYgYwFC1p47aH2L.yml
@@ -14,6 +14,7 @@ system:
 
       <p>Always: +3 AC (champion) against melee attacks, but &ndash;1 AC against
       ranged attacks.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Bashing_hWC4oifdZvqujdrA.yml
+++ b/src/packs/src/srd-magic-items/Bashing_hWC4oifdZvqujdrA.yml
@@ -14,6 +14,7 @@ system:
       it. That ally can make a disengage check as a free action.</p>
 
       <p>Quirk: Can&rsquo;t pass up an opportunity to sing.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Bearclaw_xrSKpjtlSuXsONsT.yml
+++ b/src/packs/src/srd-magic-items/Bearclaw_xrSKpjtlSuXsONsT.yml
@@ -14,6 +14,7 @@ system:
       hp; epic: [[50]] temporary hp).</p>
 
       <p>Quirk: Swaggers even when overmatched.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Blade_of_Unerring_Panache___2_weapon__rThiRBKjQTPxr9rC.yml
+++ b/src/packs/src/srd-magic-items/Blade_of_Unerring_Panache___2_weapon__rThiRBKjQTPxr9rC.yml
@@ -13,6 +13,7 @@ system:
       [[10]] hp; epic: [[25]] hp).</p>
 
       <p>Quirk: Tells the same stories over and over.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Blademaster_s_Belt_J8Z4UI9SgmrqFqhd.yml
+++ b/src/packs/src/srd-magic-items/Blademaster_s_Belt_J8Z4UI9SgmrqFqhd.yml
@@ -13,6 +13,7 @@ system:
       rolls for its own powers.</p>
 
       <p>Quirk: Worries too much about tiny details.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Bloodthirsty__Any_weapon__L8xEcxTA1LlBBV9s.yml
+++ b/src/packs/src/srd-magic-items/Bloodthirsty__Any_weapon__L8xEcxTA1LlBBV9s.yml
@@ -14,6 +14,7 @@ system:
       next turn.</p>
 
       <p>Quirk: Has taste for red meat.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Body_Breaking__Dagger_of_DjmtneqgPskZE33p.yml
+++ b/src/packs/src/srd-magic-items/Body_Breaking__Dagger_of_DjmtneqgPskZE33p.yml
@@ -14,6 +14,7 @@ system:
       and damage with that spell if it targets PD.</p>
 
       <p>Quirk: Scratches self unnervingly.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Boots_of_Elvenkind_H3a2fBth57Dd6brx.yml
+++ b/src/packs/src/srd-magic-items/Boots_of_Elvenkind_H3a2fBth57Dd6brx.yml
@@ -11,6 +11,7 @@ system:
     value: |-
       <p>You gain a +4 bonus to skill checks to walk quietly.</p>
       <p>Quirk: Develops a love of elegant elven poetry.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Boots_of_Ferocious_Charge_owaL61tsoErs9fjw.yml
+++ b/src/packs/src/srd-magic-items/Boots_of_Ferocious_Charge_owaL61tsoErs9fjw.yml
@@ -14,6 +14,7 @@ system:
       (champion: +2d8; epic: +4d10).</p>
 
       <p>Quirk: You like to start fights as much as you like to finish them.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Boots_of_Rhythm_DgoCS3FyC2FYV306.yml
+++ b/src/packs/src/srd-magic-items/Boots_of_Rhythm_DgoCS3FyC2FYV306.yml
@@ -11,6 +11,7 @@ system:
     value: |-
       <p>You have a +4 bonus to dance checks.</p>
       <p>Quirk: Loves to learn new dances.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Boots_of_Sure_Feet_jbMav0pEopdyZl5i.yml
+++ b/src/packs/src/srd-magic-items/Boots_of_Sure_Feet_jbMav0pEopdyZl5i.yml
@@ -15,6 +15,7 @@ system:
       terrain.</p>
 
       <p>Quirk: Becomes exceptionally picky about diet.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Brazen_Armor___3_armor__QmTW6fZFQc76eKk6.yml
+++ b/src/packs/src/srd-magic-items/Brazen_Armor___3_armor__QmTW6fZFQc76eKk6.yml
@@ -14,6 +14,7 @@ system:
       battle.</p>
 
       <p>Quirk: Becomes unreliable with forgettable tasks.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Brutal_Vigor_GPcxLB6Oml51aDTK.yml
+++ b/src/packs/src/srd-magic-items/Brutal_Vigor_GPcxLB6Oml51aDTK.yml
@@ -11,6 +11,7 @@ system:
     value: |-
       <p>(Recharge 6+) When you rally, make a basic attack.</p>
       <p>Quirk: Plays with their weapons.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Certain_Pain__Two_handed_melee_weapon__jOVZJDQxVqie3JmD.yml
+++ b/src/packs/src/srd-magic-items/Certain_Pain__Two_handed_melee_weapon__jOVZJDQxVqie3JmD.yml
@@ -15,6 +15,7 @@ system:
       [[25]] damage; epic: [[60]] damage).</p>
 
       <p>Quirk: Fond of gambling.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Cheap_Shot_vyGpv0mf5PtaIHD8.yml
+++ b/src/packs/src/srd-magic-items/Cheap_Shot_vyGpv0mf5PtaIHD8.yml
@@ -13,6 +13,7 @@ system:
       takes damage equal to your normal melee miss damage.</p>
 
       <p>Quirk: Often stops speaking mid-sentence.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Chicken_Shield__shield__37pot1g3ClLPQu83.yml
+++ b/src/packs/src/srd-magic-items/Chicken_Shield__shield__37pot1g3ClLPQu83.yml
@@ -15,6 +15,7 @@ system:
       the escalation die is odd, roll a save; on a failure, you run away from
       that enemy as far as you can go (no disengage check, take opportunity
       attacks).</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Chitin_Claw__ring__UTtwthIxMJCBQMs7.yml
+++ b/src/packs/src/srd-magic-items/Chitin_Claw__ring__UTtwthIxMJCBQMs7.yml
@@ -16,6 +16,7 @@ system:
       your finger would be aided by, you gain a +2 bonus to the roll.</p>
 
       <p>Quirk: Gnarled over-long fingers on that hand.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Chosen_One__Sign_of_the_FGEpNL8QOyQnIco7.yml
+++ b/src/packs/src/srd-magic-items/Chosen_One__Sign_of_the_FGEpNL8QOyQnIco7.yml
@@ -13,6 +13,7 @@ system:
       succeed, you don&rsquo;t expend the spell.</p>
 
       <p>Quirk: Obsessed with fortune telling, oracles, signs, etc.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Chuul_Helm__helm__JiyEkGEs7TPrq4Ko.yml
+++ b/src/packs/src/srd-magic-items/Chuul_Helm__helm__JiyEkGEs7TPrq4Ko.yml
@@ -18,6 +18,7 @@ system:
       battle (champion: resist psychic 16+; epic: resist psychic 18+).</p>
 
       <p>Quirk: Bone-ridged holes in skull.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Chuulish_Cuirass__heavy_armor__nEcV0HlfDtLDkybB.yml
+++ b/src/packs/src/srd-magic-items/Chuulish_Cuirass__heavy_armor__nEcV0HlfDtLDkybB.yml
@@ -18,6 +18,7 @@ system:
       attacks until the end of the battle.</p>
 
       <p>Quirk: Over-large protruding ribs.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Circlet_of_Approachability_xorAvJGB5vwEsqYO.yml
+++ b/src/packs/src/srd-magic-items/Circlet_of_Approachability_xorAvJGB5vwEsqYO.yml
@@ -15,6 +15,7 @@ system:
       suspicious. The circlet has no power in unusual social situations.</p>
 
       <p>Quirk: Peppers speech with needless foreign words.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Clawed_Tentacles__gloves__DKUzxcqOfRQLx9Cy.yml
+++ b/src/packs/src/srd-magic-items/Clawed_Tentacles__gloves__DKUzxcqOfRQLx9Cy.yml
@@ -18,6 +18,7 @@ system:
       epic: hard save).</p>
 
       <p>Quirk: Tentacles writhe in and out of the skin unexpectedly.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Clever_Step__Usually_light_armor__Dfb4Sd4SbJFbUVms.yml
+++ b/src/packs/src/srd-magic-items/Clever_Step__Usually_light_armor__Dfb4Sd4SbJFbUVms.yml
@@ -11,6 +11,7 @@ system:
     value: |-
       <p>You gain a +4 bonus to all defenses against opportunity attacks.</p>
       <p>Quirk: Likes to dance little jigs.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Climactic_Shot__Ranged_weapon__2E8OU7TDNoBU9u16.yml
+++ b/src/packs/src/srd-magic-items/Climactic_Shot__Ranged_weapon__2E8OU7TDNoBU9u16.yml
@@ -14,6 +14,7 @@ system:
       damage; epic: [[60]] damage).</p>
 
       <p>Quirk: Can&rsquo;t stop checking the weapon and its ammunition.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Codex_of_Foreshadowed_Victory_Ryt0fhNvOtyGRM8o.yml
+++ b/src/packs/src/srd-magic-items/Codex_of_Foreshadowed_Victory_Ryt0fhNvOtyGRM8o.yml
@@ -13,6 +13,7 @@ system:
       after seeing it.</p>
 
       <p>Quirk: Jumpy.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Crown_of_the_Mighty_Strike_NTTFlNvpmrpdZIIP.yml
+++ b/src/packs/src/srd-magic-items/Crown_of_the_Mighty_Strike_NTTFlNvpmrpdZIIP.yml
@@ -16,6 +16,7 @@ system:
 
       <p>Quirk: Likely to make bold statements or undertake bold actions,
       especially by reflex.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Cruel__Any_weapon__O8FVdySsL4K6CGAH.yml
+++ b/src/packs/src/srd-magic-items/Cruel__Any_weapon__O8FVdySsL4K6CGAH.yml
@@ -14,6 +14,7 @@ system:
       hp/[[10]] ongoing damage; epic: 80 hp/[[20]] ongoing damage).</p>
 
       <p>Quirk: Tortures flies.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Cudgel_of_Heedlessness__heavy_two_handed_melee_weapon__ErHLLCdmd56mnS4t.yml
+++ b/src/packs/src/srd-magic-items/Cudgel_of_Heedlessness__heavy_two_handed_melee_weapon__ErHLLCdmd56mnS4t.yml
@@ -15,6 +15,7 @@ system:
       you roll a natural 1 with a melee attack using this weapon, you hit a
       random nearby ally with that attack and deal maximum damage. If you try to
       use a different weapon, the cudgel will teleport into your hand.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Cups_JtNb3vrh9TorLjfM.yml
+++ b/src/packs/src/srd-magic-items/Cups_JtNb3vrh9TorLjfM.yml
@@ -14,6 +14,7 @@ system:
       bad.</p>
 
       <p>Quirk: Not reluctant to drink excessively in public.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Dancing_Shoes__boots__fBWiaCbULpTb6n34.yml
+++ b/src/packs/src/srd-magic-items/Dancing_Shoes__boots__fBWiaCbULpTb6n34.yml
@@ -17,6 +17,7 @@ system:
 
       <p>Recharge 6+: You gain a +3 bonus to disengage checks until the end of
       the battle (or five minutes).</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Danger_Bracers__light_armor__9uGHcph67a5oAefZ.yml
+++ b/src/packs/src/srd-magic-items/Danger_Bracers__light_armor__9uGHcph67a5oAefZ.yml
@@ -13,6 +13,7 @@ system:
 
       <p>Always: +4 AC (epic). In addition, you can&rsquo;t disengage from
       enemies.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Death_Claw__gloves__bIMVB8xEPGP4Faxg.yml
+++ b/src/packs/src/srd-magic-items/Death_Claw__gloves__bIMVB8xEPGP4Faxg.yml
@@ -17,6 +17,7 @@ system:
 
       <p>Quirk: The claw flexes and snaps reflexively when wearer is
       excited.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Death__Epic__zhNgAfygmpz0rqNh.yml
+++ b/src/packs/src/srd-magic-items/Death__Epic__zhNgAfygmpz0rqNh.yml
@@ -13,6 +13,7 @@ system:
       hp or fewer after the hit, the creature drops to 0 hp. If it hits but
       fails to drop its target, the ammunition is not used up. It must of course
       be retrieved.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Deck_of_Many_Cards__wondrous_item__Zt6NfT3r8PG8OfJy.yml
+++ b/src/packs/src/srd-magic-items/Deck_of_Many_Cards__wondrous_item__Zt6NfT3r8PG8OfJy.yml
@@ -15,6 +15,7 @@ system:
       and pouches filling with cards that spill out leaving a trail for anyone
       to follow. Occasionally, the cards spill out in a prophetic pattern that
       might have meaning to the owner or an ally.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Defense_yEbWu3wMPVzNOMyw.yml
+++ b/src/packs/src/srd-magic-items/Defense_yEbWu3wMPVzNOMyw.yml
@@ -13,6 +13,7 @@ system:
       that damage (champion: prevent [[20]]; epic: prevent [[40]]).</p>
 
       <p>Quirk: Stubborn.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Dexterous_Parry__One_handed_melee_weapon__u6qvIuRYtiqxKVnw.yml
+++ b/src/packs/src/srd-magic-items/Dexterous_Parry__One_handed_melee_weapon__u6qvIuRYtiqxKVnw.yml
@@ -14,6 +14,7 @@ system:
       attacker&rsquo;s MD. If you succeed, the attack misses instead.</p>
 
       <p>Quirk: Jumpy and suspicious.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Diabolical_Staff_immemisvGhlW7W8R.yml
+++ b/src/packs/src/srd-magic-items/Diabolical_Staff_immemisvGhlW7W8R.yml
@@ -17,6 +17,7 @@ system:
 
       <p>Quirk: Exaggerates a chaotic or destructive trait that is already
       there.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Disappointment_Hat__hat__f3w9jq8gXtzWNOIV.yml
+++ b/src/packs/src/srd-magic-items/Disappointment_Hat__hat__f3w9jq8gXtzWNOIV.yml
@@ -17,6 +17,7 @@ system:
       [[d6]] to see what you get: 1&ndash;2: You get a useless or disgusting
       item. 3&ndash;6: You pull a useful non-magical item that grants a +d6
       bonus to your next skill check until the end of your next turn.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Distraction__Two_handed_melee_weapon__rU8IkvweCU1K2upT.yml
+++ b/src/packs/src/srd-magic-items/Distraction__Two_handed_melee_weapon__rU8IkvweCU1K2upT.yml
@@ -14,6 +14,7 @@ system:
       action.</p>
 
       <p>Quirk: Intrudes on personal space.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Divine_Harmony__Knot_of_vZFoi8arRIv68k66.yml
+++ b/src/packs/src/srd-magic-items/Divine_Harmony__Knot_of_vZFoi8arRIv68k66.yml
@@ -15,6 +15,7 @@ system:
       discretion.</p>
 
       <p>Quirk: Believes in everything.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Dodging_Doom__Symbol_of_MXaa0SHvGpNVNlNl.yml
+++ b/src/packs/src/srd-magic-items/Dodging_Doom__Symbol_of_MXaa0SHvGpNVNlNl.yml
@@ -13,6 +13,7 @@ system:
       roll a save against one ongoing save ends effect as a free action.</p>
 
       <p>Quirk: Wildly optimistic.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Dominating_Truth__Symbol_of_EpbQiyQ82s8v4wGV.yml
+++ b/src/packs/src/srd-magic-items/Dominating_Truth__Symbol_of_EpbQiyQ82s8v4wGV.yml
@@ -15,6 +15,7 @@ system:
       requirement or less.</p>
 
       <p>Quirk: Never admits they&rsquo;re wrong.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Drakefanged_WVmoOgehjansRXSR.yml
+++ b/src/packs/src/srd-magic-items/Drakefanged_WVmoOgehjansRXSR.yml
@@ -19,6 +19,7 @@ system:
 
       <p>Quirk: Compares everything to dragons or to draconic things, and judges
       actions by how they stack up to draconic expectations.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Dwarven_Mug_0uVTow5KdGhk4Y4T.yml
+++ b/src/packs/src/srd-magic-items/Dwarven_Mug_0uVTow5KdGhk4Y4T.yml
@@ -21,6 +21,7 @@ system:
 
       <p>Quirk: Speaks in dwarven, especially while drunk, even if ordinarily
       unable to speak dwarven.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Elven_gj4wvkuSAhE0ywU2.yml
+++ b/src/packs/src/srd-magic-items/Elven_gj4wvkuSAhE0ywU2.yml
@@ -13,6 +13,7 @@ system:
 
       <p>Quirk: Prefers the finest things in life; of course, they are
       elven.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Energy_eRe1ydl5rO4li9Ik.yml
+++ b/src/packs/src/srd-magic-items/Energy_eRe1ydl5rO4li9Ik.yml
@@ -12,6 +12,7 @@ system:
       <p>This ammunition has been enchanted with one of the following types of
       energy: acid, cold, fire, holy, lightning, thunder. An attack using this
       ammunition deals that type of damage.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Evasion_xXYMRD2YTMnVmbh7.yml
+++ b/src/packs/src/srd-magic-items/Evasion_xXYMRD2YTMnVmbh7.yml
@@ -14,6 +14,7 @@ system:
 
       <p>Quirk: You can&rsquo;t answer a question directly even if you want
       to.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Evil_Eyes__gloves__9k4aivHQPWZMKfWO.yml
+++ b/src/packs/src/srd-magic-items/Evil_Eyes__gloves__9k4aivHQPWZMKfWO.yml
@@ -21,6 +21,7 @@ system:
       illusions for what they are.</p>
 
       <p>Quirk: Bone ridges and oddly patterned callouses on the arms.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Flaming__Champion__yNyhPEbdc4xt9qbn.yml
+++ b/src/packs/src/srd-magic-items/Flaming__Champion__yNyhPEbdc4xt9qbn.yml
@@ -11,6 +11,7 @@ system:
     value: >-
       <p>Bursts into fire as it flies. You deal [[8]] extra ongoing fire damage
       on a hit (epic: [[20]] ongoing fire).</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Flaring_Wand_GwH4ZzLfpiE4pL3r.yml
+++ b/src/packs/src/srd-magic-items/Flaring_Wand_GwH4ZzLfpiE4pL3r.yml
@@ -14,6 +14,7 @@ system:
       roll.</p>
 
       <p>Quirk: Often looks frazzled.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Flurry__Two_handed_melee_weapon__TjnY1TH289NHE6lJ.yml
+++ b/src/packs/src/srd-magic-items/Flurry__Two_handed_melee_weapon__TjnY1TH289NHE6lJ.yml
@@ -13,6 +13,7 @@ system:
       against a different enemy as a free action.</p>
 
       <p>Quirk: Fidgety.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Forceful_Impact_csks9tECEJx2Yvtu.yml
+++ b/src/packs/src/srd-magic-items/Forceful_Impact_csks9tECEJx2Yvtu.yml
@@ -11,6 +11,7 @@ system:
     value: >-
       <p>When you hit with an attack using this ammunition, the target also pops
       free from each enemy engaged with it.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Gathered_Power__Symbol_of_ZVs8fNtGFlRF0sD8.yml
+++ b/src/packs/src/srd-magic-items/Gathered_Power__Symbol_of_ZVs8fNtGFlRF0sD8.yml
@@ -14,6 +14,7 @@ system:
       level, in practice) (champion: champion-level spell, 5th or 7th).</p>
 
       <p>Quirk: Has onetrack mind.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Gauntlets_of_Clobbering_fUJzBdmO7qqvYdiR.yml
+++ b/src/packs/src/srd-magic-items/Gauntlets_of_Clobbering_fUJzBdmO7qqvYdiR.yml
@@ -13,6 +13,7 @@ system:
       the end of the battle (champion: +[[2d8]]; epic: +[[4d10]]).</p>
 
       <p>Quirk: Clobber first, talk later.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Girdle_of_Gender_Switching__belt__cd5VfPfEIHbay9Th.yml
+++ b/src/packs/src/srd-magic-items/Girdle_of_Gender_Switching__belt__cd5VfPfEIHbay9Th.yml
@@ -16,6 +16,7 @@ system:
       you if removed for more than 10 minutes. In addition, minor shifts in
       weight distribution throw your balance off, and you take a &ndash;1
       penalty with melee attacks during your first battle each day.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Glandular_Parasite__cloak_mantle__1kveWGIU0E8JtlTz.yml
+++ b/src/packs/src/srd-magic-items/Glandular_Parasite__cloak_mantle__1kveWGIU0E8JtlTz.yml
@@ -18,6 +18,7 @@ system:
       the battle or for five minutes.</p>
 
       <p>Quirk: Strangely pronounced spine.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Glorious_Rally_e2RN5Xm3JjXLevNC.yml
+++ b/src/packs/src/srd-magic-items/Glorious_Rally_e2RN5Xm3JjXLevNC.yml
@@ -12,6 +12,7 @@ system:
       <p>When you rally, you gain [[4]] temporary hit points that last until the
       end of your next turn (champion: [[10]] temp hp; epic: [[25]] temp
       hp).</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Glory_8Msy6xQJAQbLSBHW.yml
+++ b/src/packs/src/srd-magic-items/Glory_8Msy6xQJAQbLSBHW.yml
@@ -16,6 +16,7 @@ system:
       <p>Quirk: Becomes more and more obsessed with the idea that all their
       accomplishments are undeserved and that they themselves are frauds. This
       obsession often drives them to heroic acts.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Gloves_of_Mind_Rot_yfeP9xTKJIiSAJd7.yml
+++ b/src/packs/src/srd-magic-items/Gloves_of_Mind_Rot_yfeP9xTKJIiSAJd7.yml
@@ -15,6 +15,7 @@ system:
 
       <p>Quirk: The texture of your skin seems wrong to everyone else, but you
       know it&rsquo;s all in their minds and often explain that to them.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Godlike_Glory__Holy_Symbol_of_HGI1vgzstqFKWWBP.yml
+++ b/src/packs/src/srd-magic-items/Godlike_Glory__Holy_Symbol_of_HGI1vgzstqFKWWBP.yml
@@ -13,6 +13,7 @@ system:
       (champion: [[4d6]] temp hp, epic: [[7d10]] temp hp).</p>
 
       <p>Quirk: Dispenses pithy observations.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Great_Low_Sickle___5_weapon__8zbwADDZvq7pkdeB.yml
+++ b/src/packs/src/srd-magic-items/Great_Low_Sickle___5_weapon__8zbwADDZvq7pkdeB.yml
@@ -11,6 +11,7 @@ system:
     value: >-
       <p>You deal +5 damage with missed attacks, but all of your defenses take a
       &ndash;3 penalty</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Greater_Power__Relic_of_V6Dg6HgF4OLOLUlA.yml
+++ b/src/packs/src/srd-magic-items/Greater_Power__Relic_of_V6Dg6HgF4OLOLUlA.yml
@@ -13,6 +13,7 @@ system:
       allies, the spell affects one additional ally.</p>
 
       <p>Quirk: Keeps the relic meticulously clean, rests it on velvet, etc.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Greater_Striking__Melee_weapon__cHS9ZxJc27Bd9Ieb.yml
+++ b/src/packs/src/srd-magic-items/Greater_Striking__Melee_weapon__cHS9ZxJc27Bd9Ieb.yml
@@ -13,6 +13,7 @@ system:
       hit with this weapon (champion: +[[2d8]]; epic: +[[4d8]]).</p>
 
       <p>Quirk: Favors iron and steel, seeing little beauty in gold or gems.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Greatsword_of_Utter_Night___3_greatsword__MaPMjKf9ATzy0dz7.yml
+++ b/src/packs/src/srd-magic-items/Greatsword_of_Utter_Night___3_greatsword__MaPMjKf9ATzy0dz7.yml
@@ -18,6 +18,7 @@ system:
 
       <p>Quirk: Has disturbing dreams that can&rsquo;t be remembered, or at the
       very least must not be.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Guardian_YbriBPAAQDDEWUrs.yml
+++ b/src/packs/src/srd-magic-items/Guardian_YbriBPAAQDDEWUrs.yml
@@ -16,6 +16,7 @@ system:
 
       <p>Quirk: Compelled to the defense of others, even those who might not
       need defending.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Guardian__One_handed_melee_weapon__k1HykZh0w3iYxcVz.yml
+++ b/src/packs/src/srd-magic-items/Guardian__One_handed_melee_weapon__k1HykZh0w3iYxcVz.yml
@@ -14,6 +14,7 @@ system:
       defenses).</p>
 
       <p>Quirk: Looks serious all the time.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Haughty__Any_weapon__fl5OEX3yRS6AaPoi.yml
+++ b/src/packs/src/srd-magic-items/Haughty__Any_weapon__fl5OEX3yRS6AaPoi.yml
@@ -16,6 +16,7 @@ system:
       ([[(@tier)d10]])).</p>
 
       <p>Quirk: Challenges others to improvised contests.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Heedlessness_c99fjccZqXLkqbDo.yml
+++ b/src/packs/src/srd-magic-items/Heedlessness_c99fjccZqXLkqbDo.yml
@@ -13,6 +13,7 @@ system:
       battle.</p>
 
       <p>Quirk: Needlessly provocative.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Helm_of_Fortunate_Dodging_kaSv0r4UhyanWvDo.yml
+++ b/src/packs/src/srd-magic-items/Helm_of_Fortunate_Dodging_kaSv0r4UhyanWvDo.yml
@@ -15,6 +15,7 @@ system:
 
       <p>Quirk: Easily moved to dancing by rhythmic music, and taps foot when
       there is no music.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Helm_of_Psychic_Armor_0iJ7wXOM9CEa9LCr.yml
+++ b/src/packs/src/srd-magic-items/Helm_of_Psychic_Armor_0iJ7wXOM9CEa9LCr.yml
@@ -14,6 +14,7 @@ system:
 
       <p>Quirk: Won&rsquo;t stop going on about &ldquo;the amazing dream I had
       last night.&rdquo;</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Helm_of_Psychic_Retribution_8CeziEW91f8rOY9X.yml
+++ b/src/packs/src/srd-magic-items/Helm_of_Psychic_Retribution_8CeziEW91f8rOY9X.yml
@@ -14,6 +14,7 @@ system:
       damage; epic: [[60]] damage).</p>
 
       <p>Quirk: Stares into space often.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Helm_of_the_Undaunted_Hero_6kU3lcmoUhLjucCU.yml
+++ b/src/packs/src/srd-magic-items/Helm_of_the_Undaunted_Hero_6kU3lcmoUhLjucCU.yml
@@ -13,6 +13,7 @@ system:
       save ends effect.</p>
 
       <p>Quirk: Favors traditional battle hymns.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Heroic_Resolve_KrwDOHtCbhK8OOpm.yml
+++ b/src/packs/src/srd-magic-items/Heroic_Resolve_KrwDOHtCbhK8OOpm.yml
@@ -13,6 +13,7 @@ system:
       attack (including ongoing damage), but not effects.</p>
 
       <p>Quirk: Has terrible heartburn.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Implanted_Aventail__light_armor__nqpOXNZBqN2AyH2F.yml
+++ b/src/packs/src/srd-magic-items/Implanted_Aventail__light_armor__nqpOXNZBqN2AyH2F.yml
@@ -20,6 +20,7 @@ system:
       action, you don&rsquo;t appear to be (or count as) wearing armor.</p>
 
       <p>Quirk: Gill-like slits cover body even when the armor is not up.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Incomparable_Axe_of_Wyrm_Chopping___3_axe__fnTNvweObrS685hI.yml
+++ b/src/packs/src/srd-magic-items/Incomparable_Axe_of_Wyrm_Chopping___3_axe__fnTNvweObrS685hI.yml
@@ -15,6 +15,7 @@ system:
 
       <p>Quirk: Speaks in Draconic, first just curses, but then more and more
       elements of speech.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Infighting__Wand_of_wtH7DtEMnAeSAaJ7.yml
+++ b/src/packs/src/srd-magic-items/Infighting__Wand_of_wtH7DtEMnAeSAaJ7.yml
@@ -14,6 +14,7 @@ system:
       spell.</p>
 
       <p>Quirk: Physically pushy.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Inimical__Any_weapon__ItIkLTmXAQxFow5x.yml
+++ b/src/packs/src/srd-magic-items/Inimical__Any_weapon__ItIkLTmXAQxFow5x.yml
@@ -14,6 +14,7 @@ system:
       that extra damage.</p>
 
       <p>Quirk: Bites nails, or a similar darker habit.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Instant_Vengeance_N8KmxKNx2mN7qMOv.yml
+++ b/src/packs/src/srd-magic-items/Instant_Vengeance_N8KmxKNx2mN7qMOv.yml
@@ -14,6 +14,7 @@ system:
       ranged) against the attacker as a free action.</p>
 
       <p>Quirk: Sticks close to their friends, real close.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Inviolability_CNYkUCPNyMOsPAHX.yml
+++ b/src/packs/src/srd-magic-items/Inviolability_CNYkUCPNyMOsPAHX.yml
@@ -14,6 +14,7 @@ system:
 
       <p>Quirk: Attempts stunts of toughness and daring that a person less
       convinced of their invulnerability might be wise enough to avoid.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Iron_Grip_qhnLF3b4tfF91NWE.yml
+++ b/src/packs/src/srd-magic-items/Iron_Grip_qhnLF3b4tfF91NWE.yml
@@ -16,6 +16,7 @@ system:
 
       <p>Quirk: Loves to arm wrestle, thumb wrestle, drum fingers on tables,
       etc.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Iron_Will_xOn2RSkkodW5xjOx.yml
+++ b/src/packs/src/srd-magic-items/Iron_Will_xOn2RSkkodW5xjOx.yml
@@ -11,6 +11,7 @@ system:
     value: |-
       <p>The default AC bonus applies to Mental Defense as well.</p>
       <p>Quirk: Prone to abstract speculation.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Jack_of_All_Trades_FMRNVAt9SdnCkpx6.yml
+++ b/src/packs/src/srd-magic-items/Jack_of_All_Trades_FMRNVAt9SdnCkpx6.yml
@@ -14,6 +14,7 @@ system:
       bonus is +2 or higher, this ring has no effect).</p>
 
       <p>Quirk: Talks as though they know everything.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Jeweled_Glove_8k2ozLkjlIWUFWyR.yml
+++ b/src/packs/src/srd-magic-items/Jeweled_Glove_8k2ozLkjlIWUFWyR.yml
@@ -15,6 +15,7 @@ system:
       <p>Quirk: Alternately paranoid that people are looking too closely at your
       precious jeweled glove and upset that people aren&rsquo;t paying enough
       attention to your amazing jeweled glove.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Keen_3xYjXdTMlo9IslJg.yml
+++ b/src/packs/src/srd-magic-items/Keen_3xYjXdTMlo9IslJg.yml
@@ -11,6 +11,7 @@ system:
     value: >-
       <p>When you make an attack with this ammunition, the crit range of that
       attack expands by 1 (usually 18+ including the default bonus).</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Kilt_of_the_Mad_Archmage_RgNXNIcaxZjzLcC5.yml
+++ b/src/packs/src/srd-magic-items/Kilt_of_the_Mad_Archmage_RgNXNIcaxZjzLcC5.yml
@@ -14,6 +14,7 @@ system:
       spells until the end of your next turn.</p>
 
       <p>Quirk: Roll eyes and giggle too often for comfort.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Last_Legs_NBUBRhe8sSHoZFs3.yml
+++ b/src/packs/src/srd-magic-items/Last_Legs_NBUBRhe8sSHoZFs3.yml
@@ -13,6 +13,7 @@ system:
       left (champion: two or fewer, epic: three or fewer).</p>
 
       <p>Quirk: Loves long-shot bets.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Last_Stand__Usually_heavy_armor__daEngbvr6VNMt4mm.yml
+++ b/src/packs/src/srd-magic-items/Last_Stand__Usually_heavy_armor__daEngbvr6VNMt4mm.yml
@@ -11,6 +11,7 @@ system:
     value: |-
       <p>You gain a +4 bonus to AC while you have no recoveries left.</p>
       <p>Quirk: Has a high pain tolerance.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Last_Word_sb8RLVGiap8PQkQ5.yml
+++ b/src/packs/src/srd-magic-items/Last_Word_sb8RLVGiap8PQkQ5.yml
@@ -13,6 +13,7 @@ system:
       additional hit points (champion [[75]] hp; epic: [[200]] hp).</p>
 
       <p>Quirk: Stubbornly independent.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Lethal_Strike_zO8Ubzd36RkPl0gT.yml
+++ b/src/packs/src/srd-magic-items/Lethal_Strike_zO8Ubzd36RkPl0gT.yml
@@ -11,6 +11,7 @@ system:
     value: >-
       <p>You deal +[[1d10]] damage on a hit (champion: +[[2d10]]; epic:
       +[[4d10]]).</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Liberation__Melee_weapon__ukyNVYoC388jTmX0.yml
+++ b/src/packs/src/srd-magic-items/Liberation__Melee_weapon__ukyNVYoC388jTmX0.yml
@@ -14,6 +14,7 @@ system:
       ends effect as a free action.</p>
 
       <p>Quirk: Drones on about how healing grace will save all the worlds.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Lifestone_PDDNScgA3qXPqWku.yml
+++ b/src/packs/src/srd-magic-items/Lifestone_PDDNScgA3qXPqWku.yml
@@ -15,6 +15,7 @@ system:
 
       <p>Quirk: Chides others for taking risks when they have lesser magical
       protection.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Longbow_of_Fallen_Grace___3_longbow__F68U9ASSTv8aaMwp.yml
+++ b/src/packs/src/srd-magic-items/Longbow_of_Fallen_Grace___3_longbow__F68U9ASSTv8aaMwp.yml
@@ -15,6 +15,7 @@ system:
 
       <p>Quirk: Complains too often that the glorious centuries of old are gone
       forever.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Lore_Bottle_6J5t2Kehv3gHDbZr.yml
+++ b/src/packs/src/srd-magic-items/Lore_Bottle_6J5t2Kehv3gHDbZr.yml
@@ -22,6 +22,7 @@ system:
       <p>Quirk: The connection formed with the face in the bottle can be
       compelling and unsettling, as the spirit literally &ldquo;gets in your
       head.&rdquo; Each bottle has a different effect on its owner.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Lucky_Stray_z5XfAJP41pOJRn1X.yml
+++ b/src/packs/src/srd-magic-items/Lucky_Stray_z5XfAJP41pOJRn1X.yml
@@ -12,6 +12,7 @@ system:
       <p>On a miss, you can make a basic ranged attack against another foe that
       is near the target or along your line of sight to the target (between you
       and the original target or past the original target).</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Mage_s_Invisible_Aegis__Wand_of_the_J8CmDDNxV6Awfjr6.yml
+++ b/src/packs/src/srd-magic-items/Mage_s_Invisible_Aegis__Wand_of_the_J8CmDDNxV6Awfjr6.yml
@@ -14,6 +14,7 @@ system:
       11+).</p>
 
       <p>Quirk: Hums tunelessly.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Manual_of_Enlightened_Flesh_J8ME76ItPAXmRDHv.yml
+++ b/src/packs/src/srd-magic-items/Manual_of_Enlightened_Flesh_J8ME76ItPAXmRDHv.yml
@@ -11,6 +11,7 @@ system:
     value: |-
       <p>You gain a +1 bonus to all skill checks based on Str, Con, or Dex.</p>
       <p>Quirk: Takes heightened satisfaction in their own physical prowess.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Manual_of_Puissant_Skill_at_Arms__Champion__o0dL6ridD3fOi1rg.yml
+++ b/src/packs/src/srd-magic-items/Manual_of_Puissant_Skill_at_Arms__Champion__o0dL6ridD3fOi1rg.yml
@@ -16,6 +16,7 @@ system:
 
       <p>Quirk: Constantly checking self out and flexing, and seems to want to
       be caught doing that.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Mauling__Two_handed_melee_weapon__cGKCAMdZRWdV5esY.yml
+++ b/src/packs/src/srd-magic-items/Mauling__Two_handed_melee_weapon__cGKCAMdZRWdV5esY.yml
@@ -13,6 +13,7 @@ system:
       this turn.</p>
 
       <p>Quirk: Yells battle cries during battle.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Mighty_Stunning__One_handed_blunt_1d6_melee_weapon__yiZUAo5wzEgChTPB.yml
+++ b/src/packs/src/srd-magic-items/Mighty_Stunning__One_handed_blunt_1d6_melee_weapon__yiZUAo5wzEgChTPB.yml
@@ -14,6 +14,7 @@ system:
       until the end of its next turn.</p>
 
       <p>Quirk: Warns of impending doom.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Mighty_Swing__Two_handed_melee_weapon__Nn2wQHv2r5PUzbrz.yml
+++ b/src/packs/src/srd-magic-items/Mighty_Swing__Two_handed_melee_weapon__Nn2wQHv2r5PUzbrz.yml
@@ -14,6 +14,7 @@ system:
       you miss, you take that damage instead.</p>
 
       <p>Quirk: Tends to break things.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Mindbending__Wand_of_CzWrbUNJJ6Op3Ce0.yml
+++ b/src/packs/src/srd-magic-items/Mindbending__Wand_of_CzWrbUNJJ6Op3Ce0.yml
@@ -14,6 +14,7 @@ system:
       Defense.</p>
 
       <p>Quirk: Uses pedantically circumlocutious phraseology.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Momentous_Harmony_eCRxf6CzDnyl3Erh.yml
+++ b/src/packs/src/srd-magic-items/Momentous_Harmony_eCRxf6CzDnyl3Erh.yml
@@ -17,6 +17,7 @@ system:
 
       <p>Quirk: Treats all their magic items well&mdash;talks to them as if
       they&rsquo;re alive, refers to them as &ldquo;children,&rdquo; etc.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Musical_Touch_sqiF03IoEAAFNIpV.yml
+++ b/src/packs/src/srd-magic-items/Musical_Touch_sqiF03IoEAAFNIpV.yml
@@ -14,6 +14,7 @@ system:
       any more of a musician than you already are.</p>
 
       <p>Quirk: Hums and picks up tunes easily.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Nemesis_7MsRyrWatDr5xldr.yml
+++ b/src/packs/src/srd-magic-items/Nemesis_7MsRyrWatDr5xldr.yml
@@ -17,6 +17,7 @@ system:
       this type of ammunition two or more times against the same creature group
       this battle, monsters of that type can instead reroll each attack against
       you that misses this battle (once per attack).</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Neural_Blade__any_bladed_weapon__3c96sLHpZwizzZv2.yml
+++ b/src/packs/src/srd-magic-items/Neural_Blade__any_bladed_weapon__3c96sLHpZwizzZv2.yml
@@ -19,6 +19,7 @@ system:
 
       <p>Quirk: Large sphincters on arm where the ganglia-tentacles from the
       blade&rsquo;s hilt insert themselves.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Neural_Whip__light_one_handed_melee_weapon__Gi3GbuD6F7wqmPRW.yml
+++ b/src/packs/src/srd-magic-items/Neural_Whip__light_one_handed_melee_weapon__Gi3GbuD6F7wqmPRW.yml
@@ -20,6 +20,7 @@ system:
       page 44), and the attack deals psychic damage.</p>
 
       <p>Quirk: Grows eyes in unusual places.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/No_Mercy__Ranged_weapon__YFlO0uxu5msTRAKl.yml
+++ b/src/packs/src/srd-magic-items/No_Mercy__Ranged_weapon__YFlO0uxu5msTRAKl.yml
@@ -14,6 +14,7 @@ system:
 
       <p>Quirk: Develops a surprising lip-curl sneer that shows up a bit too
       often.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Paragon_e9uNWg0t4AhgLLiK.yml
+++ b/src/packs/src/srd-magic-items/Paragon_e9uNWg0t4AhgLLiK.yml
@@ -16,6 +16,7 @@ system:
       <p>Quirk: Sometimes unwittingly speaks in a language that sounds like it
       could be the original language of their race, if anyone else could
       understand it.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Perfection__Usually_heavy_armor__YCcABFwjb8nH0w9L.yml
+++ b/src/packs/src/srd-magic-items/Perfection__Usually_heavy_armor__YCcABFwjb8nH0w9L.yml
@@ -11,6 +11,7 @@ system:
     value: |-
       <p>You gain a +1 bonus to all defenses while at maximum hit points.</p>
       <p>Quirk: Made uneasy by the sight of blood.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Perseverance_r3kIH0Qwjtd089VO.yml
+++ b/src/packs/src/srd-magic-items/Perseverance_r3kIH0Qwjtd089VO.yml
@@ -16,6 +16,7 @@ system:
       power this way.</p>
 
       <p>Quirk: Repeats stories over and over.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Potion_Belt_pb6vfXEO94s3QBv1.yml
+++ b/src/packs/src/srd-magic-items/Potion_Belt_pb6vfXEO94s3QBv1.yml
@@ -15,6 +15,7 @@ system:
 
       <p>Quirk: Constantly attempts to refill everyone else&rsquo;s drinks. Or
       potions. Or ration bags.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Procrastination_Tome__implement__cOmM6ov5EfMz8Jda.yml
+++ b/src/packs/src/srd-magic-items/Procrastination_Tome__implement__cOmM6ov5EfMz8Jda.yml
@@ -15,6 +15,7 @@ system:
       during the first round of each battle you must spend all your actions
       either moving or &ldquo;limbering up.&rdquo; This means not using any
       abilities, you&rsquo;re just jogging and stretching.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Protection_IOesLadFnSWY27r1.yml
+++ b/src/packs/src/srd-magic-items/Protection_IOesLadFnSWY27r1.yml
@@ -13,6 +13,7 @@ system:
       allies.</p>
 
       <p>Quirk: Tends to others with too much familiarity.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Protection__Melee_weapon__7nBNJGd6KtOkB2sS.yml
+++ b/src/packs/src/srd-magic-items/Protection__Melee_weapon__7nBNJGd6KtOkB2sS.yml
@@ -14,6 +14,7 @@ system:
       +6).</p>
 
       <p>Quirk: Has urges to watch over the *helpless* or innocent.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Puissance__Melee_weapon__jKgLCGKj4bSUAxtW.yml
+++ b/src/packs/src/srd-magic-items/Puissance__Melee_weapon__jKgLCGKj4bSUAxtW.yml
@@ -13,6 +13,7 @@ system:
       recharge roll for one power.</p>
 
       <p>Quirk: Tremendous appetite for meat.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Puissance_uXnz3VA9UMXjIonP.yml
+++ b/src/packs/src/srd-magic-items/Puissance_uXnz3VA9UMXjIonP.yml
@@ -13,6 +13,7 @@ system:
       for one expended power.</p>
 
       <p>Quirk: Tremendous appetite for meat.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Rachis_Girdle__belt__DulzgrmmfsmQEdad.yml
+++ b/src/packs/src/srd-magic-items/Rachis_Girdle__belt__DulzgrmmfsmQEdad.yml
@@ -17,6 +17,7 @@ system:
       level.</p>
 
       <p>Quirk: Odd gait from reconfigured pelvis.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Rasping_Greaves__boots__xdKVoV1R0UeADGDN.yml
+++ b/src/packs/src/srd-magic-items/Rasping_Greaves__boots__xdKVoV1R0UeADGDN.yml
@@ -18,6 +18,7 @@ system:
 
       <p>Quirk: A billow-like lung inside each greave makes a breathing
       sound.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Reckless__Melee_weapon__ghBcazeZrlfioaxh.yml
+++ b/src/packs/src/srd-magic-items/Reckless__Melee_weapon__ghBcazeZrlfioaxh.yml
@@ -16,6 +16,7 @@ system:
 
       <p>Quirk: Low impulse control, particularly when it comes to impulsive
       movements through doors, onto railings, or over tables.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Recovery_QRXh3elqSOyup4mV.yml
+++ b/src/packs/src/srd-magic-items/Recovery_QRXh3elqSOyup4mV.yml
@@ -14,6 +14,7 @@ system:
 
       <p>Quirk: You grow small extra appendages that slowly wither away over
       days or weeks.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Relentless_Strike_NfolKqLZmVPzTmc6.yml
+++ b/src/packs/src/srd-magic-items/Relentless_Strike_NfolKqLZmVPzTmc6.yml
@@ -16,6 +16,7 @@ system:
       couldn&rsquo;t normally take an action.</p>
 
       <p>Quirk: Has near-constant insomnia.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Resilience_6p95MqX42A0rewzF.yml
+++ b/src/packs/src/srd-magic-items/Resilience_6p95MqX42A0rewzF.yml
@@ -13,6 +13,7 @@ system:
       recovery.</p>
 
       <p>Quirk: Eats an odd vegetarian diet and advocates it loudly.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Resilience_wXb7ISKOM8cF3uVa.yml
+++ b/src/packs/src/srd-magic-items/Resilience_wXb7ISKOM8cF3uVa.yml
@@ -13,6 +13,7 @@ system:
       after using the first (and seeing the recovery roll).</p>
 
       <p>Quirk: Grinningly optimistic.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Resilience_xtmWW2LPoLeMK8NE.yml
+++ b/src/packs/src/srd-magic-items/Resilience_xtmWW2LPoLeMK8NE.yml
@@ -11,6 +11,7 @@ system:
     value: |-
       <p>(Recharge 6+) When you use this ring, heal using a recovery.</p>
       <p>Quirk: Eats an odd vegetarian diet and advocates it loudly.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Resurgence_poHK3xIv3lyuA789.yml
+++ b/src/packs/src/srd-magic-items/Resurgence_poHK3xIv3lyuA789.yml
@@ -14,6 +14,7 @@ system:
 
       <p>Quirk: Bursts forth with wildly optimistic comments from time to
       time.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Ring_of_Delusion__ring__qBxzX4QlD52YpfZR.yml
+++ b/src/packs/src/srd-magic-items/Ring_of_Delusion__ring__qBxzX4QlD52YpfZR.yml
@@ -15,6 +15,7 @@ system:
       obviously ridiculous, that is what you believe provided there is no
       obvious and direct proof that contradicts your delusion. In addition, you
       gain +3 bonus to checks to find traps and see through illusions.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Rope_of_Entangling_0apwiD13Wu5p05RO.yml
+++ b/src/packs/src/srd-magic-items/Rope_of_Entangling_0apwiD13Wu5p05RO.yml
@@ -20,6 +20,7 @@ system:
 
       <p>Quirk: Speaks in sentences for which &ldquo;convoluted&rdquo; is the
       only proper term.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Sandals_of_Wall_Striding_gbEfRz5XZAQgJ9Wu.yml
+++ b/src/packs/src/srd-magic-items/Sandals_of_Wall_Striding_gbEfRz5XZAQgJ9Wu.yml
@@ -14,6 +14,7 @@ system:
 
       <p>Quirk: Has compulsion to snatch small insects out of the air and pop
       them into mouth when they think no one is watching.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Sandals_of_the_Slippery_Eel_hxoZ8PhjUYUrKPaa.yml
+++ b/src/packs/src/srd-magic-items/Sandals_of_the_Slippery_Eel_hxoZ8PhjUYUrKPaa.yml
@@ -11,6 +11,7 @@ system:
     value: |-
       <p>(Recharge 11+) Reroll a failed disengage check.</p>
       <p>Quirk: Loves puns.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Sash_of_Suppleness_UvLkklRN3FRoooyu.yml
+++ b/src/packs/src/srd-magic-items/Sash_of_Suppleness_UvLkklRN3FRoooyu.yml
@@ -15,6 +15,7 @@ system:
 
       <p>Quirk: Always stretching, even when it would be more polite or sensible
       to not be doing so.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Scroll_of_Seven_Subtle_Serpents_mkxXuFfeLoPHCPVB.yml
+++ b/src/packs/src/srd-magic-items/Scroll_of_Seven_Subtle_Serpents_mkxXuFfeLoPHCPVB.yml
@@ -20,6 +20,7 @@ system:
       [[8d8]]).</li><li>Roll a save against an ongoing save ends
       effect.</li></ul><p>Quirk: Always in constant motion, or swaying gently
       when still.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Scroll_of_the_Fortuitous_Outlook_GoDUmXhC7XgaRYij.yml
+++ b/src/packs/src/srd-magic-items/Scroll_of_the_Fortuitous_Outlook_GoDUmXhC7XgaRYij.yml
@@ -14,6 +14,7 @@ system:
       successful, you regain that power this turn.</p>
 
       <p>Quirk: Paranoid about the weather.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Scroll_of_the_Unerring_Shaft_KuEJMhkoSeyJCuDI.yml
+++ b/src/packs/src/srd-magic-items/Scroll_of_the_Unerring_Shaft_KuEJMhkoSeyJCuDI.yml
@@ -14,6 +14,7 @@ system:
       instead.</p>
 
       <p>Quirk: Sings snatches of nonsense.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Seeking_2v25grBLMFBIX4wT.yml
+++ b/src/packs/src/srd-magic-items/Seeking_2v25grBLMFBIX4wT.yml
@@ -11,6 +11,7 @@ system:
     value: >-
       <p>You deal +[[4]] damage on a miss (champion: +[[10]]; epic:
       +[[25]]).</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Shelter_XtV4EfVq6qG1grMp.yml
+++ b/src/packs/src/srd-magic-items/Shelter_XtV4EfVq6qG1grMp.yml
@@ -13,6 +13,7 @@ system:
       the elements, barring full immersion in water or other liquid.</p>
 
       <p>Quirk: Prefers the outdoors.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Skin_of_Your_Teeth_9wwGmszdcbaXyHTs.yml
+++ b/src/packs/src/srd-magic-items/Skin_of_Your_Teeth_9wwGmszdcbaXyHTs.yml
@@ -14,6 +14,7 @@ system:
 
       <p>Quirk: Regularly finds copper pieces and other minor valuables on the
       ground.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Skullcap_of_Wit_7C2mt83RVqpz619I.yml
+++ b/src/packs/src/srd-magic-items/Skullcap_of_Wit_7C2mt83RVqpz619I.yml
@@ -15,6 +15,7 @@ system:
       cares about only once in a campaign.</p>
 
       <p>Quirk: Banters with lively wit.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Slayer_s_Boots_lpTOgnjVMJEdZfxu.yml
+++ b/src/packs/src/srd-magic-items/Slayer_s_Boots_lpTOgnjVMJEdZfxu.yml
@@ -14,6 +14,7 @@ system:
       past them instead so they can&rsquo;t intercept.</p>
 
       <p>Quirk: Recites death poems of ancient heroes. At length.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Spiked_krXRkO7WABOLOI9X.yml
+++ b/src/packs/src/srd-magic-items/Spiked_krXRkO7WABOLOI9X.yml
@@ -14,6 +14,7 @@ system:
       it were an off-hand weapon (use d6 damage dice).</p>
 
       <p>Quirk: Has shifty eyes.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Splendor_cvpL8U22DK39ImJh.yml
+++ b/src/packs/src/srd-magic-items/Splendor_cvpL8U22DK39ImJh.yml
@@ -13,6 +13,7 @@ system:
       without splendor.</p>
 
       <p>Quirk: Fastidious about clothing and gear.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Staff_of_Dark_Karma_sx6utMwTQ3cxqaZS.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_Dark_Karma_sx6utMwTQ3cxqaZS.yml
@@ -13,6 +13,7 @@ system:
       target. If the spell targets one enemy, deal +[[4d10]] damage. Otherwise,
       deal +[[2d10]] damage. In addition, the first time you take damage each
       battle, you lose [[20]] hp.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Staff_of_Health_xZjgHzlEkUxrM2qC.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_Health_xZjgHzlEkUxrM2qC.yml
@@ -14,6 +14,7 @@ system:
 
       <p>Quirk: The diseased of nearly every population center somehow know to
       seek you out for healing.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Staff_of_Manipulation_duBlPFmbuMkLX2Ys.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_Manipulation_duBlPFmbuMkLX2Ys.yml
@@ -14,6 +14,7 @@ system:
       on the target(s) besides damage (including ongoing damage).</p>
 
       <p>Quirk: Expects to be treated with respect.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Staff_of_Massacres_6ZcXG9fV9LZ6qKTf.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_Massacres_6ZcXG9fV9LZ6qKTf.yml
@@ -13,6 +13,7 @@ system:
       bonus with that spell if it has more than one target.</p>
 
       <p>Quirk: Obsessed with numbers and calculations.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Staff_of_the_Diffident_Magician_jYWFQPPM0suuSS89.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_the_Diffident_Magician_jYWFQPPM0suuSS89.yml
@@ -15,6 +15,7 @@ system:
       the creature is large or smaller (epic: any size).</p>
 
       <p>Quirk: Doesn&rsquo;t like to be touched.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Staff_of_the_God_s_Riches_NTGfwzzq7ujUdQjo.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_the_God_s_Riches_NTGfwzzq7ujUdQjo.yml
@@ -14,6 +14,7 @@ system:
       choosing different targets.</p>
 
       <p>Quirk: Careless with money.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Staff_of_the_Imperium_FporgUiMi60viLYg.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_the_Imperium_FporgUiMi60viLYg.yml
@@ -17,6 +17,7 @@ system:
       ever.</p>
 
       <p>Quirk: Becomes certain that they are destined to rule.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Staff_of_the_Uncrowned_King_P6PjIItnS1tKAtSm.yml
+++ b/src/packs/src/srd-magic-items/Staff_of_the_Uncrowned_King_P6PjIItnS1tKAtSm.yml
@@ -13,6 +13,7 @@ system:
       save against an effect created or caused by an undead enemy.</p>
 
       <p>Quirk: You see dead people&hellip;sometimes.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Stalwart_u2Py3bV0v85hUzcl.yml
+++ b/src/packs/src/srd-magic-items/Stalwart_u2Py3bV0v85hUzcl.yml
@@ -14,6 +14,7 @@ system:
       epic: 25).</p>
 
       <p>Quirk: Always the last to retreat or avoid danger.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Steady__Ranged_weapon__X3QW449dcOMjaQCb.yml
+++ b/src/packs/src/srd-magic-items/Steady__Ranged_weapon__X3QW449dcOMjaQCb.yml
@@ -13,6 +13,7 @@ system:
       10 as the natural roll for that attack.</p>
 
       <p>Quirk: Talks too much about the weather.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Stone_Flesh_10OJxfD5NwVUmz6U.yml
+++ b/src/packs/src/srd-magic-items/Stone_Flesh_10OJxfD5NwVUmz6U.yml
@@ -11,6 +11,7 @@ system:
     value: |-
       <p>The default AC bonus applies to Physical Defense as well.</p>
       <p>Quirk: Extremely stubborn.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Strider_Symbiote__cloak_mantle___champion_tier_item__fxMQ7hN568UaXXHg.yml
+++ b/src/packs/src/srd-magic-items/Strider_Symbiote__cloak_mantle___champion_tier_item__fxMQ7hN568UaXXHg.yml
@@ -21,6 +21,7 @@ system:
       (epic: chuulish recharge starts at 11+)</p>
 
       <p>Quirk: Twitching antenna.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Sure_Fingers_RZWwcpf2RfgqT9nb.yml
+++ b/src/packs/src/srd-magic-items/Sure_Fingers_RZWwcpf2RfgqT9nb.yml
@@ -13,6 +13,7 @@ system:
       strength of grip, hand-eye coordination, or similar abilities.</p>
 
       <p>Quirk: Holds a pinky finger up when holding a cup.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Sword_of_Relentless_Glory___2_weapon__PaFwgiNT99YsFwn3.yml
+++ b/src/packs/src/srd-magic-items/Sword_of_Relentless_Glory___2_weapon__PaFwgiNT99YsFwn3.yml
@@ -14,6 +14,7 @@ system:
       battle.</p>
 
       <p>Quirk: Spouts furious curses in battle.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Termination_mmhoLsaJEBJksF8E.yml
+++ b/src/packs/src/srd-magic-items/Termination_mmhoLsaJEBJksF8E.yml
@@ -14,6 +14,7 @@ system:
 
       <p>Quirk: Continually fails to finish sentences, stopping in
       mid-thoug&hellip;.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/The_Gods_and_Goddesses__Gem_of_dNUKzANWniomZsG4.yml
+++ b/src/packs/src/srd-magic-items/The_Gods_and_Goddesses__Gem_of_dNUKzANWniomZsG4.yml
@@ -14,6 +14,7 @@ system:
 
       <p>Quirk: Insists on courtesy even in situations where none should be
       required.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Thief_s_Eye_nwfbGVjMqGXoNVcI.yml
+++ b/src/packs/src/srd-magic-items/Thief_s_Eye_nwfbGVjMqGXoNVcI.yml
@@ -15,6 +15,7 @@ system:
 
       <p>Quirk: You&rsquo;re always prying into things that should maybe be left
       shut; doors, topics of conversation, taboos&hellip;.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Tome_of_Arcane_Mysteries__Epic__DORrPedz0G1JvEIM.yml
+++ b/src/packs/src/srd-magic-items/Tome_of_Arcane_Mysteries__Epic__DORrPedz0G1JvEIM.yml
@@ -14,6 +14,7 @@ system:
       instead of the natural roll.</p>
 
       <p>Quirk: Doodles insane geometrical designs.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Tome_of_Misfortune__implement__g8nUFbIbGqsYsow2.yml
+++ b/src/packs/src/srd-magic-items/Tome_of_Misfortune__implement__g8nUFbIbGqsYsow2.yml
@@ -15,6 +15,7 @@ system:
       cast the recovered spell, roll a [[d6]]. 1&ndash;3: The book chooses the
       targets for the spell and can consider you and your allies as enemies, or
       your enemies as allies. 4&ndash;6: You choose targets normally.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Tome_of_the_Divinities_and_their_Deeds_YzZ89cSh4rmo7FUb.yml
+++ b/src/packs/src/srd-magic-items/Tome_of_the_Divinities_and_their_Deeds_YzZ89cSh4rmo7FUb.yml
@@ -15,6 +15,7 @@ system:
 
       <p>Quirk: Sees the hands of the gods operating subtly through the natural
       and social world, and makes others aware of it.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Tome_of_the_Open_Mind_WuMRnCwDuebSHYPz.yml
+++ b/src/packs/src/srd-magic-items/Tome_of_the_Open_Mind_WuMRnCwDuebSHYPz.yml
@@ -13,6 +13,7 @@ system:
       or Charisma and dislike the result, reroll the check.</p>
 
       <p>Quirk: Annoyingly curious.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Totem_Kilt_ey0iNirRSygl5RrE.yml
+++ b/src/packs/src/srd-magic-items/Totem_Kilt_ey0iNirRSygl5RrE.yml
@@ -14,6 +14,7 @@ system:
       each battle. Add +2 to the roll.</p>
 
       <p>Quirk: Sometimes speaks with the voices of ancestors.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Treasured_Chest__wondrous_item__hv3pwNEA9Mb9Wa81.yml
+++ b/src/packs/src/srd-magic-items/Treasured_Chest__wondrous_item__hv3pwNEA9Mb9Wa81.yml
@@ -15,6 +15,7 @@ system:
       <p>Always: You can&rsquo;t move faster than the chest, and the chest is
       slow. You travel at half speed everywhere and can&rsquo;t use actions to
       move twice during a turn in battle.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Twin_pNLZK9eFDuHkK6K2.yml
+++ b/src/packs/src/srd-magic-items/Twin_pNLZK9eFDuHkK6K2.yml
@@ -13,6 +13,7 @@ system:
       out of the first and targets the same or a different enemy. Make a free
       action basic ranged attack for it with a +8 attack bonus instead of your
       normal bonus (champion: +12; epic: +16).</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Uncanny__Epic__Im6fVrZDfkclQV6x.yml
+++ b/src/packs/src/srd-magic-items/Uncanny__Epic__Im6fVrZDfkclQV6x.yml
@@ -12,6 +12,7 @@ system:
       <p>It warps the forces of necessity and miracle as it flies. When you
       attack with this ammunition, use the target&rsquo;s lowest defense instead
       of the defense your attack would normally target.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Unfettered_Minion__Wand_of_qliKmDVSH4Rd6fkg.yml
+++ b/src/packs/src/srd-magic-items/Unfettered_Minion__Wand_of_qliKmDVSH4Rd6fkg.yml
@@ -15,6 +15,7 @@ system:
 
       <p>Quirk: Switches unexpectedly into &ldquo;evil mastermind&rdquo; tone of
       voice.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Unstinting_Virtue__Melee_weapon__9Op9UpT8ItEvos9y.yml
+++ b/src/packs/src/srd-magic-items/Unstinting_Virtue__Melee_weapon__9Op9UpT8ItEvos9y.yml
@@ -13,6 +13,7 @@ system:
       save against a save ends effect.</p>
 
       <p>Quirk: Insists that all weakness is an illusion.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Vanity__Melee_weapon__HPK6UneNjBeMr2vn.yml
+++ b/src/packs/src/srd-magic-items/Vanity__Melee_weapon__HPK6UneNjBeMr2vn.yml
@@ -14,6 +14,7 @@ system:
       +[[4d6]]).</p>
 
       <p>Quirk: Tells their name (their real one) to everyone.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Vengeance__Melee_weapon__3Sa8quAXxuEOCxe9.yml
+++ b/src/packs/src/srd-magic-items/Vengeance__Melee_weapon__3Sa8quAXxuEOCxe9.yml
@@ -13,6 +13,7 @@ system:
       damage to that enemy.</p>
 
       <p>Quirk: Quick to take offense.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Victory_by_Inches_Jk5A45hN30rnvEZL.yml
+++ b/src/packs/src/srd-magic-items/Victory_by_Inches_Jk5A45hN30rnvEZL.yml
@@ -14,6 +14,7 @@ system:
       weapon&rsquo;s magic bonus to miss damage.</p>
 
       <p>Quirk: Have a hard time taking no for an answer.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Vitality_Pn4rgWHGYo7mcxdD.yml
+++ b/src/packs/src/srd-magic-items/Vitality_Pn4rgWHGYo7mcxdD.yml
@@ -13,6 +13,7 @@ system:
       effect without taking damage first.</p>
 
       <p>Quirk: Fascinated by patterns.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Vulnerability_tB6vhO2HW8P5FoLG.yml
+++ b/src/packs/src/srd-magic-items/Vulnerability_tB6vhO2HW8P5FoLG.yml
@@ -12,6 +12,7 @@ system:
       <p>When you hit with an attack using this ammunition, if the target is
       from the same tier or lower than the ammunition, it&rsquo;s also
       *vulnerable* to all attacks until the start of your next turn.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Wand_of_Unerring_Pain_EZpjj8AD5ndgBf4x.yml
+++ b/src/packs/src/srd-magic-items/Wand_of_Unerring_Pain_EZpjj8AD5ndgBf4x.yml
@@ -15,6 +15,7 @@ system:
       damage.</p>
 
       <p>Quirk: Stares intently, often at nothing.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Wand_of_the_Bloodless_Mage___2_implement__lL7D5tzmhIMbjq6m.yml
+++ b/src/packs/src/srd-magic-items/Wand_of_the_Bloodless_Mage___2_implement__lL7D5tzmhIMbjq6m.yml
@@ -13,6 +13,7 @@ system:
       epic: [[6]] hp).</p>
 
       <p>Quirk: Laughs turn hollow or spectral.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Warding_m8110GWgnH0copb6.yml
+++ b/src/packs/src/srd-magic-items/Warding_m8110GWgnH0copb6.yml
@@ -13,6 +13,7 @@ system:
       Mental Defense.</p>
 
       <p>Quirk: Stretches and meditates whenever inactive.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Water_Breathing_tHDhGK1XcxaLdNJP.yml
+++ b/src/packs/src/srd-magic-items/Water_Breathing_tHDhGK1XcxaLdNJP.yml
@@ -14,6 +14,7 @@ system:
       slowly, so you&rsquo;ll have warning to get to the surface.</p>
 
       <p>Quirk: Hiccups in stressful situations.</p>
+  publicationSource: 1e
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Wild_Heart_2JnqRy7SnNNU6irY.yml
+++ b/src/packs/src/srd-magic-items/Wild_Heart_2JnqRy7SnNNU6irY.yml
@@ -14,6 +14,7 @@ system:
       animals are especially wary of you.</p>
 
       <p>Quirk: Seems out of place in civilization.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Wing_clipper_gZdINsdvyr4OJP96.yml
+++ b/src/packs/src/srd-magic-items/Wing_clipper_gZdINsdvyr4OJP96.yml
@@ -13,6 +13,7 @@ system:
       from the same tier or lower than the ammunition, it loses the flight
       ability (save ends). If the target is presently flying, it must attempt to
       land during its next turn.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Wise_Eyelet_Boots_C9iMetnbXQmnyuYg.yml
+++ b/src/packs/src/srd-magic-items/Wise_Eyelet_Boots_C9iMetnbXQmnyuYg.yml
@@ -13,6 +13,7 @@ system:
       take its turn this round, you pop free from all enemies.</p>
 
       <p>Quirk: Hesitates before speaking.</p>
+  publicationSource: 13TW
   powerUsage:
     type: String
     label: Power Usage

--- a/src/packs/src/srd-magic-items/Xenoteros__cloak_mantle__UhGkILf5eHoQoqKp.yml
+++ b/src/packs/src/srd-magic-items/Xenoteros__cloak_mantle__UhGkILf5eHoQoqKp.yml
@@ -19,6 +19,7 @@ system:
 
       <p>Quirk: Insectile mouthparts grow at the back of the throat and squiggle
       out when wearer talks excitedly.</p>
+  publicationSource: B1
   powerUsage:
     type: String
     label: Power Usage

--- a/src/scss/v2/components/compendium-browser/_compendium-browser.scss
+++ b/src/scss/v2/components/compendium-browser/_compendium-browser.scss
@@ -176,7 +176,7 @@
     }
 
     .equipment-grid {
-      grid-template-columns: 75px auto 100px 60px 60px;
+      grid-template-columns: 75px auto 100px 60px 60px 50px;
     }
 
     .equipment-title {

--- a/src/template.yaml
+++ b/src/template.yaml
@@ -820,3 +820,4 @@ Item:
     icons: ''
     tier: 'adventurer'
     isActive: true
+    publicationSource: ''

--- a/src/templates/items/item-equipment-sheet.html
+++ b/src/templates/items/item-equipment-sheet.html
@@ -43,6 +43,12 @@
                             data-dtype="String" placeholder="{{localize 'ARCHMAGE.ITEM.iconPlaceholder'}}" />
                     </div>
 
+                    <div class="settings-group">
+                        <strong class="attribute-name">{{localize 'ARCHMAGE.CHARACTERSETTINGS.publicationSource'}}</strong>
+                        <input class="attribute-name" name="system.publicationSource" type="text" value="{{system.publicationSource}}"
+                            data-dtype="String" placeholder="13tw" />
+                    </div>
+
                     <div class="settings-group form-group">
                         <label>{{localize 'ARCHMAGE.ITEM.attackBonuses'}}</label>
                     </div>


### PR DESCRIPTION
This adds a `publicationSource` field to magic items, and a filter field to the compendium browser, much like #515.

- [x] Update the template with the new field
- [x] Update the pack sources with correct data
- [x] Update the equipment sheet with the new field
- [x] Add display and filtering to the compendium browser