### PR TITLE
Promote 2e to full release status (in the settings)

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -210,7 +210,7 @@ ARCHMAGE:
   SETTINGS:
     newSetting: New!
     groups:
-      secondEdition: 2e Playtest
+      secondEdition: Edition
       automation: Automation
       appearance: Appearance
       accessibility: Accessibility
@@ -251,8 +251,8 @@ ARCHMAGE:
     allowTargetDamageApplicationName: Allow target damage application
     allowRerollsHint: Whether or not to allow non-GM players to reroll their own dice rolls.
     allowRerollsName: Allow dice rerolls
-    secondEditionHint: Turn this on to use the 13th Age second edition playtest rules, off if you'd prefer the regular rules.
-    secondEditionName: Use 2e Gamma Playtest Rules
+    secondEditionHint: Turn this on to use the 13th Age second edition rules, off if you'd prefer the first edition.
+    secondEditionName: Second Edition
     ShowDebugLogsHint: Turn this on for bug reports
     ShowDebugLogsName: Show debug logs?
     showDefensesInChatHint: Enable this to display a list of targeted defenses in the attack line of chat power cards.


### PR DESCRIPTION
Probably the next release will be after the full PDF release and will include all the changes in #556, so probably we should be just calling it "second edition."

![CleanShot 2025-05-29 at 07 05 30@2x](https://github.com/user-attachments/assets/be4f1d80-dfae-41dc-8a8d-9e6b7cd4b4f4)
