### PR TITLE
Release 1.37.0

### DIFF
--- a/release-notes/1.37.0.md
+++ b/release-notes/1.37.0.md
@@ -12,11 +12,15 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.37.0/syste
 It took rather a lot of fiddly work, but thanks mainly to the heroic efforts of our @ben the system is now compatible with Foundry v13 and its revamped UI.
 [screenshots]
 
-## Condition Parsing Improvements
+## Active effects editor upgrade
+This release includes a new editor for effects.
+[screenshots]
+
+## Condition parsing improvements
 Conditions (like `dazed` and `confused`) are now parsed into draggable links even without requiring users to manually wrap them in asterisks, support localization, and attempt to guess the duration of the related Active Effect (supports only a few standard phrasings).
 [screenshots]
 
-## Bug Fixes
+## Bug fixes
 - Fix hp incremental not working using 2e rules.
 - Fix wrongly localized hints in equipment sheet.
 

--- a/release-notes/1.37.0.md
+++ b/release-notes/1.37.0.md
@@ -13,7 +13,7 @@ It took rather a lot of fiddly work, but thanks mainly to the heroic efforts of 
 [screenshots]
 
 ## Condition Parsing Improvements
-Conditions (like `dazed` and `confused` are now parsed even without requiring users to manually wrap them in asterisks, support localization, and attempt to guess the duration of the related Active Effect (supports only a few standard phrasings).
+Conditions (like `dazed` and `confused`) are now parsed into draggable links even without requiring users to manually wrap them in asterisks, support localization, and attempt to guess the duration of the related Active Effect (supports only a few standard phrasings).
 [screenshots]
 
 ## Bug Fixes

--- a/release-notes/1.37.0.md
+++ b/release-notes/1.37.0.md
@@ -1,0 +1,29 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.37.0/system.json
+
+## Compatible Foundry versions
+
+![Foundry v13.348](https://img.shields.io/badge/Foundry-v13.348-green)
+
+**Note**: Starting from this release the system will *only* support Foundry v13.
+
+## Foundry v13 compatibility
+It took rather a lot of fiddly work, but thanks mainly to the heroic efforts of our @ben the system is now compatible with Foundry v13 and its revamped UI.
+[screenshots]
+
+## Condition Parsing Improvements
+Conditions (like `dazed` and `confused` are now parsed even without requiring users to manually wrap them in asterisks, support localization, and attempt to guess the duration of the related Active Effect (supports only a few standard phrasings).
+[screenshots]
+
+## Bug Fixes
+- Fix hp incremental not working using 2e rules.
+- Fix wrongly localized hints in equipment sheet.
+
+## Changelog
+
+Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.36.1...1.37.0
+
+## Contributors
+
+@ben, @LegoFed3, @asacolips

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -1,6 +1,6 @@
 id: archmage
 title: 13th Age
-version: "1.36.1"
+version: "1.37.0"
 authors:
   - name: Matt Smith
     discord: asacolips
@@ -15,7 +15,7 @@ description: The official 13th Age system for Foundry Virtual Tabletop.
 
 compatibility:
   minimum: "13"
-  verified: "13.342"
+  verified: "13.348"
   maximum: "13"
 
 esmodules:


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.37.0/system.json

## Compatible Foundry versions

![Foundry v13.348](https://img.shields.io/badge/Foundry-v13.348-green)

**Note**: Starting from this release the system will *only* support Foundry v13.

## Foundry v13 compatibility
It took rather a lot of fiddly work, but thanks mainly to the heroic efforts of our @ben the system is now compatible with Foundry v13 and its revamped UI.

<figure>
<img src="https://github.com/user-attachments/assets/7b730696-55f1-4165-ad47-09da5b79ee7f">
<figcaption>Map from <a href="https://www.czepeku.com/">Czepeku</a></figcaption>
</figure>

## Active effects editor upgrade
This release includes a new editor for effects.

![CleanShot 2025-09-08 at 11 55 43@2x](https://github.com/user-attachments/assets/8cc38d77-714c-4d9f-a50f-7fefbbd50ca1)


## Condition parsing improvements
Conditions (like `dazed` and `confused`) are now parsed into draggable links even without requiring users to manually wrap them in asterisks, support localization, and attempt to guess the duration of the related Active Effect (supports only a few standard phrasings).
<img width="302" height="750" alt="immagine" src="https://github.com/user-attachments/assets/389a7b0a-53ab-4308-8700-f700033c056c" />

## Bug fixes
- Fix hp incremental not working using 2e rules.
- Fix wrongly localized hints in equipment sheet.

## Changelog

Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.36.1...1.37.0

## Contributors

@ben, @LegoFed3, @asacolips
