### PR TITLE
Dual roles and types

### DIFF
--- a/src/template.yaml
+++ b/src/template.yaml
@@ -459,7 +459,11 @@ Actor:
         value: ''
       role:
         value: ''
+      roleB:
+        value: ''
       size:
+        value: ''
+      sizeB:
         value: ''
       strength:
         value: ''

--- a/src/vue/components/actor/npc/NpcHeader.vue
+++ b/src/vue/components/actor/npc/NpcHeader.vue
@@ -51,9 +51,13 @@
               <br/>
               {{localize("ARCHMAGE.role")}}
               <Select name="system.details.role.value" :actor="actor" :options="getOptions('creatureRoles')"/>
+              /
+              <Select name="system.details.roleB.value" :actor="actor" :options="getOptions('creatureRoles', true)"/>
               <br/>
               {{localize("ARCHMAGE.type")}}
               <Select name="system.details.type.value" :actor="actor" :options="getOptions('creatureTypes')"/>
+              /
+              <Select name="system.details.typeB.value" :actor="actor" :options="getOptions('creatureTypes', true)"/>
               <br/>
             </template>
           </ToggleInput>
@@ -174,8 +178,12 @@
           });
         }
       },
-      getOptions(key) {
-        return CONFIG.ARCHMAGE[key] ?? [];
+      getOptions(key, includeNone = false) {
+        let options = CONFIG.ARCHMAGE[key] ?? [];
+        if (includeNone) {
+          options = {"":"", ...options};
+        }
+        return options;
       }
     },
     watch: {

--- a/src/vue/components/actor/npc/NpcHeader.vue
+++ b/src/vue/components/actor/npc/NpcHeader.vue
@@ -122,11 +122,16 @@
         return CONFIG.ARCHMAGE.creatureStrengths[this.actor.system.details?.strength?.value] ?? this.actor.system.details?.strength?.value;
       },
       roleFormatted() {
-        return CONFIG.ARCHMAGE.creatureRoles[this.actor.system.details?.role?.value] ?? this.actor.system.details?.role?.value;
+        const roleA = CONFIG.ARCHMAGE.creatureRoles[this.actor.system.details?.role?.value] ?? this.actor.system.details?.role?.value;
+        const roleB = CONFIG.ARCHMAGE.creatureRoles[this.actor.system.details?.roleB?.value] ?? this.actor.system.details?.roleB?.value;
+        return roleB ? `${roleA}/${roleB}` : roleA;
       },
       typeFormatted() {
-        let type = CONFIG.ARCHMAGE.creatureTypes[this.actor.system.details?.type?.value] ?? this.actor.system.details?.type?.value;
-        return typeof type == 'string' ? type.toUpperCase() : '';
+        let typeA = CONFIG.ARCHMAGE.creatureTypes[this.actor.system.details?.type?.value] ?? this.actor.system.details?.type?.value;
+        let typeB = CONFIG.ARCHMAGE.creatureTypes[this.actor.system.details?.typeB?.value] ?? this.actor.system.details?.typeB?.value;
+        if (typeB) return `${typeA.toUpperCase()}/${typeB.toUpperCase()}`;
+        if (typeof typeA == 'string') return typeA.toUpperCase();
+        return "";
       },
     },
     methods: {

--- a/src/vue/components/dialogs/compendium-browser/CompendiumBrowserCreatures.vue
+++ b/src/vue/components/dialogs/compendium-browser/CompendiumBrowserCreatures.vue
@@ -114,8 +114,8 @@
                 <span><strong>{{ localize('ARCHMAGE.pd.key') }}:</strong> {{ entry.system.attributes.pd.value }}</span>
                 <span><strong>{{ localize('ARCHMAGE.md.key') }}:</strong> {{ entry.system.attributes.md.value }}</span>
               </div>
-              <div class="creature-type" :data-tooltip="localize('ARCHMAGE.type')">{{ CONFIG.ARCHMAGE.creatureTypes[entry?.system?.details?.type?.value] }}</div>
-              <div class="creature-role" :data-tooltip="localize('ARCHMAGE.role')">{{ CONFIG.ARCHMAGE.creatureRoles[entry?.system?.details?.role?.value] }}</div>
+              <div class="creature-type" :data-tooltip="localize('ARCHMAGE.type')">{{ creatureType(entry) }}</div>
+              <div class="creature-role" :data-tooltip="localize('ARCHMAGE.role')">{{ creatureRole(entry) }}</div>
               <div class="creature-size" :data-tooltip="localize('ARCHMAGE.size')">{{ CONFIG.ARCHMAGE.creatureSizes[entry?.system?.details?.size?.value] }}</div>
               <div v-if="entry?.system?.publicationSource" class="creature-source" :data-tooltip="sourceTooltip(entry?.system?.publicationSource)">{{ entry?.system?.publicationSource }}</div>
             </div>
@@ -236,7 +236,21 @@ export default {
       let localized = game.i18n.localize(`ARCHMAGE.COMPENDIUMBROWSER.sources.${source}`);
       if (localized.startsWith('ARCHMAGE')) { localized = source }
       return game.i18n.format('ARCHMAGE.COMPENDIUMBROWSER.sources.tooltipTemplate', {source: localized});
-    }
+    },
+    creatureRole(entry) {
+      const {role, roleB} = entry?.system?.details || {};
+      if (roleB?.value) {
+        return `${CONFIG.ARCHMAGE.creatureRoles[role?.value]}/${CONFIG.ARCHMAGE.creatureRoles[roleB.value]}`;
+      }
+      return CONFIG.ARCHMAGE.creatureRoles[role?.value];
+    },
+    creatureType(entry) {
+      const {type, typeB} = entry?.system?.details || {};
+      if (typeB?.value) {
+        return `${CONFIG.ARCHMAGE.creatureTypes[type?.value]}/${CONFIG.ARCHMAGE.creatureTypes[typeB.value]}`;
+      }
+      return CONFIG.ARCHMAGE.creatureTypes[type?.value];
+    },
   },
   computed: {
     nightmode() {
@@ -354,8 +368,10 @@ export default {
       'system.attributes.pd.value',
       'system.attributes.md.value',
       'system.details.role.value',
+      'system.details.roleB.value',
       'system.details.size.value',
-      'system.details.type.value'
+      'system.details.type.value',
+      'system.details.typeB.value',
     ]).then(packIndex => {
       // Ensure all entries are "monster" type
       packIndex = packIndex.filter(entry => {

--- a/src/vue/components/dialogs/compendium-browser/CompendiumBrowserCreatures.vue
+++ b/src/vue/components/dialogs/compendium-browser/CompendiumBrowserCreatures.vue
@@ -280,10 +280,16 @@ export default {
 
       // Handle multiselect filters, which use arrays as their values.
       if (Array.isArray(this.type) && this.type.length > 0) {
-        result = result.filter(entry => this.type.includes(entry.system.details.type.value));
+        result = result.filter(entry =>
+          this.type.includes(entry.system.details?.type?.value) ||
+          this.type.includes(entry.system.details?.typeB?.value)
+        );
       }
       if (Array.isArray(this.role) && this.role.length > 0) {
-        result = result.filter(entry => this.role.includes(entry.system.details.role.value));
+        result = result.filter(entry =>
+          this.role.includes(entry.system.details?.role?.value) ||
+          this.role.includes(entry.system.details?.roleB?.value)
+        );
       }
       if (Array.isArray(this.size) && this.size.length > 0) {
         result = result.filter(entry => this.size.includes(entry.system.details.size.value));


### PR DESCRIPTION
Allowing monsters to have two roles and/or types.

- [x] Update template to add second field
- [x] NPC sheet
  - [x] Display view
  - [x] Edit view
- [x] Compendium browser
  - [x] Display in column
  - [x] Include in filtering logic