### PR TITLE
Magic item sheet v2

### DIFF
--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -6,6 +6,7 @@ import { ActorArchmageSheetV2 } from './actor/actor-sheet-v2.js';
 import { ItemArchmage } from './item/item.js';
 import { ItemArchmageSheet } from './item/item-sheet.js';
 import { ArchmagePowerSheetV2 } from './item/power-sheet-v2.js';
+import { ArchmageEquipmentSheetV2 } from './item/equipment-sheet-v2.js';
 import { ArchmageActionSheetV2 } from './item/action-sheet-v2.js';
 import { ArchmageMacros } from './setup/macros.js';
 import { ArchmageUtility } from './setup/utility-classes.js';
@@ -206,6 +207,11 @@ Hooks.once('init', async function() {
   Items.registerSheet("archmage", ArchmagePowerSheetV2, {
     label: 'ARCHMAGE.sheetItemV2',
     types: ["power"],
+    makeDefault: true,
+  });
+  Items.registerSheet("archmage", ArchmageEquipmentSheetV2, {
+    label: 'ARCHMAGE.sheetItemV2',
+    types: ["equipment"],
     makeDefault: true,
   });
   Items.registerSheet("archmage", ArchmageActionSheetV2, {

--- a/src/module/item/equipment-sheet-v2.js
+++ b/src/module/item/equipment-sheet-v2.js
@@ -21,13 +21,6 @@ export class ArchmageEquipmentSheetV2 extends VueRenderingMixin(ArchmageBaseItem
   /** @override */
   static DEFAULT_OPTIONS = {
     classes: ["archmage-appv2", "item", "dialog-form", "standard-form"],
-    actions: {
-      onEditImage: this._onEditImage,
-      edit: this._viewEffect,
-      create: this._createEffect,
-      delete: this._deleteEffect,
-      toggle: this._toggleEffect
-    },
     position: {
       width: 950,
       height: 650,

--- a/src/module/item/equipment-sheet-v2.js
+++ b/src/module/item/equipment-sheet-v2.js
@@ -29,8 +29,8 @@ export class ArchmageEquipmentSheetV2 extends VueRenderingMixin(ArchmageBaseItem
       toggle: this._toggleEffect
     },
     position: {
-      width: 860,
-      height: 630,
+      width: 950,
+      height: 550,
     },
     window: {
       resizable: true,
@@ -88,19 +88,9 @@ export class ArchmageEquipmentSheetV2 extends VueRenderingMixin(ArchmageBaseItem
             label: game.i18n.localize('ARCHMAGE.details'),
             active: true,
           },
-          attack: {
-            key: 'attack',
-            label: game.i18n.localize('ARCHMAGE.attack'),
-            active: false,
-          },
-          special: {
-            key: 'special',
-            label: game.i18n.localize('ARCHMAGE.special'),
-            active: false,
-          },
-          feats: {
-            key: 'feats',
-            label: game.i18n.localize('ARCHMAGE.feats'),
+          bonuses: {
+            key: 'bonuses',
+            label: game.i18n.localize('ARCHMAGE.bonuses'),
             active: false,
           },
           effects: {
@@ -136,19 +126,16 @@ export class ArchmageEquipmentSheetV2 extends VueRenderingMixin(ArchmageBaseItem
 
     // Enrich the description.
     context.editors = {
-      // 'system.description.value': {
-      //   enriched: await wrapRolls(this.item.system.description.value ?? '', [], 'short', {}, 'description', enrichmentOptions),
-      //   element: foundry.applications.elements.HTMLProseMirrorElement.create({
-      //     ...editorOptions,
-      //     name: 'system.description.value',
-      //     value: context.system.description?.value ?? '',
-      //   }),
-      // },
+      'system.description.value': {
+        enriched: await wrapRolls(this.item.system.description.value ?? '', [], 'short', {}, 'description', enrichmentOptions),
+        element: foundry.applications.elements.HTMLProseMirrorElement.create({
+          ...editorOptions,
+          name: 'system.description.value',
+          value: context.system.description?.value ?? '',
+        }),
+      },
     };
 
-    // Enrich powers and feats.
-    // await this._enrichPowers(context, enrichmentOptions, editorOptions);
-    await this._enrichFeats(context, enrichmentOptions, editorOptions);
 
     // Make another pass through the editors to fix the element contents.
     for (let [field, editor] of Object.entries(context.editors)) {
@@ -158,188 +145,5 @@ export class ArchmageEquipmentSheetV2 extends VueRenderingMixin(ArchmageBaseItem
     }
 
     return context;
-  }
-
-  /**
-   * Enrich values for power fields.
-   *
-   * @param {object} context
-   * @param {object} enrichmentOptions
-   * @param {object} editorOptions
-   */
-  async _enrichPowers(context, enrichmentOptions, editorOptions) {
-    // Enrich other fields.
-    const spellFields = CONFIG.ARCHMAGE.is2e ? [
-      'spellLevel2',
-      'spellLevel3',
-      'spellLevel4',
-      'spellLevel5',
-      'spellLevel6',
-      'spellLevel7',
-      'spellLevel8',
-      'spellLevel9',
-      'spellLevel10',
-      'spellLevel11',
-    ] : [
-      'spellLevel3',
-      'spellLevel5',
-      'spellLevel7',
-      'spellLevel9',
-    ];
-    const powerFields = [
-      'trigger',
-      'sustainOn',
-      'target',
-      'always',
-      'attack',
-      'hit',
-      'hitEven',
-      'hitOdd',
-      'crit',
-      'miss',
-      'missEven',
-      'missOdd',
-      'resources',
-      'castBroadEffect',
-      'castPower',
-      'sustainedEffect',
-      'finalVerse',
-      'special',
-      'effect',
-      ...spellFields,
-      'spellChain',
-      'breathWeapon',
-      'recharge',
-    ];
-
-    for (let field of powerFields) {
-      context.editors[field] = {
-        // @todo write a power enricher.
-        enriched: await wrapRolls(this.item.system[field].value ?? '', [], 'short', {}, field, enrichmentOptions),
-        element: foundry.applications.elements.HTMLProseMirrorElement.create({
-          ...editorOptions,
-          name: `system.${field}.value`,
-          value: context.system[field]?.value ?? '',
-        }),
-      };
-    }
-  }
-
-  /**
-   * Enrich values for feats.
-   *
-   * @param {object} context
-   * @param {object} enrichmentOptions
-   * @param {object} editorOptions
-   */
-  async _enrichFeats(context, enrichmentOptions, editorOptions) {
-    // Enrich feats.
-    if (this.item.system.feats) {
-      for (let [featKey, feat] of Object.entries(this.item.system.feats)) {
-        context.editors[`feat.${featKey}`] = {
-          enriched: await wrapRolls(feat.description.value ?? '', [], 'short', {}, featKey, enrichmentOptions),
-          element: foundry.applications.elements.HTMLProseMirrorElement.create({
-            ...editorOptions,
-            name: `system.feats.${featKey}.description.value`,
-            value: feat.description.value ?? '',
-          }),
-        }
-      }
-    }
-  }
-
-  /* ---------------------------------------------------- */
-
-  /**
-   * Add/delete/reorder feats on a power.
-   *
-   * @param {Event} event
-   *   Html event that triggered the method.
-   */
-  static async _updateFeat(event, target) {
-    if (!this.isEditable) return;
-
-    let dataset = target.dataset;
-
-    let item = this.item;
-    if (item.type != "power") return;
-
-    let featIndex = Number(dataset.featKey);
-    let feats = item.system.feats;
-
-    let deleteFeat = (async () => {return;});
-    switch(dataset.action) {
-      case 'createFeat':
-        if (feats) feats = Object.values(feats);
-        else feats = [];
-        feats.push({
-          "description": {
-            "type": "String",
-            "value": ""
-          },
-          "isActive": {
-            "type": "Boolean",
-            "value": false
-          },
-          "tier": {
-            "type": "String",
-            "value": "adventurer"
-          },
-          "powerUsage": {
-            "type": "String",
-            "value": ""
-          },
-          "quantity": {
-            "type": "Number",
-            "value": null
-          },
-          "maxQuantity": {
-            "type": "Number",
-            "value": null
-          }
-        });
-        await item.update({'system.feats': Object.assign({}, feats)});
-        return;
-      case 'deleteFeat':
-        deleteFeat = (async () => {
-          let newFeats = foundry.utils.deepClone(feats);
-          delete newFeats[featIndex];
-          newFeats = Object.assign({}, Object.values(newFeats));  // Re-index from 0
-          let updateData = {'system.feats': newFeats};
-          for (let key of Object.keys(item.system.feats)) {
-            if (!newFeats[key]) updateData[`system.feats.-=${key}`] = null;
-          }
-          await item.update(updateData);
-        });
-        break;
-      case 'moveFeatUp':
-        if (featIndex == 0) return;
-        feats = Object.values(feats);
-        [feats[featIndex], feats[featIndex - 1]] = [feats[featIndex - 1], feats[featIndex]]
-        await item.update({'system.feats': Object.assign({}, feats)});
-        return;
-      case 'moveFeatDown':
-        feats = Object.values(feats);
-        if (featIndex >= feats.length - 1) return;
-        [feats[featIndex + 1], feats[featIndex]] = [feats[featIndex], feats[featIndex + 1]]
-        await item.update({'system.feats': Object.assign({}, feats)});
-        return;
-    }
-
-    let bypass = event.shiftKey ? true : false;
-    if (bypass) {
-      await deleteFeat();
-      return;
-    }
-    foundry.applications.api.DialogV2.prompt({
-      window: {title: 'Delete feat?'},
-      content: `<p>${game.i18n.localize("ARCHMAGE.CHAT.DeleteConfirm")}</p>`,
-      rejectClose: false,
-      ok: {
-        callback: (event, button, dialog) => {
-          deleteFeat();
-        }
-      }
-    });
   }
 }

--- a/src/module/item/equipment-sheet-v2.js
+++ b/src/module/item/equipment-sheet-v2.js
@@ -30,7 +30,7 @@ export class ArchmageEquipmentSheetV2 extends VueRenderingMixin(ArchmageBaseItem
     },
     position: {
       width: 950,
-      height: 550,
+      height: 650,
     },
     window: {
       resizable: true,

--- a/src/module/item/equipment-sheet-v2.js
+++ b/src/module/item/equipment-sheet-v2.js
@@ -1,0 +1,345 @@
+import { ArchmageBaseItemSheetV2 } from "./base-item-sheet-v2.js";
+import { wrapRolls } from "./_item-sheet-helpers.mjs";
+
+import VueRenderingMixin from "./_vue-application-mixin.mjs";
+import { ArchmageEquipmentSheetVue } from "../../vue/components.vue.es.js";
+
+const { DOCUMENT_OWNERSHIP_LEVELS } = CONST;
+
+export class ArchmageEquipmentSheetV2 extends VueRenderingMixin(ArchmageBaseItemSheetV2) {
+  vueParts = {
+    'archmage-equipment-sheet-vue': {
+      component: ArchmageEquipmentSheetVue,
+      template: `<archmage-equipment-sheet-vue :context="context">Vue rendering for sheet failed.</archmage-equipment-sheet-vue>`
+    }
+  }
+
+  constructor(options = {}) {
+    super(options);
+  }
+
+  /** @override */
+  static DEFAULT_OPTIONS = {
+    classes: ["archmage-appv2", "item", "dialog-form", "standard-form"],
+    actions: {
+      onEditImage: this._onEditImage,
+      edit: this._viewEffect,
+      create: this._createEffect,
+      delete: this._deleteEffect,
+      toggle: this._toggleEffect
+    },
+    position: {
+      width: 860,
+      height: 630,
+    },
+    window: {
+      resizable: true,
+      controls: [
+        {
+          action: "showItemArtwork",
+          icon: "fa-solid fa-image",
+          label: "ITEM.ViewArt",
+          ownership: "OWNER"
+        },
+        {
+          action: "parseInlineRolls",
+          icon: "fa-solid fa-dice",
+          label: "ARCHMAGE.UI.parseInlineRolls",
+          ownership: "OWNER"
+        }
+      ]
+    },
+    tag: 'form',
+    form: {
+      submitOnChange: true,
+      submitOnClose: true,
+    },
+    // Custom property that's merged into `this.options`
+    dragDrop: [{ dragSelector: "[data-drag]", dropSelector: null }]
+  };
+
+  /* -------------------------------------------- */
+
+  /** @override */
+  async _prepareContext(options) {
+
+    const context = {
+      // Validates both permissions and compendium status
+      editable: this.isEditable,
+      owner: this.isOwner,
+      limited: this.document.limited,
+      // Add the item document.
+      item: this.item.toObject(),
+      actor: this.actor?.toObject() ?? false,
+      // Adding system and flags for easier access
+      system: this.item.system,
+      flags: this.item.flags,
+      // Rolldata.
+      rollData: this.actor?.getRollData() ?? {},
+      // Adding a pointer to CONFIG.ARCHMAGE
+      config: CONFIG.ARCHMAGE,
+      // Sequencer (module) support.
+      sequencerEnabled: game.modules.get("sequencer")?.active,
+      // Add tabs:
+      tabs: {
+        primary: {
+          details: {
+            key: 'details',
+            label: game.i18n.localize('ARCHMAGE.details'),
+            active: true,
+          },
+          attack: {
+            key: 'attack',
+            label: game.i18n.localize('ARCHMAGE.attack'),
+            active: false,
+          },
+          special: {
+            key: 'special',
+            label: game.i18n.localize('ARCHMAGE.special'),
+            active: false,
+          },
+          feats: {
+            key: 'feats',
+            label: game.i18n.localize('ARCHMAGE.feats'),
+            active: false,
+          },
+          effects: {
+            key: 'effects',
+            label: game.i18n.localize('ARCHMAGE.effects'),
+            active: false,
+          }
+        },
+      },
+      // Force re-renders. Defined in the vue mixin.
+      _renderKey: this._renderKey ?? 0,
+      // @todo add this after switching to DataModel
+      // fields: this.document.schema.fields,
+      // systemFields: this.document.system.schema.fields
+    };
+
+    // Handle enriched fields.
+    const enrichmentOptions = {
+      // Whether to show secret blocks in the finished html
+      secrets: this.document.isOwner,
+      // Data to fill in for inline rolls
+      rollData: this.item?.getRollData() ?? {},
+      // Relative UUID resolution
+      relativeTo: this.item
+    };
+
+    const editorOptions = {
+      toggled: true,
+      collaborate: true,
+      documentUUID: this.document.uuid,
+      height: 300,
+    };
+
+    // Enrich the description.
+    context.editors = {
+      // 'system.description.value': {
+      //   enriched: await wrapRolls(this.item.system.description.value ?? '', [], 'short', {}, 'description', enrichmentOptions),
+      //   element: foundry.applications.elements.HTMLProseMirrorElement.create({
+      //     ...editorOptions,
+      //     name: 'system.description.value',
+      //     value: context.system.description?.value ?? '',
+      //   }),
+      // },
+    };
+
+    // Enrich powers and feats.
+    // await this._enrichPowers(context, enrichmentOptions, editorOptions);
+    await this._enrichFeats(context, enrichmentOptions, editorOptions);
+
+    // Make another pass through the editors to fix the element contents.
+    for (let [field, editor] of Object.entries(context.editors)) {
+      if (context.editors[field].element) {
+        context.editors[field].element.innerHTML = context.editors[field].enriched;
+      }
+    }
+
+    return context;
+  }
+
+  /**
+   * Enrich values for power fields.
+   *
+   * @param {object} context
+   * @param {object} enrichmentOptions
+   * @param {object} editorOptions
+   */
+  async _enrichPowers(context, enrichmentOptions, editorOptions) {
+    // Enrich other fields.
+    const spellFields = CONFIG.ARCHMAGE.is2e ? [
+      'spellLevel2',
+      'spellLevel3',
+      'spellLevel4',
+      'spellLevel5',
+      'spellLevel6',
+      'spellLevel7',
+      'spellLevel8',
+      'spellLevel9',
+      'spellLevel10',
+      'spellLevel11',
+    ] : [
+      'spellLevel3',
+      'spellLevel5',
+      'spellLevel7',
+      'spellLevel9',
+    ];
+    const powerFields = [
+      'trigger',
+      'sustainOn',
+      'target',
+      'always',
+      'attack',
+      'hit',
+      'hitEven',
+      'hitOdd',
+      'crit',
+      'miss',
+      'missEven',
+      'missOdd',
+      'resources',
+      'castBroadEffect',
+      'castPower',
+      'sustainedEffect',
+      'finalVerse',
+      'special',
+      'effect',
+      ...spellFields,
+      'spellChain',
+      'breathWeapon',
+      'recharge',
+    ];
+
+    for (let field of powerFields) {
+      context.editors[field] = {
+        // @todo write a power enricher.
+        enriched: await wrapRolls(this.item.system[field].value ?? '', [], 'short', {}, field, enrichmentOptions),
+        element: foundry.applications.elements.HTMLProseMirrorElement.create({
+          ...editorOptions,
+          name: `system.${field}.value`,
+          value: context.system[field]?.value ?? '',
+        }),
+      };
+    }
+  }
+
+  /**
+   * Enrich values for feats.
+   *
+   * @param {object} context
+   * @param {object} enrichmentOptions
+   * @param {object} editorOptions
+   */
+  async _enrichFeats(context, enrichmentOptions, editorOptions) {
+    // Enrich feats.
+    if (this.item.system.feats) {
+      for (let [featKey, feat] of Object.entries(this.item.system.feats)) {
+        context.editors[`feat.${featKey}`] = {
+          enriched: await wrapRolls(feat.description.value ?? '', [], 'short', {}, featKey, enrichmentOptions),
+          element: foundry.applications.elements.HTMLProseMirrorElement.create({
+            ...editorOptions,
+            name: `system.feats.${featKey}.description.value`,
+            value: feat.description.value ?? '',
+          }),
+        }
+      }
+    }
+  }
+
+  /* ---------------------------------------------------- */
+
+  /**
+   * Add/delete/reorder feats on a power.
+   *
+   * @param {Event} event
+   *   Html event that triggered the method.
+   */
+  static async _updateFeat(event, target) {
+    if (!this.isEditable) return;
+
+    let dataset = target.dataset;
+
+    let item = this.item;
+    if (item.type != "power") return;
+
+    let featIndex = Number(dataset.featKey);
+    let feats = item.system.feats;
+
+    let deleteFeat = (async () => {return;});
+    switch(dataset.action) {
+      case 'createFeat':
+        if (feats) feats = Object.values(feats);
+        else feats = [];
+        feats.push({
+          "description": {
+            "type": "String",
+            "value": ""
+          },
+          "isActive": {
+            "type": "Boolean",
+            "value": false
+          },
+          "tier": {
+            "type": "String",
+            "value": "adventurer"
+          },
+          "powerUsage": {
+            "type": "String",
+            "value": ""
+          },
+          "quantity": {
+            "type": "Number",
+            "value": null
+          },
+          "maxQuantity": {
+            "type": "Number",
+            "value": null
+          }
+        });
+        await item.update({'system.feats': Object.assign({}, feats)});
+        return;
+      case 'deleteFeat':
+        deleteFeat = (async () => {
+          let newFeats = foundry.utils.deepClone(feats);
+          delete newFeats[featIndex];
+          newFeats = Object.assign({}, Object.values(newFeats));  // Re-index from 0
+          let updateData = {'system.feats': newFeats};
+          for (let key of Object.keys(item.system.feats)) {
+            if (!newFeats[key]) updateData[`system.feats.-=${key}`] = null;
+          }
+          await item.update(updateData);
+        });
+        break;
+      case 'moveFeatUp':
+        if (featIndex == 0) return;
+        feats = Object.values(feats);
+        [feats[featIndex], feats[featIndex - 1]] = [feats[featIndex - 1], feats[featIndex]]
+        await item.update({'system.feats': Object.assign({}, feats)});
+        return;
+      case 'moveFeatDown':
+        feats = Object.values(feats);
+        if (featIndex >= feats.length - 1) return;
+        [feats[featIndex + 1], feats[featIndex]] = [feats[featIndex], feats[featIndex + 1]]
+        await item.update({'system.feats': Object.assign({}, feats)});
+        return;
+    }
+
+    let bypass = event.shiftKey ? true : false;
+    if (bypass) {
+      await deleteFeat();
+      return;
+    }
+    foundry.applications.api.DialogV2.prompt({
+      window: {title: 'Delete feat?'},
+      content: `<p>${game.i18n.localize("ARCHMAGE.CHAT.DeleteConfirm")}</p>`,
+      rejectClose: false,
+      ok: {
+        callback: (event, button, dialog) => {
+          deleteFeat();
+        }
+      }
+    });
+  }
+}

--- a/src/packs/src/occultist/Better_Yet__Here_4ArO57LHfFhXLkTx.yml
+++ b/src/packs/src/occultist/Better_Yet__Here_4ArO57LHfFhXLkTx.yml
@@ -67,7 +67,7 @@ system:
   trigger:
     type: String
     label: Trigger
-    value: One of your allies hits, but does not crit, a nearby enemy with an attack
+    value: One of your allies hits a nearby enemy with an attack
   target:
     type: String
     label: Target

--- a/src/scss/v2/components/items/_item-sheet-app-v2.scss
+++ b/src/scss/v2/components/items/_item-sheet-app-v2.scss
@@ -42,6 +42,10 @@
       flex: 1;
       overflow-y: auto;
     }
+
+    &.equipment .form-group>label {
+      flex: 3;
+    }
   }
 
   // fixes a weird bug with form heights in fieldsets
@@ -132,7 +136,7 @@
   .field.flexcol {
     gap: 8px;
   }
-  
+
   .power.include-title {
     .power-summary,
     .power-header-labels {

--- a/src/template.yaml
+++ b/src/template.yaml
@@ -782,6 +782,7 @@ Item:
   equipment:
     templates:
       - standard
+      - spendable
       - usable
     properties: {}
     attributes:

--- a/src/vue/ArchmageEquipmentSheetVue.vue
+++ b/src/vue/ArchmageEquipmentSheetVue.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="`archmage-appv2-vue flexcol`">
+  <div class="archmage-appv2-vue flexcol equipment">
     <!-- Header -->
     <header class="sheet-header">
       <img class="profile-img" :src="equipment.img" data-edit="img" data-action="onEditImage" :title="equipment.name"
@@ -23,6 +23,7 @@
 
         <!-- Details fields -->
         <Tab group="primary" :tab="tabs.primary.bonuses">
+          <EquipmentBonuses :item="equipment" :context="context" />
         </Tab>
 
         <!-- Active Effect Fields -->
@@ -64,7 +65,7 @@
                 v-if="equipment.system.recharge && equipment.system.recharge.value && equipment.system.powerUsage.value == 'recharge'">
                 <Rollable name="recharge" type="recharge" :opt="equipment._id">{{
                   Number(equipment.system.recharge.value)
-                  || 16}}+</Rollable>
+                  || 16 }}+</Rollable>
               </div>
               <div class="equipment-quantity" :data-item-id="equipment._id"
                 :data-quantity="equipment.system.quantity.value"><span>{{ equipment.system.quantity.value }}</span>
@@ -85,6 +86,7 @@ import {
   Tab,
   Equipment,
   EquipmentDetails,
+  EquipmentBonuses,
   CharEffects,
   Rollable
 } from '@/components';

--- a/src/vue/ArchmageEquipmentSheetVue.vue
+++ b/src/vue/ArchmageEquipmentSheetVue.vue
@@ -1,0 +1,78 @@
+<template>
+  <div :class="`archmage-appv2-vue flexcol`">
+    <!-- Header -->
+    <header class="sheet-header">
+      <img
+        class="profile-img"
+        :src="context.item.img"
+        data-edit="img"
+        data-action="onEditImage"
+        :title="context.item.name"
+        height="100"
+        width="100"
+      />
+      <div class="header-fields flexrow">
+        <button class="item-roll flexshrink" @click="itemDocument.roll()"><i class="fas fa-dice-d20"></i><span class="visually-hidden"> Send to Chat</span></button>
+        <input type="text" name="name" v-model="context.item.name"/>
+      </div>
+    </header>
+
+    <div class="section--main">
+      <section class="section--fields has-preview">
+        <!-- Tab links -->
+        <Tabs :tabs="tabs.primary" no-span="true"/>
+
+        <!-- Details fields -->
+        <Tab group="primary" :tab="tabs.primary.details">
+          Primary
+        </Tab>
+
+        <!-- Details fields -->
+        <Tab group="primary" :tab="tabs.primary.attack">
+        </Tab>
+
+        <!-- Active Effect Fields -->
+        <Tab group="primary" :tab="tabs.primary.effects">
+          <fieldset class="section--effects">
+            <legend>{{ game.i18n.localize('ARCHMAGE.activeEffects') }}</legend>
+            <p class="hint" v-html="game.i18n.localize('ARCHMAGE.TOOLTIP.activeEffectsItemHint')"></p>
+            <div class="archmage-v2 sheet">
+              <section class="section--powers">
+                <CharEffects :actor="context.item" :key="context._renderKey"/>
+              </section>
+            </div>
+          </fieldset>
+        </Tab>
+      </section>
+
+      <fieldset class="section--preview">
+        <legend>{{ game.i18n.localize('Preview') }}</legend>
+        <div class="archmage-v2 sheet">
+          <section class="section--powers">
+            (preview)
+          </section>
+        </div>
+      </fieldset>
+    </div>
+
+  </div>
+</template>
+
+<script setup>
+import {
+  Tabs,
+  Tab,
+  CharEffects,
+} from '@/components';
+import { inject, reactive, toRaw } from 'vue';
+
+const props = defineProps(['context']);
+// Convert the tabs into a new reactive variable so that they
+// don't change every time the item is updated.
+const rawTabs = toRaw(props.context.tabs);
+const tabs = reactive({...rawTabs});
+// Retrieve a copy of the full item document instance provided by
+// the VueApplicationMixin.
+const itemDocument = inject('itemDocument');
+
+</script>

--- a/src/vue/ArchmageEquipmentSheetVue.vue
+++ b/src/vue/ArchmageEquipmentSheetVue.vue
@@ -18,7 +18,7 @@
 
         <!-- Details fields -->
         <Tab group="primary" :tab="tabs.primary.details">
-          <!--EquipmentPower :item="equipment" :context="context" /-->
+          <EquipmentDetails :item="equipment" :context="context" />
         </Tab>
 
         <!-- Details fields -->
@@ -44,7 +44,7 @@
         <div class="archmage-v2 sheet">
           <section class="section--inventory">
             <div class="equipment-summary grid equipment-grid equipment">
-              <div class="equipment-feat-pips" v-if="groupKey === 'equipment'">
+              <div class="equipment-feat-pips">
                 <ul class="feat-pips">
                   <li :class="concat('feat-pip', (equipment.system.isActive ? ' active' : ''))"
                     :data-item-id="equipment._id">
@@ -84,8 +84,9 @@ import {
   Tabs,
   Tab,
   Equipment,
-  EquipmentPower,
+  EquipmentDetails,
   CharEffects,
+  Rollable
 } from '@/components';
 import { inject, reactive, toRaw } from 'vue';
 import { concat, localize, localizeEquipmentBonus, numberFormat } from '@/methods/Helpers';

--- a/src/vue/ArchmageEquipmentSheetVue.vue
+++ b/src/vue/ArchmageEquipmentSheetVue.vue
@@ -54,7 +54,7 @@
                 </ul>
               </div>
               <div class="equipment-bonus flexrow" v-if="equipment.system.attributes">
-                <span class="bonus" v-for="(bonus, bonusProp) in getBonuses(equipment)" :key="bonusProp">
+                <span class="bonus" v-for="(bonus, bonusProp) in bonuses" :key="bonusProp">
                   <span class="bonus-label">{{ localizeEquipmentBonus(bonusProp) }} </span>
                   <span class="bonus-value">{{ numberFormat(bonus, 0, true) }}</span>
                 </span>
@@ -71,7 +71,7 @@
                 :data-quantity="equipment.system.quantity.value"><span>{{ equipment.system.quantity.value }}</span>
               </div>
             </div>
-            <Equipment :equipment="equipment" :bonuses="getBonuses(equipment)" />
+            <Equipment :equipment="equipment" :bonuses="bonuses" />
           </section>
         </div>
       </fieldset>
@@ -90,7 +90,7 @@ import {
   CharEffects,
   Rollable
 } from '@/components';
-import { inject, reactive, toRaw } from 'vue';
+import { inject, reactive, toRaw, computed } from 'vue';
 import { concat, localize, localizeEquipmentBonus, numberFormat } from '@/methods/Helpers';
 
 const props = defineProps(['context']);
@@ -104,7 +104,7 @@ const itemDocument = inject('itemDocument');
 
 const equipment = props.context.item;
 
-function getBonuses(equipment) {
+const bonuses = computed(() => {
   let bonuses = {};
   for (let [prop, value] of Object.entries(equipment.system.attributes)) {
     if (value.bonus) {
@@ -120,5 +120,5 @@ function getBonuses(equipment) {
     }
   }
   return bonuses;
-}
+})
 </script>

--- a/src/vue/ArchmageEquipmentSheetVue.vue
+++ b/src/vue/ArchmageEquipmentSheetVue.vue
@@ -102,11 +102,11 @@ const tabs = reactive({ ...rawTabs });
 // the VueApplicationMixin.
 const itemDocument = inject('itemDocument');
 
-const equipment = props.context.item;
+const equipment = computed(() => props.context.item);
 
 const bonuses = computed(() => {
   let bonuses = {};
-  for (let [prop, value] of Object.entries(equipment.system.attributes)) {
+  for (let [prop, value] of Object.entries(equipment.value.system.attributes)) {
     if (value.bonus) {
       if (prop == 'disengage' && game.settings.get("archmage", "secondEdition")) prop = 'disengage&initiative';
       bonuses[prop] = value.bonus;

--- a/src/vue/ArchmageEquipmentSheetVue.vue
+++ b/src/vue/ArchmageEquipmentSheetVue.vue
@@ -2,43 +2,37 @@
   <div :class="`archmage-appv2-vue flexcol`">
     <!-- Header -->
     <header class="sheet-header">
-      <img
-        class="profile-img"
-        :src="context.item.img"
-        data-edit="img"
-        data-action="onEditImage"
-        :title="context.item.name"
-        height="100"
-        width="100"
-      />
+      <img class="profile-img" :src="equipment.img" data-edit="img" data-action="onEditImage" :title="equipment.name"
+        height="100" width="100" />
       <div class="header-fields flexrow">
-        <button class="item-roll flexshrink" @click="itemDocument.roll()"><i class="fas fa-dice-d20"></i><span class="visually-hidden"> Send to Chat</span></button>
-        <input type="text" name="name" v-model="context.item.name"/>
+        <button class="item-roll flexshrink" @click="itemDocument.roll()"><i class="fas fa-dice-d20"></i><span
+            class="visually-hidden"> Send to Chat</span></button>
+        <input type="text" name="name" v-model="equipment.name" />
       </div>
     </header>
 
     <div class="section--main">
       <section class="section--fields has-preview">
         <!-- Tab links -->
-        <Tabs :tabs="tabs.primary" no-span="true"/>
+        <Tabs :tabs="tabs.primary" no-span="true" />
 
         <!-- Details fields -->
         <Tab group="primary" :tab="tabs.primary.details">
-          Primary
+          <!--EquipmentPower :item="equipment" :context="context" /-->
         </Tab>
 
         <!-- Details fields -->
-        <Tab group="primary" :tab="tabs.primary.attack">
+        <Tab group="primary" :tab="tabs.primary.bonuses">
         </Tab>
 
         <!-- Active Effect Fields -->
         <Tab group="primary" :tab="tabs.primary.effects">
           <fieldset class="section--effects">
-            <legend>{{ game.i18n.localize('ARCHMAGE.activeEffects') }}</legend>
-            <p class="hint" v-html="game.i18n.localize('ARCHMAGE.TOOLTIP.activeEffectsItemHint')"></p>
+            <legend>{{ localize('ARCHMAGE.activeEffects') }}</legend>
+            <p class="hint" v-html="localize('ARCHMAGE.TOOLTIP.activeEffectsItemHint')"></p>
             <div class="archmage-v2 sheet">
               <section class="section--powers">
-                <CharEffects :actor="context.item" :key="context._renderKey"/>
+                <CharEffects :actor="equipment" :key="context._renderKey" />
               </section>
             </div>
           </fieldset>
@@ -46,10 +40,37 @@
       </section>
 
       <fieldset class="section--preview">
-        <legend>{{ game.i18n.localize('Preview') }}</legend>
+        <legend>{{ localize('Preview') }}</legend>
         <div class="archmage-v2 sheet">
-          <section class="section--powers">
-            (preview)
+          <section class="section--inventory">
+            <div class="equipment-summary grid equipment-grid equipment">
+              <div class="equipment-feat-pips" v-if="groupKey === 'equipment'">
+                <ul class="feat-pips">
+                  <li :class="concat('feat-pip', (equipment.system.isActive ? ' active' : ''))"
+                    :data-item-id="equipment._id">
+                    <div class="hide">{{ equipment.system.isActive }}</div>
+                  </li>
+                </ul>
+              </div>
+              <div class="equipment-bonus flexrow" v-if="equipment.system.attributes">
+                <span class="bonus" v-for="(bonus, bonusProp) in getBonuses(equipment)" :key="bonusProp">
+                  <span class="bonus-label">{{ localizeEquipmentBonus(bonusProp) }} </span>
+                  <span class="bonus-value">{{ numberFormat(bonus, 0, true) }}</span>
+                </span>
+              </div>
+              <div class="equipment-chakra" v-if="equipment.system.chackra">{{ localize(concat('ARCHMAGE.CHAKRA.',
+                equipment.system.chackra, "Label")) }}</div>
+              <div class="equipment-recharge"
+                v-if="equipment.system.recharge && equipment.system.recharge.value && equipment.system.powerUsage.value == 'recharge'">
+                <Rollable name="recharge" type="recharge" :opt="equipment._id">{{
+                  Number(equipment.system.recharge.value)
+                  || 16}}+</Rollable>
+              </div>
+              <div class="equipment-quantity" :data-item-id="equipment._id"
+                :data-quantity="equipment.system.quantity.value"><span>{{ equipment.system.quantity.value }}</span>
+              </div>
+            </div>
+            <Equipment :equipment="equipment" :bonuses="getBonuses(equipment)" />
           </section>
         </div>
       </fieldset>
@@ -62,17 +83,39 @@
 import {
   Tabs,
   Tab,
+  Equipment,
+  EquipmentPower,
   CharEffects,
 } from '@/components';
 import { inject, reactive, toRaw } from 'vue';
+import { concat, localize, localizeEquipmentBonus, numberFormat } from '@/methods/Helpers';
 
 const props = defineProps(['context']);
 // Convert the tabs into a new reactive variable so that they
 // don't change every time the item is updated.
 const rawTabs = toRaw(props.context.tabs);
-const tabs = reactive({...rawTabs});
+const tabs = reactive({ ...rawTabs });
 // Retrieve a copy of the full item document instance provided by
 // the VueApplicationMixin.
 const itemDocument = inject('itemDocument');
 
+const equipment = props.context.item;
+
+function getBonuses(equipment) {
+  let bonuses = {};
+  for (let [prop, value] of Object.entries(equipment.system.attributes)) {
+    if (value.bonus) {
+      if (prop == 'disengage' && game.settings.get("archmage", "secondEdition")) prop = 'disengage&initiative';
+      bonuses[prop] = value.bonus;
+    }
+    else if (prop == 'attack') {
+      for (let [atkProp, atkValue] of Object.entries(value)) {
+        if (atkValue.bonus) {
+          bonuses[atkProp] = atkValue.bonus;
+        }
+      }
+    }
+  }
+  return bonuses;
+}
 </script>

--- a/src/vue/components/index.js
+++ b/src/vue/components/index.js
@@ -19,6 +19,7 @@ export { default as PowerSpells } from '@/components/item/power/PowerSpells.vue'
 export { default as PowerFeats } from '@/components/item/power/PowerFeats.vue';
 
 export { default as EquipmentDetails } from '@/components/item/equipment/EquipmentDetails.vue';
+export { default as EquipmentBonuses } from '@/components/item/equipment/EquipmentBonuses.vue';
 
 export { default as ActionDetails } from '@/components/item/action/ActionDetails.vue';
 export { default as ActionAttack } from '@/components/item/action/ActionAttack.vue';

--- a/src/vue/components/index.js
+++ b/src/vue/components/index.js
@@ -18,6 +18,8 @@ export { default as PowerDetails } from '@/components/item/power/PowerDetails.vu
 export { default as PowerSpells } from '@/components/item/power/PowerSpells.vue';
 export { default as PowerFeats } from '@/components/item/power/PowerFeats.vue';
 
+export { default as EquipmentDetails } from '@/components/item/equipment/EquipmentDetails.vue';
+
 export { default as ActionDetails } from '@/components/item/action/ActionDetails.vue';
 export { default as ActionAttack } from '@/components/item/action/ActionAttack.vue';
 

--- a/src/vue/components/item/equipment/EquipmentBonuses.vue
+++ b/src/vue/components/item/equipment/EquipmentBonuses.vue
@@ -37,6 +37,73 @@
         <input type="number" name="system.attributes.attack.arcane.bonus" v-model="item.system.attributes.attack.arcane.bonus" />
       </div>
     </div>
+  </fieldset>
+
+  <fieldset class="fieldset-defense">
+    <legend>{{ game.i18n.localize('ARCHMAGE.ITEM.defenseBonuses') }}</legend>
+
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.acBonus') }}
+      </label>
+      <div class="field">
+        <input type="number" name="system.attributes.ac.bonus" v-model="item.system.attributes.ac.bonus" />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.pdBonus') }}
+      </label>
+      <div class="field">
+        <input type="number" name="system.attributes.pd.bonus" v-model="item.system.attributes.pd.bonus" />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.mdBonus') }}
+      </label>
+      <div class="field">
+        <input type="number" name="system.attributes.md.bonus" v-model="item.system.attributes.md.bonus" />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.hpBonus') }}
+      </label>
+      <div class="field">
+        <input type="number" name="system.attributes.hp.bonus" v-model="item.system.attributes.hp.bonus" />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.recoveriesBonus') }}
+      </label>
+      <div class="field">
+        <input type="number" name="system.attributes.recoveries.bonus" v-model="item.system.attributes.recoveries.bonus" />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.saveBonus') }}
+      </label>
+      <div class="field">
+        <input type="number" name="system.attributes.save.bonus" v-model="item.system.attributes.save.bonus" />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.saveBonusHPTreshold') }}
+      </label>
+      <div class="field">
+        <input type="number" name="system.attributes.save.threshold" v-model="item.system.attributes.save.threshold" />
+      </div>
+    </div>
 
   </fieldset>
 

--- a/src/vue/components/item/equipment/EquipmentBonuses.vue
+++ b/src/vue/components/item/equipment/EquipmentBonuses.vue
@@ -3,38 +3,34 @@
     <legend>{{ game.i18n.localize('ARCHMAGE.ITEM.attackBonuses') }}</legend>
 
     <div class="form-group">
-      <label>
-        {{ game.i18n.localize('ARCHMAGE.ITEM.meleeBonus') }}
-      </label>
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.meleeBonus') }} </label>
       <div class="field">
-        <input type="number" name="system.attributes.attack.melee.bonus" v-model="item.system.attributes.attack.melee.bonus" />
+        <input type="number" name="system.attributes.attack.melee.bonus"
+          v-model="item.system.attributes.attack.melee.bonus" />
       </div>
     </div>
 
     <div class="form-group">
-      <label>
-        {{ game.i18n.localize('ARCHMAGE.ITEM.rangedBonus') }}
-      </label>
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.rangedBonus') }} </label>
       <div class="field">
-        <input type="number" name="system.attributes.attack.ranged.bonus" v-model="item.system.attributes.attack.ranged.bonus" />
+        <input type="number" name="system.attributes.attack.ranged.bonus"
+          v-model="item.system.attributes.attack.ranged.bonus" />
       </div>
     </div>
 
     <div class="form-group">
-      <label>
-        {{ game.i18n.localize('ARCHMAGE.ITEM.divineBonus') }}
-      </label>
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.divineBonus') }} </label>
       <div class="field">
-        <input type="number" name="system.attributes.attack.divine.bonus" v-model="item.system.attributes.attack.divine.bonus" />
+        <input type="number" name="system.attributes.attack.divine.bonus"
+          v-model="item.system.attributes.attack.divine.bonus" />
       </div>
     </div>
 
     <div class="form-group">
-      <label>
-        {{ game.i18n.localize('ARCHMAGE.ITEM.arcaneBonus') }}
-      </label>
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.arcaneBonus') }} </label>
       <div class="field">
-        <input type="number" name="system.attributes.attack.arcane.bonus" v-model="item.system.attributes.attack.arcane.bonus" />
+        <input type="number" name="system.attributes.attack.arcane.bonus"
+          v-model="item.system.attributes.attack.arcane.bonus" />
       </div>
     </div>
   </fieldset>
@@ -43,101 +39,130 @@
     <legend>{{ game.i18n.localize('ARCHMAGE.ITEM.defenseBonuses') }}</legend>
 
     <div class="form-group">
-      <label>
-        {{ game.i18n.localize('ARCHMAGE.ITEM.acBonus') }}
-      </label>
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.acBonus') }} </label>
       <div class="field">
         <input type="number" name="system.attributes.ac.bonus" v-model="item.system.attributes.ac.bonus" />
       </div>
     </div>
 
     <div class="form-group">
-      <label>
-        {{ game.i18n.localize('ARCHMAGE.ITEM.pdBonus') }}
-      </label>
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.pdBonus') }} </label>
       <div class="field">
         <input type="number" name="system.attributes.pd.bonus" v-model="item.system.attributes.pd.bonus" />
       </div>
     </div>
 
     <div class="form-group">
-      <label>
-        {{ game.i18n.localize('ARCHMAGE.ITEM.mdBonus') }}
-      </label>
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.mdBonus') }} </label>
       <div class="field">
         <input type="number" name="system.attributes.md.bonus" v-model="item.system.attributes.md.bonus" />
       </div>
     </div>
 
     <div class="form-group">
-      <label>
-        {{ game.i18n.localize('ARCHMAGE.ITEM.hpBonus') }}
-      </label>
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.hpBonus') }} </label>
       <div class="field">
         <input type="number" name="system.attributes.hp.bonus" v-model="item.system.attributes.hp.bonus" />
       </div>
     </div>
 
     <div class="form-group">
-      <label>
-        {{ game.i18n.localize('ARCHMAGE.ITEM.recoveriesBonus') }}
-      </label>
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.recoveriesBonus') }} </label>
       <div class="field">
-        <input type="number" name="system.attributes.recoveries.bonus" v-model="item.system.attributes.recoveries.bonus" />
+        <input type="number" name="system.attributes.recoveries.bonus"
+          v-model="item.system.attributes.recoveries.bonus" />
       </div>
     </div>
 
     <div class="form-group">
-      <label>
-        {{ game.i18n.localize('ARCHMAGE.ITEM.saveBonus') }}
-      </label>
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.saveBonus') }} </label>
       <div class="field">
         <input type="number" name="system.attributes.save.bonus" v-model="item.system.attributes.save.bonus" />
       </div>
     </div>
 
     <div class="form-group">
-      <label>
-        {{ game.i18n.localize('ARCHMAGE.ITEM.saveBonusHPTreshold') }}
-      </label>
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.saveBonusHPTreshold') }} </label>
       <div class="field">
         <input type="number" name="system.attributes.save.threshold" v-model="item.system.attributes.save.threshold" />
       </div>
     </div>
 
     <div class="form-group">
-      <label>
-        {{ game.i18n.localize(disengageKey) }}
-      </label>
+      <label> {{ game.i18n.localize(disengageKey) }} </label>
       <div class="field">
-        <input type="number" name="system.attributes.disengage.bonus" v-model="item.system.attributes.disengage.bonus" />
+        <input type="number" name="system.attributes.disengage.bonus"
+          v-model="item.system.attributes.disengage.bonus" />
       </div>
     </div>
 
     <div class="form-group">
-      <label>
-        {{ game.i18n.localize('ARCHMAGE.ITEM.rerollAcBonus') }}
-      </label>
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.rerollAcBonus') }} </label>
       <div class="field flexrow">
-        <input type="number" name="system.attributes.rerollAc.current" v-model="item.system.attributes.rerollAc.current" />
+        <input type="number" name="system.attributes.rerollAc.current"
+          v-model="item.system.attributes.rerollAc.current" />
         <span :class="$style.divider">/</span>
         <input type="number" name="system.attributes.rerollAc.bonus" v-model="item.system.attributes.rerollAc.bonus" />
       </div>
     </div>
 
     <div class="form-group">
-      <label>
-        {{ game.i18n.localize('ARCHMAGE.ITEM.rerollSaveBonus') }}
-      </label>
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.rerollSaveBonus') }} </label>
       <div class="field flexrow">
-        <input :class="$style.halfwidth" type="number" name="system.attributes.rerollSave.current" v-model="item.system.attributes.rerollSave.current" />
+        <input :class="$style.halfwidth" type="number" name="system.attributes.rerollSave.current"
+          v-model="item.system.attributes.rerollSave.current" />
         <span :class="$style.divider">/</span>
-        <input :class="$style.halfwidth" type="number" name="system.attributes.rerollSave.bonus" v-model="item.system.attributes.rerollSave.bonus" />
+        <input :class="$style.halfwidth" type="number" name="system.attributes.rerollSave.bonus"
+          v-model="item.system.attributes.rerollSave.bonus" />
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset class="fieldset-defense">
+    <legend>{{ game.i18n.localize('ARCHMAGE.ITEM.otherBonuses') }}</legend>
+
+    <div class="form-group">
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.strBonus') }} </label>
+      <div class="field">
+        <input type="number" name="system.attributes.str.bonus" v-model="item.system.attributes.str.bonus" />
       </div>
     </div>
 
-  </fieldset>
+    <div class="form-group">
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.dexBonus') }} </label>
+      <div class="field">
+        <input type="number" name="system.attributes.dex.bonus" v-model="item.system.attributes.dex.bonus" />
+      </div>
+    </div>
 
+    <div class="form-group">
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.conBonus') }} </label>
+      <div class="field">
+        <input type="number" name="system.attributes.con.bonus" v-model="item.system.attributes.con.bonus" />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.intBonus') }} </label>
+      <div class="field">
+        <input type="number" name="system.attributes.int.bonus" v-model="item.system.attributes.int.bonus" />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.wisBonus') }} </label>
+      <div class="field">
+        <input type="number" name="system.attributes.wis.bonus" v-model="item.system.attributes.wis.bonus" />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label> {{ game.i18n.localize('ARCHMAGE.ITEM.chaBonus') }} </label>
+      <div class="field">
+        <input type="number" name="system.attributes.cha.bonus" v-model="item.system.attributes.cha.bonus" />
+      </div>
+    </div>
+  </fieldset>
 </template>
 
 <script setup>

--- a/src/vue/components/item/equipment/EquipmentBonuses.vue
+++ b/src/vue/components/item/equipment/EquipmentBonuses.vue
@@ -1,0 +1,50 @@
+<template>
+  <fieldset class="fieldset-attack">
+    <legend>{{ game.i18n.localize('ARCHMAGE.ITEM.attackBonuses') }}</legend>
+
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.meleeBonus') }}
+      </label>
+      <div class="field">
+        <input type="number" name="system.attributes.attack.melee.bonus" v-model="item.system.attributes.attack.melee.bonus" />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.rangedBonus') }}
+      </label>
+      <div class="field">
+        <input type="number" name="system.attributes.attack.ranged.bonus" v-model="item.system.attributes.attack.ranged.bonus" />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.divineBonus') }}
+      </label>
+      <div class="field">
+        <input type="number" name="system.attributes.attack.divine.bonus" v-model="item.system.attributes.attack.divine.bonus" />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.arcaneBonus') }}
+      </label>
+      <div class="field">
+        <input type="number" name="system.attributes.attack.arcane.bonus" v-model="item.system.attributes.attack.arcane.bonus" />
+      </div>
+    </div>
+
+  </fieldset>
+
+</template>
+
+<script setup>
+import {
+  InfoBubble,
+} from '@/components';
+const props = defineProps(['item', 'context']);
+</script>

--- a/src/vue/components/item/equipment/EquipmentBonuses.vue
+++ b/src/vue/components/item/equipment/EquipmentBonuses.vue
@@ -105,6 +105,37 @@
       </div>
     </div>
 
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize(disengageKey) }}
+      </label>
+      <div class="field">
+        <input type="number" name="system.attributes.disengage.bonus" v-model="item.system.attributes.disengage.bonus" />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.rerollAcBonus') }}
+      </label>
+      <div class="field flexrow">
+        <input type="number" name="system.attributes.rerollAc.current" v-model="item.system.attributes.rerollAc.current" />
+        <span :class="$style.divider">/</span>
+        <input type="number" name="system.attributes.rerollAc.bonus" v-model="item.system.attributes.rerollAc.bonus" />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.rerollSaveBonus') }}
+      </label>
+      <div class="field flexrow">
+        <input :class="$style.halfwidth" type="number" name="system.attributes.rerollSave.current" v-model="item.system.attributes.rerollSave.current" />
+        <span :class="$style.divider">/</span>
+        <input :class="$style.halfwidth" type="number" name="system.attributes.rerollSave.bonus" v-model="item.system.attributes.rerollSave.bonus" />
+      </div>
+    </div>
+
   </fieldset>
 
 </template>
@@ -114,4 +145,13 @@ import {
   InfoBubble,
 } from '@/components';
 const props = defineProps(['item', 'context']);
+
+const disengageKey = CONFIG.ARCHMAGE.is2e ? 'ARCHMAGE.ITEM.disengageBonus' : 'ARCHMAGE.ITEM.disengageInitBonus';
 </script>
+
+<style lang="css" module>
+.divider {
+  flex-grow: 0 !important;
+  margin: 0 0.5rem;
+}
+</style>

--- a/src/vue/components/item/equipment/EquipmentDetails.vue
+++ b/src/vue/components/item/equipment/EquipmentDetails.vue
@@ -1,0 +1,67 @@
+<template>
+  <fieldset class="fieldset-description">
+    <legend>{{ game.i18n.localize('ARCHMAGE.description') }}</legend>
+    <Prosemirror :editable="context.editable" :field="context.editors['system.description.value']"/>
+  </fieldset>
+
+  <fieldset class="fieldset-usage">
+    <legend>{{ game.i18n.localize('ARCHMAGE.GROUPS.powerUsage') }}</legend>
+
+    <div class="form-group">
+      <label>{{game.i18n.localize('ARCHMAGE.CHAT.powerUsage')}}</label>
+      <div class="field">
+        <select name="system.powerUsage.value" v-model="item.system.powerUsage.value">
+          <option value="">{{ game.i18n.localize('ARCHMAGE.noneOption') }}</option>
+          <option v-for="(label, value) in CONFIG.ARCHMAGE.powerUsages" :key="value" :value="value">{{ label }}</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.CHAT.recharge') }}
+        <InfoBubble :tooltip="game.i18n.localize('ARCHMAGE.CHAT.rechargeHint')"/>
+      </label>
+      <div class="field">
+        <input type="number" name="system.recharge.value"
+          v-model="item.system.recharge.value"
+          :placeholder="game.i18n.localize('ARCHMAGE.CHAT.numbersOnly')"
+        />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.usesRemaining') }}
+        <InfoBubble :tooltip="game.i18n.localize('ARCHMAGE.CHAT.usesRemainingHint')"/>
+      </label>
+      <div class="field">
+        <input type="number" name="system.quantity.value"
+          v-model="item.system.quantity.value"
+          :placeholder="game.i18n.localize('ARCHMAGE.CHAT.numbersOnly')"
+        />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.usesMax') }}
+        <InfoBubble :tooltip="game.i18n.localize('ARCHMAGE.CHAT.usesMaxHint')"/>
+      </label>
+      <div class="field">
+        <input type="number" name="system.maxQuantity.value"
+          v-model="item.system.maxQuantity.value"
+          :placeholder="game.i18n.localize('ARCHMAGE.CHAT.numbersOnly')"
+        />
+      </div>
+    </div>
+  </fieldset>
+</template>
+
+<script setup>
+  import {
+    Prosemirror,
+    InfoBubble,
+  } from '@/components';
+  const props = defineProps(['item', 'context']);
+</script>

--- a/src/vue/components/item/equipment/EquipmentDetails.vue
+++ b/src/vue/components/item/equipment/EquipmentDetails.vue
@@ -1,14 +1,14 @@
 <template>
   <fieldset class="fieldset-description">
     <legend>{{ game.i18n.localize('ARCHMAGE.description') }}</legend>
-    <Prosemirror :editable="context.editable" :field="context.editors['system.description.value']"/>
+    <Prosemirror :editable="context.editable" :field="context.editors['system.description.value']" />
   </fieldset>
 
   <fieldset class="fieldset-usage">
     <legend>{{ game.i18n.localize('ARCHMAGE.GROUPS.powerUsage') }}</legend>
 
     <div class="form-group">
-      <label>{{game.i18n.localize('ARCHMAGE.CHAT.powerUsage')}}</label>
+      <label>{{ game.i18n.localize('ARCHMAGE.CHAT.powerUsage') }}</label>
       <div class="field">
         <select name="system.powerUsage.value" v-model="item.system.powerUsage.value">
           <option value="">{{ game.i18n.localize('ARCHMAGE.noneOption') }}</option>
@@ -20,48 +20,102 @@
     <div class="form-group">
       <label>
         {{ game.i18n.localize('ARCHMAGE.CHAT.recharge') }}
-        <InfoBubble :tooltip="game.i18n.localize('ARCHMAGE.CHAT.rechargeHint')"/>
+        <InfoBubble :tooltip="game.i18n.localize('ARCHMAGE.CHAT.rechargeHint')" />
       </label>
       <div class="field">
-        <input type="number" name="system.recharge.value"
-          v-model="item.system.recharge.value"
-          :placeholder="game.i18n.localize('ARCHMAGE.CHAT.numbersOnly')"
-        />
+        <input type="number" name="system.recharge.value" v-model="item.system.recharge.value"
+          :placeholder="game.i18n.localize('ARCHMAGE.CHAT.numbersOnly')" />
       </div>
     </div>
 
     <div class="form-group">
       <label>
         {{ game.i18n.localize('ARCHMAGE.ITEM.usesRemaining') }}
-        <InfoBubble :tooltip="game.i18n.localize('ARCHMAGE.CHAT.usesRemainingHint')"/>
+        <InfoBubble :tooltip="game.i18n.localize('ARCHMAGE.CHAT.usesRemainingHint')" />
       </label>
       <div class="field">
-        <input type="number" name="system.quantity.value"
-          v-model="item.system.quantity.value"
-          :placeholder="game.i18n.localize('ARCHMAGE.CHAT.numbersOnly')"
-        />
+        <input type="number" name="system.quantity.value" v-model="item.system.quantity.value"
+          :placeholder="game.i18n.localize('ARCHMAGE.CHAT.numbersOnly')" />
       </div>
     </div>
 
     <div class="form-group">
       <label>
         {{ game.i18n.localize('ARCHMAGE.ITEM.usesMax') }}
-        <InfoBubble :tooltip="game.i18n.localize('ARCHMAGE.CHAT.usesMaxHint')"/>
+        <InfoBubble :tooltip="game.i18n.localize('ARCHMAGE.CHAT.usesMaxHint')" />
       </label>
       <div class="field">
-        <input type="number" name="system.maxQuantity.value"
-          v-model="item.system.maxQuantity.value"
-          :placeholder="game.i18n.localize('ARCHMAGE.CHAT.numbersOnly')"
-        />
+        <input type="number" name="system.maxQuantity.value" v-model="item.system.maxQuantity.value"
+          :placeholder="game.i18n.localize('ARCHMAGE.CHAT.numbersOnly')" />
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset class="fieldset-details">
+    <legend>{{ game.i18n.localize('ARCHMAGE.details') }}</legend>
+
+    <!-- active -->
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.active') }}
+      </label>
+      <div class="field">
+        <input type="checkbox" name="system.isActive" v-model="item.system.isActive" />
+      </div>
+    </div>
+
+    <!-- tier -->
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.CHAT.tier') }}
+        <InfoBubble :tooltip="game.i18n.localize('ARCHMAGE.CHAT.rechargeHint')" />
+      </label>
+      <div class="field">
+        <select name="system.tier" v-model="item.system.tier">
+          <option value="">{{ game.i18n.localize('ARCHMAGE.noneOption') }}</option>
+          <option v-for="(label, value) in CONFIG.ARCHMAGE.featTiers" :key="value" :value="value">{{ label }}</option>
+        </select>
+      </div>
+    </div>
+
+    <!-- icons -->
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.icons') }}
+      </label>
+      <div class="field">
+        <input type="text" name="system.icons" v-model="item.system.icons"
+          :placeholder="game.i18n.localize('ARCHMAGE.ITEM.iconPlaceholder')" />
+      </div>
+    </div>
+
+    <!-- publication source -->
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.CHARACTERSETTINGS.publicationSource') }}
+      </label>
+      <div class="field">
+        <input type="text" name="system.publicationSource" v-model="item.system.publicationSource" placeholder="13tw" />
+      </div>
+    </div>
+
+    <!-- price -->
+    <div class="form-group">
+      <label>
+        {{ game.i18n.localize('ARCHMAGE.ITEM.price') }}
+      </label>
+      <div class="field">
+        <input type="text" name="system.price.value" v-model="item.system.price.value"
+          :placeholder="game.i18n.localize('ARCHMAGE.ITEM.pricePlaceholder')" />
       </div>
     </div>
   </fieldset>
 </template>
 
 <script setup>
-  import {
-    Prosemirror,
-    InfoBubble,
-  } from '@/components';
-  const props = defineProps(['item', 'context']);
+import {
+  Prosemirror,
+  InfoBubble,
+} from '@/components';
+const props = defineProps(['item', 'context']);
 </script>

--- a/src/vue/components/item/equipment/EquipmentDetails.vue
+++ b/src/vue/components/item/equipment/EquipmentDetails.vue
@@ -2,6 +2,17 @@
   <fieldset class="fieldset-description">
     <legend>{{ game.i18n.localize('ARCHMAGE.description') }}</legend>
     <Prosemirror :editable="context.editable" :field="context.editors['system.description.value']" />
+
+    <div class="form-group">
+      <label>{{ game.i18n.localize('ARCHMAGE.ITEM.chakraSlot') }}</label>
+      <div class="field">
+        <select name="system.chackra" v-model="item.system.chackra">
+          <option value="">{{ game.i18n.localize('ARCHMAGE.CHAKRA.none') }}</option>
+          <option v-for="(label, value) in CONFIG.ARCHMAGE.chakraSlots" :key="value" :value="value">{{ game.i18n.localize(label) }}</option>
+        </select>
+      </div>
+    </div>
+
   </fieldset>
 
   <fieldset class="fieldset-usage">

--- a/src/vue/components/parts/Enriched.vue
+++ b/src/vue/components/parts/Enriched.vue
@@ -1,19 +1,17 @@
 <template>
-  <component :is="tag" v-html="wrappedRolls"/>
+  <component :is="tag" v-html="wrappedRolls" />
 </template>
 
-<script>
+<script setup>
+import { ref, watch } from 'vue';
 import { wrapRolls } from '@/methods/Helpers';
-export default {
-  name: 'Enriched',
-  props: ['tag', 'text', 'replacements', 'diceFormulaMode', 'rollData', 'field'],
-  async setup(props) {
-    const wrappedRolls = await wrapRolls(props.text, props.replacements, props.diceFormulaMode, props.rollData, props.field);
-    return {
-      wrappedRolls
-    };
-  },
-  computed: {},
-  methods: {},
-}
+
+const props = defineProps(['tag', 'text', 'replacements', 'diceFormulaMode', 'rollData', 'field']);
+
+const wrappedRolls = ref(props.text);
+
+watch(() => props.text, async (newText) => {
+  wrappedRolls.value = await wrapRolls(newText, props.replacements, props.diceFormulaMode, props.rollData, props.field);
+}, { immediate: true });
+
 </script>

--- a/src/vue/index.js
+++ b/src/vue/index.js
@@ -3,4 +3,5 @@ export { default as ArchmageCharacterSheet } from './ArchmageCharacterSheet.vue'
 export { default as ArchmageNpcSheet } from './ArchmageNpcSheet.vue';
 export { default as ArchmageCompendiumBrowser } from './ArchmageCompendiumBrowser.vue';
 export { default as ArchmagePowerSheetVue } from './ArchmagePowerSheetVue.vue';
+export { default as ArchmageEquipmentSheetVue } from './ArchmageEquipmentSheetVue.vue';
 export { default as ArchmageActionSheetVue } from './ArchmageActionSheetVue.vue';


### PR DESCRIPTION
A V2 of the magic item sheet, which is nicer and will make punching in the 2e material much less unpleasant.

An important note: this updates the `Enriched` component to react to changes in the underlying text data. It no longer needs to be wrapped in `<Suspense>`, but I'm not doing that work here.

### Screenshots

("chakra" control added since these were taken)

This is the default size:

![CleanShot 2025-07-05 at 15 16 24@2x](https://github.com/user-attachments/assets/4c4b75ef-b415-4378-917b-fe2a1d43e90f)

All three tabs with their full height:
![CleanShot 2025-07-05 at 15 16 54@2x](https://github.com/user-attachments/assets/3ddd139b-7982-4c7f-a0e2-e76fd59fbcbe)
![CleanShot 2025-07-05 at 15 17 00@2x](https://github.com/user-attachments/assets/af259d64-e702-495a-8bc6-54503044eb60)
![CleanShot 2025-07-05 at 15 17 05@2x](https://github.com/user-attachments/assets/c932a8d2-695c-498a-b484-a681cf476e02)
