### PR TITLE
Max skulls as a character setting

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -111,6 +111,7 @@ ARCHMAGE:
   magicItems: Magic Items
   maneuver: Maneuver
   maneuvers: Maneuvers
+  maxSkulls: Max Death Saves/Skulls
   melee: Melee
   meleeWeaponDice: Melee Weapon Dice
   misc: Misc.

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -221,7 +221,7 @@ export class ActorArchmage extends Actor {
         }
       }
       // Bonuses stack if the name is different or if flagged to
-      else { 
+      else {
         // If it's meant to stack save it and handle it later
         if (change.effect.flags.archmage?.stacksAlways) {
           if (!stackingBonuses[change.key]) stackingBonuses[change.key] = [];
@@ -447,7 +447,6 @@ export class ActorArchmage extends Actor {
     }
 
     // Fix max death saves based on 2e.
-    data.attributes.saves.deathFails.max = game.settings.get('archmage', 'secondEdition') ? 5 : 4;
     // Update death save count.
     let deathCount = data.attributes.saves.deathFails.value;
     data.attributes.saves.deathFails.steps = game.settings.get('archmage', 'secondEdition') ? [false, false, false, false, false] : [false, false, false, false];
@@ -1867,11 +1866,14 @@ export class ActorArchmage extends Actor {
 
     // For characters only, set some defaults
     if (this.type == "character") {
-      await this.update({prototypeToken: {
-        actorLink: true,
-        disposition: 1, // friendly
-        sight: {enabled: true}
-      }});
+      await this.update({
+        prototypeToken: {
+          actorLink: true,
+          disposition: 1, // friendly
+          sight: { enabled: true },
+        },
+        "system.attributes.saves.deathFails.max": CONFIG.ARCHMAGE.is2e ? 5 : 4,
+      });
     }
   }
 

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -446,7 +446,10 @@ export class ActorArchmage extends Actor {
       delete data.incrementals.feature;
     }
 
-    // Fix max death saves based on 2e.
+    // If max death saves are not already set, make sure they get the default value.
+    // This is done on character creation, but if a character was created before the new adjustable-death-saves feature,
+    // it will not have the max set.
+    data.attributes.saves.deathFails.max ||= game.settings.get('archmage', 'secondEdition') ? 5 : 4;
     // Update death save count.
     let deathCount = data.attributes.saves.deathFails.value;
     data.attributes.saves.deathFails.steps = game.settings.get('archmage', 'secondEdition') ? [false, false, false, false, false] : [false, false, false, false];

--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -446,10 +446,9 @@ export class ActorArchmage extends Actor {
       delete data.incrementals.feature;
     }
 
-    // If max death saves are not already set, make sure they get the default value.
-    // This is done on character creation, but if a character was created before the new adjustable-death-saves feature,
-    // it will not have the max set.
-    data.attributes.saves.deathFails.max ||= game.settings.get('archmage', 'secondEdition') ? 5 : 4;
+    // Fix max death saves based on 2e.
+    data.attributes.saves.deathFails.max = parseInt(data.attributes.saves.deathFails.maxOverride)
+      || (game.settings.get('archmage', 'secondEdition') ? 5 : 4);
     // Update death save count.
     let deathCount = data.attributes.saves.deathFails.value;
     data.attributes.saves.deathFails.steps = game.settings.get('archmage', 'secondEdition') ? [false, false, false, false, false] : [false, false, false, false];
@@ -1869,14 +1868,11 @@ export class ActorArchmage extends Actor {
 
     // For characters only, set some defaults
     if (this.type == "character") {
-      await this.update({
-        prototypeToken: {
-          actorLink: true,
-          disposition: 1, // friendly
-          sight: { enabled: true },
-        },
-        "system.attributes.saves.deathFails.max": CONFIG.ARCHMAGE.is2e ? 5 : 4,
-      });
+      await this.update({prototypeToken: {
+        actorLink: true,
+        disposition: 1, // friendly
+        sight: {enabled: true}
+      }});
     }
   }
 

--- a/src/template.yaml
+++ b/src/template.yaml
@@ -62,6 +62,7 @@ Actor:
             value: 0
             # Max and steps are adjusted in actor.js depending on 2e setting.
             max: 4
+            maxOverride: 0
             steps:
               - false
               - false

--- a/src/vue/components/actor/character/main/CharSettings.vue
+++ b/src/vue/components/actor/character/main/CharSettings.vue
@@ -67,11 +67,12 @@
         </div>
         <div class="sub-unit sub-unit--skulls flexrow">
           <strong class="unit-subtitle">{{localize('ARCHMAGE.maxSkulls')}}</strong>
-          <select name="system.attributes.saves.deathFails.max" v-model="actor.system.attributes.saves.deathFails.max">
-            <option value="4">4</option>
-            <option value="5">5</option>
-            <option value="6">6</option>
-            <option value="7">7</option>
+          <select name="system.attributes.saves.deathFails.maxOverride" v-model="actor.system.attributes.saves.deathFails.maxOverride">
+            <option :value="0">{{localize('Default')}}</option>
+            <option :value="4">4</option>
+            <option :value="5">5</option>
+            <option :value="6">6</option>
+            <option :value="7">7</option>
           </select>
         </div>
         <div class="sub-unit sub-unit--melee">

--- a/src/vue/components/actor/character/main/CharSettings.vue
+++ b/src/vue/components/actor/character/main/CharSettings.vue
@@ -65,6 +65,15 @@
             <option v-for="(option, index) in abilities" :key="index" :value="option.value">{{option.label}}</option>
           </select>
         </div>
+        <div class="sub-unit sub-unit--skulls flexrow">
+          <strong class="unit-subtitle">{{localize('ARCHMAGE.maxSkulls')}}</strong>
+          <select name="system.attributes.saves.deathFails.max" v-model="actor.system.attributes.saves.deathFails.max">
+            <option value="4">4</option>
+            <option value="5">5</option>
+            <option value="6">6</option>
+            <option value="7">7</option>
+          </select>
+        </div>
         <div class="sub-unit sub-unit--melee">
           <div class="sub-unit sub-unit--melee-dice flexrow">
             <strong class="unit-subtitle">{{localize('ARCHMAGE.meleeWeaponDice')}}</strong>

--- a/src/vue/components/actor/character/top/CharAttributes.vue
+++ b/src/vue/components/actor/character/top/CharAttributes.vue
@@ -71,11 +71,7 @@
           <div class="death-saves" :data-tooltip="tooltip('pcDeathSaves')">
             <a class="rollable rollable--save" data-roll-type="save" data-roll-opt="death">{{localize('ARCHMAGE.SAVE.death')}}</a>
             <div class="death-save-attempts attempts flexrow">
-              <input type="checkbox" v-model="actor.system.attributes.saves.deathFails.steps[0]" data-opt="1"/>
-              <input type="checkbox" v-model="actor.system.attributes.saves.deathFails.steps[1]" data-opt="2"/>
-              <input type="checkbox" v-model="actor.system.attributes.saves.deathFails.steps[2]" data-opt="3"/>
-              <input type="checkbox" v-model="actor.system.attributes.saves.deathFails.steps[3]" data-opt="4"/>
-              <input v-if="secondEdition" type="checkbox" v-model="actor.system.attributes.saves.deathFails.steps[4]" data-opt="5"/>
+              <input type="checkbox" v-for="(step, i) in deathSaves" :key="i" v-model="actor.system.attributes.saves.deathFails.steps[i]" :data-opt="i+1"/>
             </div>
           </div>
           <div class="last-gasp-saves" :data-tooltip="tooltip('pcLastGaspSaves')">
@@ -123,7 +119,18 @@ export default {
   computed: {
     secondEdition() {
       return game.settings.get('archmage', 'secondEdition') === true;
-    }
+    },
+    deathSaves() {
+      const deathFails = this.actor.system.attributes.saves.deathFails;
+      const max = parseInt(deathFails.max) || 4;
+      const ret = Array.from(Array(max)).fill(false);
+      for (let i = 0; i < Math.min(deathFails.steps.length, max); i++) {
+        if (deathFails.steps[i]) {
+          ret[i] = true;
+        }
+      }
+      return ret;
+    },
   },
   methods: {
     getAvatarDimensions() {


### PR DESCRIPTION
This exposes `system.attributes.saves.deathFails.max` as a configurable setting, and uses it for the display of death-save checkboxes. This is an alternate to #563. 

![CleanShot 2025-06-04 at 08 59 57@2x](https://github.com/user-attachments/assets/8da25b8f-d684-41c9-a823-a384a2047974)
![CleanShot 2025-06-04 at 09 00 18@2x](https://github.com/user-attachments/assets/743aa180-a2f2-4f66-915f-7a215822fd3b)
