### PR TITLE
Release 1.35.0

### DIFF
--- a/release-notes/1.35.0.md
+++ b/release-notes/1.35.0.md
@@ -4,7 +4,7 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.35.0/syste
 
 ## Compatible Foundry versions
 
-![Foundry v12.331](https://img.shields.io/badge/Foundry-v12.331-green)
+![Foundry v12.331](https://img.shields.io/badge/Foundry-v12.343-green)
 
 ## Compendium Browser Improvements
 - Load content for the compendium browser from all compendia (system, modules, world).

--- a/release-notes/1.35.0.md
+++ b/release-notes/1.35.0.md
@@ -1,0 +1,31 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.35.0/system.json
+
+## Compatible Foundry versions
+
+![Foundry v12.331](https://img.shields.io/badge/Foundry-v12.331-green)
+
+## Compendium Browser Improvements
+- Load content for the compendium browser from all compendia (system, modules, world).
+- Add a `location` filter to limit browsing to elements from specific compendia.
+- Add `publicationSource` field to magic items, and a related filter field to the compendium browser.
+
+## Active Effects Improvements and Fixes
+- Add an `Always stacks` flag to the system AE sheet to make make the related AE ignore the usual stacking rules (to support monsters with special rules).
+- Rework AE ADD rules for bonuses to actually allow stacking of bonuses from different sources as per the rules.
+- Make system AE sheet melee dice bonus apply to monk weapons too.
+- Add monk bonuses to `Strength of the Gods`' embedded AE.
+- Fix PC-specific AE effect preventing the NPC sheet from opening if used on NPC actors.
+
+## Bug Fixes
+- Remove recoveries data from srd-monsters that have it (thanks @nebbers for this contribution).
+- Fix localization of helpless status applied on failing first last gp save.
+
+## Changelog
+
+Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.34.0...1.35.0
+
+## Contributors
+
+@ben, @LegoFed3

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -16,7 +16,7 @@ description: The official 13th Age system for Foundry Virtual Tabletop.
 
 compatibility:
   minimum: "12"
-  verified: "12.331"
+  verified: "12.343"
   maximum: "12"
 
 esmodules:


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.35.0/system.json

## Compatible Foundry versions

![Foundry v12.331](https://img.shields.io/badge/Foundry-v12.331-green)

## Compendium Browser Improvements
- Load content for the compendium browser from all compendia (system, modules, world).
- Add a `location` filter to limit browsing to elements from specific compendia.
- Add `publicationSource` field to magic items, and a related filter field to the compendium browser.

## Active Effects Improvements and Fixes
- Add an `Always stacks` flag to the system AE sheet to make make the related AE ignore the usual stacking rules (to support monsters with special rules).
- Rework AE ADD rules for bonuses to actually allow stacking of bonuses from different sources as per the rules.
- Make system AE sheet melee dice bonus apply to monk weapons too.
- Add monk bonuses to `Strength of the Gods`' embedded AE.
- Fix PC-specific AE effect preventing the NPC sheet from opening if used on NPC actors.

## Bug Fixes
- Remove recoveries data from srd-monsters that have it (thanks @nebbers for this contribution).
- Fix localization of helpless status applied on failing first last gp save.

## Changelog

Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.34.0...1.35.0

## Contributors

@ben, @LegoFed3