### PR TITLE
Optional bonuses to initiative

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -92,6 +92,7 @@ ARCHMAGE:
   importSubmit: Import
   incrementalAdvances: Incremental Advances
   initAdjustment: Initiative Adjustment
+  initBonus: Optional Initiative Bonus
   initiative: Initiative
   INT: INT
   interrupt: Interrupt Action

--- a/src/module/actor/actor-sheet-v2.js
+++ b/src/module/actor/actor-sheet-v2.js
@@ -600,6 +600,10 @@ export class ActorArchmageSheetV2 extends ActorSheet {
    * Roll initiative for the actor.
    */
   async _onInitRoll() {
+    let formula = this.actor.getInitiativeFormula();
+    // TODO: show dialog, add bonus to formula
+    formula += " + 12"
+
     let combat = game.combat;
     // Check to see if this actor is already in the combat.
     if (!combat) {
@@ -609,11 +613,11 @@ export class ActorArchmageSheetV2 extends ActorSheet {
     let combatant = combat.combatants.find(c => c?.actor?._id == this.actor.id);
     // Create the combatant if needed.
     if (!combatant) {
-      await this.actor.rollInitiative({createCombatants: true});
+      await this.actor.rollInitiative({createCombatants: true, initiativeOptions: {formula}});
     }
     // Otherwise, determine if the existing combatant should roll init.
     else if (!combatant.initiative && combatant.initiative !== 0) {
-      await combat.rollInitiative([combatant.id]);
+      await combat.rollInitiative([combatant.id], {formula});
     }
   }
 

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -221,7 +221,7 @@ export class ActorArchmage extends Actor {
         }
       }
       // Bonuses stack if the name is different or if flagged to
-      else { 
+      else {
         // If it's meant to stack save it and handle it later
         if (change.effect.flags.archmage?.stacksAlways) {
           if (!stackingBonuses[change.key]) stackingBonuses[change.key] = [];
@@ -862,6 +862,17 @@ export class ActorArchmage extends Actor {
     }
 
     return data;
+  }
+
+  getInitiativeFormula() {
+    const init = this.system.attributes.init.mod;
+    // Init mod includes dex + level + misc bonuses.
+    const parts = ["1d20", init];
+    if (this.getFlag("archmage", "initiativeAdv")) parts[0] = "2d20kh";
+    if (game.settings.get("archmage", "initiativeStaticNpc") &&  this.type == 'npc') parts[0] = "10";
+    if (CONFIG.Combat.initiative.tiebreaker) parts.push(init / 100);
+    else parts.push((this.type === 'npc' ? 0.01 : 0));
+    return parts.filter(p => p !== null).join(" + ");
   }
 
   async rollSave(difficulty, target=11) {

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -614,17 +614,8 @@ Hooks.once('init', async function() {
    * @private
    */
   Combatant.prototype._getInitiativeFormula = function() {
-    const actor = this.actor;
-    if (!actor) return "1d20";
-    const init = actor.system.attributes.init.mod;
-    // Init mod includes dex + level + misc bonuses.
-    const parts = ["1d20", init];
-    if (actor.getFlag("archmage", "initiativeAdv")) parts[0] = "2d20kh";
-    if (game.settings.get("archmage", "initiativeStaticNpc") &&  actor.type == 'npc') parts[0] = "10";
-    if (CONFIG.Combat.initiative.tiebreaker) parts.push(init / 100);
-    else parts.push((actor.type === 'npc' ? 0.01 : 0));
-    return parts.filter(p => p !== null).join(" + ");
-  }
+    return this.actor?.getInitiativeFormula() ?? "1d20";
+  };
 
   ArchmageUtility.fixVuePopoutBug();
 });


### PR DESCRIPTION
This adds an interstitial dialog to the initiative rolling flow for PCs, to support circumstances like ambushes and the commander's _Into the Fray_ talent. It only pops up when rolling initiative from the actor sheet, not from the combat bar or combat carousel or any other source.