### PR TITLE
Fix stoke flags

### DIFF
--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -110,7 +110,7 @@ export class ItemArchmage extends Item {
           const breathString = game.i18n.localize('ARCHMAGE.CHAT.breath').toLocaleLowerCase().trim();
           if (combatantUuid && combatantUuid == this.itemActor.uuid && this.name.toLocaleLowerCase().includes(breathString)) {
             // This will be set to false at the start of the actor's turn.
-            game.combat.combatant.setFlag('archmage', 'breathUsed', true);
+            await this.itemActor.update({ "system.resources.spendable.stoke.breathUsed": true });
           }
         }
       }


### PR DESCRIPTION
Managing the stoke flag was doing weird things with turns not ending properly, specifically there seems to be an issue with setting a flag on a combatant during the end-turn hook. This moves that tracking data into the actor's system data, and adds a cleanup step at the end of combat to make sure no junk is left behind.