### PR TITLE
Extra skulls

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -331,6 +331,8 @@ ARCHMAGE:
     diceFormulaModeOptnumeric: Calculated modifiers (experimental)
     diceFormulaModeOptlong: Formula (long)
     diceFormulaModeOptshort: Formula (short)
+    extraSkullsName: Extra Skulls
+    extraSkullsHint: Forgeborn or Undead Remnant sorcerers might have access to more than the usual number of skulls.
     hideCurrencyHint: Hide the currency section in the inventory.
     hideCurrencyName: Hide Currency
     hideEmptyPowerGroupsHint: Hide empty Power groups on the sheet (besides the default one).

--- a/src/module/setup/config.js
+++ b/src/module/setup/config.js
@@ -1198,6 +1198,12 @@ FLAGS.characterFlags = {
     section: "Feats",
     type: Boolean
   },
+  "extraSkulls": {
+    name: "ARCHMAGE.CHARACTERFLAGS.extraSkullsName",
+    hint: "ARCHMAGE.CHARACTERFLAGS.extraSkullsHint",
+    section: "Feats",
+    type: Boolean
+  },
   "dexToCha": {
     name: "ARCHMAGE.CHARACTERFLAGS.dexToChaName",
     hint: "ARCHMAGE.CHARACTERFLAGS.dexToChaHint",

--- a/src/vue/components/actor/character/top/CharAttributes.vue
+++ b/src/vue/components/actor/character/top/CharAttributes.vue
@@ -76,6 +76,8 @@
               <input type="checkbox" v-model="actor.system.attributes.saves.deathFails.steps[2]" data-opt="3"/>
               <input type="checkbox" v-model="actor.system.attributes.saves.deathFails.steps[3]" data-opt="4"/>
               <input v-if="secondEdition" type="checkbox" v-model="actor.system.attributes.saves.deathFails.steps[4]" data-opt="5"/>
+              <input v-if="actor.flags.archmage.extraSkulls" class="extra-skull" type="checkbox" v-model="actor.system.attributes.saves.deathFails.steps[5]" data-opt="6"/>
+              <input v-if="actor.flags.archmage.extraSkulls" class="extra-skull" type="checkbox" v-model="actor.system.attributes.saves.deathFails.steps[6]" data-opt="7"/>
             </div>
           </div>
           <div class="last-gasp-saves" :data-tooltip="tooltip('pcLastGaspSaves')">


### PR DESCRIPTION
Adds a flag/setting to enable two extra skull checkboxes. An alternative to #564.

![Arc 2025-06-04 08 03 21](https://github.com/user-attachments/assets/2dfc3aaf-0734-46f2-92f0-63209d081b56)
