### PR TITLE
Fix/double attacks AEs

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -756,7 +756,8 @@ export class ActorArchmage extends Actor {
               data.wpn[wpn].dieNum = Number(data.wpn[wpn].dice.match(/d(\d+).*/)[1]);
             }
             data.wpn[wpn].dice = data.wpn[wpn].value;
-            data.wpn[wpn].diceMin2 = data.wpn[wpn].dice.replace(/d\d+/, `d${Math.max(data.wpn[wpn].dieNum - 2, 4)}`);
+            data.wpn[wpn].diceSml = data.wpn[wpn].dice.replace(/d\d+/, `d${Math.max(data.wpn[wpn].dieNum - 2, 4)}`);
+            data.wpn[wpn].diceLrg = data.wpn[wpn].dice.replace(/d\d+/, `d${data.wpn[wpn].dieNum + 2}`); // TODO: handle d12->2d6? (Nothing needs it in core)
             // data.wpn[wpn].atk = data.wpn[wpn].attack;
             // data.wpn[wpn].dmg = data.wpn[wpn].dmg;
             delete data.wpn[wpn].value;
@@ -772,7 +773,8 @@ export class ActorArchmage extends Actor {
             if (data.wpn.epicBonus) {
               wpnTypes.forEach(wpn => {
                 data.wpn[wpn].dice += `+${data.wpn.epicBonus}`
-                data.wpn[wpn].diceMin2 += `+${data.wpn.epicBonus}`
+                data.wpn[wpn].diceSml += `+${data.wpn.epicBonus}`
+                data.wpn[wpn].diceLrg += `+${data.wpn.epicBonus}`
               });
             }
           }

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -753,9 +753,10 @@ export class ActorArchmage extends Actor {
           wpnTypes.forEach(wpn => {
             if (data.wpn[wpn].dice) {
               data.wpn[wpn].die = data.wpn[wpn].dice;
-              data.wpn[wpn].dieNum = data.wpn[wpn].dice.replace('d', '');
+              data.wpn[wpn].dieNum = Number(data.wpn[wpn].dice.match(/d(\d+).*/)[1]);
             }
             data.wpn[wpn].dice = data.wpn[wpn].value;
+            data.wpn[wpn].diceMin2 = data.wpn[wpn].dice.replace(/d\d+/, `d${data.wpn[wpn].dieNum - 2}`);
             // data.wpn[wpn].atk = data.wpn[wpn].attack;
             // data.wpn[wpn].dmg = data.wpn[wpn].dmg;
             delete data.wpn[wpn].value;
@@ -770,7 +771,8 @@ export class ActorArchmage extends Actor {
             else if (actor.system.attributes.level.value >= 10) data.wpn.epicbonus = 30;
             if (data.wpn.epicbonus) {
               wpnTypes.forEach(wpn => {
-                data.wpn[wpn].dice += `+${data.wpn.epicbonus}`
+                data.wpn[wpn].dice += `+${data.wpn.epicBonus}`
+                data.wpn[wpn].diceMin2 += `+${data.wpn.epicBonus}`
               });
             }
           }

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -756,7 +756,7 @@ export class ActorArchmage extends Actor {
               data.wpn[wpn].dieNum = Number(data.wpn[wpn].dice.match(/d(\d+).*/)[1]);
             }
             data.wpn[wpn].dice = data.wpn[wpn].value;
-            data.wpn[wpn].diceMin2 = data.wpn[wpn].dice.replace(/d\d+/, `d${data.wpn[wpn].dieNum - 2}`);
+            data.wpn[wpn].diceMin2 = data.wpn[wpn].dice.replace(/d\d+/, `d${Math.max(data.wpn[wpn].dieNum - 2, 4)}`);
             // data.wpn[wpn].atk = data.wpn[wpn].attack;
             // data.wpn[wpn].dmg = data.wpn[wpn].dmg;
             delete data.wpn[wpn].value;
@@ -765,11 +765,11 @@ export class ActorArchmage extends Actor {
 
           // In 2e add extra at epic tier
           if (game.settings.get("archmage", "secondEdition")) {
-            data.wpn.epicbonus = 0;
-            if (actor.system.attributes.level.value == 8) data.wpn.epicbonus = 10;
-            else if (actor.system.attributes.level.value == 9) data.wpn.epicbonus = 20;
-            else if (actor.system.attributes.level.value >= 10) data.wpn.epicbonus = 30;
-            if (data.wpn.epicbonus) {
+            data.wpn.epicBonus = 0;
+            if (actor.system.attributes.level.value == 8) data.wpn.epicBonus = 10;
+            else if (actor.system.attributes.level.value == 9) data.wpn.epicBonus = 20;
+            else if (actor.system.attributes.level.value >= 10) data.wpn.epicBonus = 30;
+            if (data.wpn.epicBonus) {
               wpnTypes.forEach(wpn => {
                 data.wpn[wpn].dice += `+${data.wpn.epicBonus}`
                 data.wpn[wpn].diceMin2 += `+${data.wpn.epicBonus}`

--- a/src/packs/src/ranger/Double_Melee_Attack__Attack__vCOoGG96OC7tC0Rh.yml
+++ b/src/packs/src/ranger/Double_Melee_Attack__Attack__vCOoGG96OC7tC0Rh.yml
@@ -83,7 +83,7 @@ system:
   hit:
     type: String
     label: Hit
-    value: '[[@wpn.m.diceMin2 + @str.dmg + @atk.m.bonus]] damage'
+    value: '[[@wpn.m.diceSml + @str.dmg + @atk.m.bonus]] damage'
   hitEven:
     type: String
     label: Natural Even Hit

--- a/src/packs/src/ranger/Double_Melee_Attack__Attack__vCOoGG96OC7tC0Rh.yml
+++ b/src/packs/src/ranger/Double_Melee_Attack__Attack__vCOoGG96OC7tC0Rh.yml
@@ -83,7 +83,7 @@ system:
   hit:
     type: String
     label: Hit
-    value: '[[(@lvldice)d(@wpn.m.dieNum - 2) + @str.dmg + @atk.m.bonus]] damage'
+    value: '[[@wpn.m.diceMin2 + @str.dmg + @atk.m.bonus]] damage'
   hitEven:
     type: String
     label: Natural Even Hit

--- a/src/packs/src/ranger/Double_Ranged_Attack__Attack__6aE917O8Ah78HX2B.yml
+++ b/src/packs/src/ranger/Double_Ranged_Attack__Attack__6aE917O8Ah78HX2B.yml
@@ -83,7 +83,7 @@ system:
   hit:
     type: String
     label: Hit
-    value: '[[@wpn.r.diceMin2 + @dex.dmg + @atk.r.bonus]] damage'
+    value: '[[@wpn.r.diceSml + @dex.dmg + @atk.r.bonus]] damage'
   hitEven:
     type: String
     label: Natural Even Hit

--- a/src/packs/src/ranger/Double_Ranged_Attack__Attack__6aE917O8Ah78HX2B.yml
+++ b/src/packs/src/ranger/Double_Ranged_Attack__Attack__6aE917O8Ah78HX2B.yml
@@ -83,7 +83,7 @@ system:
   hit:
     type: String
     label: Hit
-    value: '[[(@lvldice)d(@wpn.r.dieNum - 2) + @dex.dmg + @atk.r.bonus]] damage'
+    value: '[[@wpn.r.diceMin2 + @dex.dmg + @atk.r.bonus]] damage'
   hitEven:
     type: String
     label: Natural Even Hit


### PR DESCRIPTION
- Fix `wpn.*.dieNum` including unwanted additions to damage rolls; it's now a JS number as expected.
- Add new `wpn.*.diceSml` shorthand to complement `wpn.*.dice` that includes dice size reduction (e.g. d8->d6, and implements a minimum size of d4) and handles AEs and 2e epic tier bonuses automatically.
- Apply the new shorthand to the ranger's Double Attacks.
- Also add new `wpn.*.diceLrg` shorthand that implements dice size *increase* (useful for some 13G and 2e classes).