### PR TITLE
Kin map, also troll-kin

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -404,6 +404,7 @@ ARCHMAGE:
     holyone: Holy One
     human: Human
     tiefling: Tiefling
+    trollkin: Troll-Kin
     silverelf: Silver Elf
     woodelf: Wood Elf
   CLASSES:

--- a/src/module/setup/archmage-prepopulate.js
+++ b/src/module/setup/archmage-prepopulate.js
@@ -58,6 +58,7 @@ export class ArchmagePrepopulate {
     if (race != '' && racePacks.length > 0) {
       let raceAr = [race];
       if (race.includes(" ")) raceAr.push(race.replace(" ", "-"));
+      raceAr = raceAr.map(applyKinAliasMap);
       for (let i=0; i < validRaces.length; i++) {
         let regexRace = new RegExp("(\\W|^)(" + validRaces[i] + ")(\\W|$)", "i");
         for (const race of raceAr) {
@@ -386,4 +387,24 @@ export class ArchmagePrepopulate {
       }
     };
   }
+}
+
+function applyKinAliasMap (kin) {
+  const kinAliasMap = {
+    'high elf': /(light elf|bright elf)/i,
+    'wood elf': /(gr[ae]y elf|wild elf|green elf)/i,
+    'silver elf': /(drow|silver ?folk|dark elf)/i,
+    'troll-kin': /(druid('s )?folk|wood troll|half-orc|trollkin)/i,
+    'dragonic': /dragon(born|spawn)/i,
+    'forgeborn': /dwarf-forged/i,
+    'tiefling': /demon-?touched/i,
+    'holy one': /aasimar/i,
+  }
+
+  for (const [alias, regex] of Object.entries(kinAliasMap)) {
+    if (kin.match(regex)) {
+      return alias;
+    }
+  }
+  return kin;
 }

--- a/src/module/setup/config.js
+++ b/src/module/setup/config.js
@@ -703,6 +703,7 @@ ARCHMAGE.raceList = {
   'holyone': "ARCHMAGE.RACES.holyone",
   'human': "ARCHMAGE.RACES.human",
   'tiefling': "ARCHMAGE.RACES.tiefling",
+  'trollkin': "ARCHMAGE.RACES.trollkin",
   'silverelf': "ARCHMAGE.RACES.silverelf",
   'woodelf': "ARCHMAGE.RACES.woodelf"
 };


### PR DESCRIPTION
Because the 2e module won't be shipping all the AKAs for all the kin, this applies some well-known aliases to make sure the importer pulls up the "High Elf" powers when someone types in "bright elf".