### PR TITLE
Release 1.39.0

### DIFF
--- a/release-notes/1.39.0.md
+++ b/release-notes/1.39.0.md
@@ -1,0 +1,25 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.39.0/system.json
+
+## Compatible Foundry versions
+
+![Foundry v13.351](https://img.shields.io/badge/Foundry-v13.351-green)
+
+**Note**: This release *only* supports Foundry v13 and will be the final v13 release. Support for v14 will come in the next release.
+
+## Changes
+
+- Added dice animations for inline rolls from resources and effect fields. #604
+- Updated this.rollAbility() to use the new DialogV2 implementation and deprecated the previous method that it called. #605
+- Add base crit range 18+ as an optional rule setting. #606
+- Fix dash and space handling in power importer. #607
+- Fix regular expressions for condition parsing to better handle word boundaries (such as save ends being included). #608
+
+## Changelog
+
+Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.38.1...1.39.0
+
+## Contributors
+
+@ben, @LegoFed3, @asacolips

--- a/release-notes/1.39.0.md
+++ b/release-notes/1.39.0.md
@@ -14,7 +14,7 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.39.0/syste
 - Updated this.rollAbility() to use the new DialogV2 implementation and deprecated the previous method that it called. #605
 - Add base crit range 18+ as an optional rule setting. #606
 - Fix dash and space handling in power importer. #607
-- Fix regular expressions for condition parsing to better handle word boundaries (such as save ends being included). #608
+- Fix regular expressions for condition parsing to better handle word boundaries (as works like undead being wrongly recognized for substrings). #608
 
 ## Changelog
 

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -1,6 +1,6 @@
 id: archmage
 title: 13th Age
-version: "1.38.1"
+version: "1.39.0"
 authors:
   - name: Matt Smith
     discord: asacolips


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.39.0/system.json

## Compatible Foundry versions

![Foundry v13.351](https://img.shields.io/badge/Foundry-v13.351-green)

**Note**: This release *only* supports Foundry v13 and will be the final v13 release. Support for v14 will come in the next release.

## Changes

- Added dice animations for inline rolls from resources and effect fields. #604
- Updated this.rollAbility() to use the new DialogV2 implementation and deprecated the previous method that it called. #605
- Add base crit range 18+ as an optional rule setting. #606
- Fix dash and space handling in power importer. #607
- Fix regular expressions for condition parsing to better handle word boundaries (such as save ends being included). #608

## Changelog

Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.38.1...1.39.0

## Contributors

ben, LegoFed3, asacolips
