### PR TITLE
Release 1.36.0

### DIFF
--- a/release-notes/1.36.0.md
+++ b/release-notes/1.36.0.md
@@ -9,22 +9,42 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.36.0/syste
 **Note**: v13 support is WIP and will happen soon in the system's next release. This will be the final v12 release for the system unless there are catastrophic bugs that need to be fixed.
 
 ## Changes
-- #562
-- #566
-- #564
-- #567
-- #569
-- #573
-- #571
 - #557
+  - Add 2e rules support. Full list in #556.
+  - Add monster strength filter to creature browser
+  - Fix SRD monsters strength and size issues
+- #562
+  - This adds an interstitial dialog to the initiative rolling flow for PCs, to support circumstances like ambushes and the commander's Into the Fray talent. It only pops up when rolling initiative from the actor sheet, not from the combat bar or combat carousel or any other source.
+- #564
+  - This exposes `system.attributes.saves.deathFails.max` as a configurable setting, and uses it for the display of death-save checkboxes.
+- #567
+  - Allowing monsters to have two roles and/or types.
+- #571
+  - Updated the magic item sheet to have a V2 version, similar to what we did with powers and actions previously.
+  - [screenshots]
 - #473
+  - Add new PC settings field to set custom max extra hp
+  - Add migration to move Toughness flag bonus to said field
+  - Changes to extra hps reflect to actual hps (increases add to them, decreases do not unless you' re above you' re suddenly lowered maximum). This applies to manual changes only, as automatic updates are currently hard to catch.
 - #554
-- #555
+  - Fix `wpn.*.dieNum` including unwanted additions to damage rolls; it's now a JS number as expected.
+  - Add new `wpn.*.diceSml` shorthand to complement `wpn.*.dice` that includes dice size reduction (e.g. d8->d6, and implements a minimum size of d4) and handles AEs and 2e epic tier bonuses automatically.
+  - Apply the new shorthand to the ranger's Double Attacks.
+  - Also add new `wpn.*.diceLrg` shorthand that implements dice size increase (useful for some 13G and 2e classes).
 - #561
+  - This reworks the icon-rolling flow to add a little dialog step, but also allows rolling all the icon relationships in one go, as at the beginning of an arc.
 - #559
+  - Adding support for JT's icon-dice rolling method (HH p270), and zhuzhing up the display a bit with tooltips. Here's what it looks like after this patch:
 
 ## Bug Fixes
-- TBD
+- #566
+  - Fix an issue with negative numeric Active Effects (a.k.a. "penalties") not applying correctly.
+- #569
+  - Managing the stoke flag was doing weird things with turns not ending properly, specifically there seems to be an issue with setting a flag on a combatant during the end-turn hook. This moves that tracking data into the actor's system data, and adds a cleanup step at the end of combat to make sure no junk is left behind.
+- #573
+  - Because the 2e module won't be shipping all the AKAs for all the kin, this applies some well-known aliases to make sure the importer pulls up the "High Elf" powers when someone types in "bright elf". (Tried a couple aliases with every 2e kin, they all seem to work fine.)
+- #555
+  - Remove small leftover bit of IP from a monk power
 
 ## Changelog
 

--- a/release-notes/1.36.0.md
+++ b/release-notes/1.36.0.md
@@ -1,0 +1,23 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.36.0/system.json
+
+## Compatible Foundry versions
+
+![Foundry v12.343](https://img.shields.io/badge/Foundry-v12.343-green)
+
+**Note**: v13 support is WIP and will happen soon in the system's next release. This will be the final v12 release for the system unless there are catastrophic bugs that need to be fixed.
+
+## Changes
+- TBD
+
+## Bug Fixes
+- TBD
+
+## Changelog
+
+Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.35.0...1.36.0
+
+## Contributors
+
+@ben, @LegoFed3

--- a/release-notes/1.36.0.md
+++ b/release-notes/1.36.0.md
@@ -8,43 +8,43 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.36.0/syste
 
 **Note**: v13 support is WIP and will happen soon in the system's next release. This will be the final v12 release for the system unless there are catastrophic bugs that need to be fixed.
 
-## Changes
-- #557
-  - Add 2e rules support. Full list in #556.
-  - Add monster strength filter to creature browser
-  - Fix SRD monsters strength and size issues
-- #562
-  - This adds an interstitial dialog to the initiative rolling flow for PCs, to support circumstances like ambushes and the commander's Into the Fray talent. It only pops up when rolling initiative from the actor sheet, not from the combat bar or combat carousel or any other source.
-- #564
-  - This exposes `system.attributes.saves.deathFails.max` as a configurable setting, and uses it for the display of death-save checkboxes.
-- #567
-  - Allowing monsters to have two roles and/or types.
-- #571
-  - Updated the magic item sheet to have a V2 version, similar to what we did with powers and actions previously.
-  - [screenshots]
-- #473
-  - Add new PC settings field to set custom max extra hp
-  - Add migration to move Toughness flag bonus to said field
+## Final 2e Rules Support
+- Update condition descriptions to their final 2e versions.
+- Update recovery dialog potions bonuses and caps if 2e enabled.
+- Change `/Desperate` recharges to only happen once per arc.
+- Support 2e paladin's `Blessing of Heaven` feature.
+- Support new `Bravado` resource for 2e rogues.
+- Support and mostly automate the effects of `Momentum` for 2e fighters.
+  - Deprecate support for the `Combat Rhythm` "resource" - it's still in the system and will keep working, but we won't be making an effort to support in in future versions of the system.
+- Adjust `Grim Determination` thresholds to match final rules.
+- Update class base stats auto-configuration when 2e is enabled.
+- Adjust 2e epic tier weapon/recovery bonus down to +5/10/15.
+- Add new incrementals if 2e enables, and restore max hp incremental (recovery incrementals are no longer in the rules).
+- Support custom initiative bonus.
+  - Added an interstitial dialog to the initiative rolling flow for PCs, to support circumstances like ambushes and the commander's Into the Fray talent. It only pops up when rolling initiative from the actor sheet, not from the combat bar or combat carousel or any other source.
+- Support configurable max death saves ("skulls" in 2e parlance) in the sheet's settings.
+- Support second monster role and types.
+- Add new PC settings field to set custom max extra hp.
+  - Add migration to move Toughness flag bonus to said field.
   - Changes to extra hps reflect to actual hps (increases add to them, decreases do not unless you' re above you' re suddenly lowered maximum). This applies to manual changes only, as automatic updates are currently hard to catch.
-- #554
-  - Fix `wpn.*.dieNum` including unwanted additions to damage rolls; it's now a JS number as expected.
-  - Add new `wpn.*.diceSml` shorthand to complement `wpn.*.dice` that includes dice size reduction (e.g. d8->d6, and implements a minimum size of d4) and handles AEs and 2e epic tier bonuses automatically.
-  - Apply the new shorthand to the ranger's Double Attacks.
-  - Also add new `wpn.*.diceLrg` shorthand that implements dice size increase (useful for some 13G and 2e classes).
-- #561
-  - This reworks the icon-rolling flow to add a little dialog step, but also allows rolling all the icon relationships in one go, as at the beginning of an arc.
-- #559
-  - Adding support for JT's icon-dice rolling method (HH p270), and zhuzhing up the display a bit with tooltips. Here's what it looks like after this patch:
+- Add new `wpn.*.diceSml` shorthand to complement `wpn.*.dice` that includes dice size reduction (e.g. d8->d6, and implements a minimum size of d4) and handles AEs and 2e epic tier bonuses automatically. Used by the ranger's Double Attacks.
+- Add new `wpn.*.diceLrg` shorthand that implements dice size increase (useful for some 13G and 2e classes, e.g. a `Two-hander`barbarian).
+- Support rolling all icon dice at once, as at the beginning of an arc.
+- Add support for JT's icon-dice rolling method (HH p270), and zhuzhing up the display a bit with tooltips. Here's what it looks like after this patch:
+[screenshots]
+
+## Other Changes
+- Add support for aliases of Kin names.
+- Add monster strength filter to creature browser.
+- Updated the magic item sheet to have a V2 version, similar to what we did with powers and actions previously.
+[screenshots]
 
 ## Bug Fixes
-- #566
-  - Fix an issue with negative numeric Active Effects (a.k.a. "penalties") not applying correctly.
-- #569
-  - Managing the stoke flag was doing weird things with turns not ending properly, specifically there seems to be an issue with setting a flag on a combatant during the end-turn hook. This moves that tracking data into the actor's system data, and adds a cleanup step at the end of combat to make sure no junk is left behind.
-- #573
-  - Because the 2e module won't be shipping all the AKAs for all the kin, this applies some well-known aliases to make sure the importer pulls up the "High Elf" powers when someone types in "bright elf". (Tried a couple aliases with every 2e kin, they all seem to work fine.)
-- #555
-  - Remove small leftover bit of IP from a monk power
+- Fix an issue with negative numeric Active Effects (a.k.a. "penalties") not applying correctly.
+- Fix `wpn.*.dieNum` including unwanted additions to damage rolls; it's now a JS number as expected.
+- Fix SRD monsters strength and size issues.
+- Fixed and issue with the stoke flag preventing turns from ending properly.
+  - Specifically there seems to be an issue with setting a flag on a combatant during the end-turn hook. Moved that tracking data into the actor's system data, and added a cleanup step at the end of combat to make sure no junk is left behind.
 
 ## Changelog
 

--- a/release-notes/1.36.0.md
+++ b/release-notes/1.36.0.md
@@ -9,7 +9,19 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.36.0/syste
 **Note**: v13 support is WIP and will happen soon in the system's next release. This will be the final v12 release for the system unless there are catastrophic bugs that need to be fixed.
 
 ## Changes
-- TBD
+- #562
+- #566
+- #564
+- #567
+- #569
+- #573
+- #571
+- #557
+- #473
+- #554
+- #555
+- #561
+- #559
 
 ## Bug Fixes
 - TBD

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -279,7 +279,7 @@ languages:
 socket: true
 url: https://github.com/asacolips-projects/13th-age
 manifest: https://asacolips-artifacts.s3.amazonaws.com/archmage/latest/system.json
-download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.35.0/archmage.zip
+download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.36.0/archmage.zip
 changelog: https://github.com/asacolips-projects/13th-age/releases
 initiative: 1d20 + (@abilities?.dex.mod || 0) + @attributes.init.value + @attributes.level.value
 grid:


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.36.0/system.json

## Compatible Foundry versions

![Foundry v12.343](https://img.shields.io/badge/Foundry-v12.343-green)

**Note**: v13 support is WIP and will happen soon in the system's next release. This will be the final v12 release for the system unless there are catastrophic bugs that need to be fixed.

## Final 2e Rules Support
- Update condition descriptions to their final 2e versions.
- Update recovery dialog potions bonuses and caps if 2e enabled.
- Change `/Desperate` recharges to only happen once per arc.
- Support 2e paladin's `Blessing of Heaven` feature.
- Support new `Bravado` resource for 2e rogues.
- Support and mostly automate the effects of `Momentum` for 2e fighters.
  - Deprecate support for the `Combat Rhythm` "resource" - it's still in the system and will keep working, but we won't be making an effort to support in in future versions of the system.
- Adjust `Grim Determination` thresholds to match final rules.
- Update class base stats auto-configuration when 2e is enabled.
- Adjust 2e epic tier weapon/recovery bonus down to +5/10/15.
- Add new incrementals if 2e enables, and restore max hp incremental (recovery incrementals are no longer in the rules).
- Support custom initiative bonus.
  - Added an interstitial dialog to the initiative rolling flow for PCs, to support circumstances like ambushes and the commander's Into the Fray talent. It only pops up when rolling initiative from the actor sheet, not from the combat bar or combat carousel or any other source.
- Support configurable max death saves ("skulls" in 2e parlance) in the sheet's settings.
- Support second monster role and types.
- Add new PC settings field to set custom max extra hp.
  - Add migration to move Toughness flag bonus to said field.
  - Changes to extra hps reflect to actual hps (increases add to them, decreases do not unless you' re above you' re suddenly lowered maximum). This applies to manual changes only, as automatic updates are currently hard to catch.
- Add new `wpn.*.diceSml` shorthand to complement `wpn.*.dice` that includes dice size reduction (e.g. d8->d6, and implements a minimum size of d4) and handles AEs and 2e epic tier bonuses automatically. Used by the ranger's Double Attacks.
- Add new `wpn.*.diceLrg` shorthand that implements dice size increase (useful for some 13G and 2e classes, e.g. a `Two-hander`barbarian).
- Support rolling all icon dice at once, as at the beginning of an arc.
- Add support for JT's icon-dice rolling method (HH p270), and zhuzhing up the display a bit with tooltips. Here's what it looks like after this patch:
[screenshots]

## Other Changes
- Add support for aliases of Kin names.
- Add monster strength filter to creature browser.
- Updated the magic item sheet to have a V2 version, similar to what we did with powers and actions previously.
[screenshots]

## Bug Fixes
- Fix an issue with negative numeric Active Effects (a.k.a. "penalties") not applying correctly.
- Fix `wpn.*.dieNum` including unwanted additions to damage rolls; it's now a JS number as expected.
- Fix SRD monsters strength and size issues.
- Fixed and issue with the stoke flag preventing turns from ending properly.
  - Specifically there seems to be an issue with setting a flag on a combatant during the end-turn hook. Moved that tracking data into the actor's system data, and added a cleanup step at the end of combat to make sure no junk is left behind.

## Changelog

Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.35.0...1.36.0

## Contributors

ben, LegoFed3
