### PR TITLE
Replace alt-click power level bump with use-power dialog

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -837,6 +837,11 @@ ARCHMAGE:
     hasUnknown: The following Effects with an <strong>unknown duration</strong> are currently active on this Actor
     powerLevel: Level
     powerLevelTitle: Adjusting the power level will affect which level effects get sent to chat.
+    powerRollLevel: Level
+    powerRollTitle: Use Power
+    powerRollUse: Use
+    consumeUsage: Consume Usage
+    consumeResources: Consume Resources
     powerSource: Power Source
     powerSourceName: Source Name
     powerSourcePlaceholder: Wizard

--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -842,6 +842,10 @@ ARCHMAGE:
     powerRollUse: Use
     consumeUsage: Consume Usage
     consumeResources: Consume Resources
+    modified: (modified)
+    modifiedLevel: "Level {level}"
+    modifiedNoUsage: usage not consumed
+    modifiedNoResources: resources not consumed
     powerSource: Power Source
     powerSourceName: Source Name
     powerSourcePlaceholder: Wizard

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -83,7 +83,7 @@ export class ItemArchmage extends Item {
     let token = this._rollGetToken(itemToRender);
 
     // Render the chat card.
-    let chatData = await this._rollRender(itemUpdateData, actorUpdateData, itemToRender, rollData, token);
+    let chatData = await this._rollRender(itemUpdateData, actorUpdateData, itemToRender, rollData, token, { tempOverrides, consumeUsage, consumeResources });
 
     // Evaluate outcomes and prepare animations.
     let [ sequencerAnim, hitEvalRes ] = preCreateChatMessageHandler.handle(chatData, {
@@ -654,15 +654,28 @@ export class ItemArchmage extends Item {
     return use;
   }
 
-  async _rollRender(itemUpdateData, actorUpdateData, itemToRender, rollData, token) {
+  async _rollRender(itemUpdateData, actorUpdateData, itemToRender, rollData, token, rollContext = {}) {
     // Basic template rendering data
     const template = `systems/archmage/templates/chat/${this.type.toLowerCase()}-card.html`
+
+    // Build a list of human-readable override descriptions for the "(modified)" tooltip.
+    const modifiedParts = [];
+    const { tempOverrides = {}, consumeUsage = true, consumeResources = true } = rollContext;
+    const origLvl = this.system.powerLevel?.value;
+    const newLvl = tempOverrides['system.powerLevel.value'];
+    if (newLvl !== undefined && newLvl !== origLvl) {
+      modifiedParts.push(game.i18n.format("ARCHMAGE.CHAT.modifiedLevel", { level: newLvl }));
+    }
+    if (!consumeUsage) modifiedParts.push(game.i18n.localize("ARCHMAGE.CHAT.modifiedNoUsage"));
+    if (!consumeResources) modifiedParts.push(game.i18n.localize("ARCHMAGE.CHAT.modifiedNoResources"));
+
     const templateData = {
       actor: this.itemActor,
       tokenId: null, //token ? `${token.scene.id}.${token.id}` : null,
       item: itemToRender,
       data: await itemToRender.getChatData({ rollData: rollData }, true),
-      usageClass: this._getUsageClass(itemToRender)
+      usageClass: this._getUsageClass(itemToRender),
+      modifiedTooltip: modifiedParts.length ? modifiedParts.join(", ") : null
     };
 
     // Basic chat message data

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -42,12 +42,14 @@ export class ItemArchmage extends Item {
     // Understand what the user is trying to do
     let usageMode = await this._rollUsageMode()
 
-    // First check remaining uses.
-    let early_exit = await this._rollUsesCheck(itemUpdateData, usageMode);
-    if (early_exit) return;
+    // For powers with a level, show a dialog to set level and consume-usage.
+    const rollOptions = await this._rollTemporaryOverrides();
+    if (!rollOptions) return;
+    const { overrides: tempOverrides, consumeUsage, consumeResources } = rollOptions;
 
-    // Determine level item is used at
-    const tempOverrides = await this._rollTemporaryOverrides()
+    // Check remaining uses, honoring the consume-usage choice from the dialog.
+    let early_exit = await this._rollUsesCheck(itemUpdateData, usageMode, consumeUsage);
+    if (early_exit) return;
 
     // Make an ephemeral clone of the item which we can dirty during processing.
     let itemToRender = this.clone(tempOverrides, {"save": false, "keepId": true});
@@ -58,7 +60,7 @@ export class ItemArchmage extends Item {
     }
 
     // Then check resources.
-    early_exit = await this._rollResourceCheck(itemUpdateData, actorUpdateData, itemToRender);
+    early_exit = await this._rollResourceCheck(itemUpdateData, actorUpdateData, itemToRender, undefined, consumeResources);
     if (early_exit) return;
 
     // Handle crit modifier
@@ -237,11 +239,13 @@ export class ItemArchmage extends Item {
     return retVal;
   }
 
-  async _rollUsesCheck(updateData, usageMode) {
+  async _rollUsesCheck(updateData, usageMode, consumeUsage = true) {
     // If we have a special usage mode skip this check
     if (!["", "openingEffect"].includes(usageMode)) return false;
     // Only check uses on owned items.
     if (!this.actor) return false;
+    // Respect the consume-usage choice from the power roll dialog.
+    if (!consumeUsage) return false;
     // Update uses left
     let uses = this.system.quantity?.value;
     if (uses == null) return false;
@@ -270,26 +274,100 @@ export class ItemArchmage extends Item {
 
   async _rollTemporaryOverrides() {
     let overrides = {};
-    if (this.type != 'power') return overrides;
-    let lvl = this.system.powerLevel?.value ?? 0;
+    if (this.type != 'power') return { overrides, consumeUsage: true };
+    let baseLvl = this.system.powerLevel?.value ?? 0;
     if (this.itemActor?.getFlag("archmage", "overridePowerLevel")) {
-      lvl = Math.max(this.itemActor.system.attributes.level.value, lvl);
+      baseLvl = Math.max(this.itemActor.system.attributes.level.value, baseLvl);
     }
-    if (event.altKey && this.system.powerLevel?.value != undefined) {
-      lvl += 1;
-      overrides['name'] = this.name + ' (+1)';
+
+    // Only show the dialog if the item has a power level defined.
+    if (this.system.powerLevel?.value == undefined) {
+      overrides['system.powerLevel.value'] = baseLvl;
+      return { overrides, consumeUsage: true };
     }
-    overrides['system.powerLevel.value'] = lvl;
-    return overrides;
+
+    const hasUses = this.system.quantity?.value != null;
+    const usesLeft = this.system.quantity?.value ?? 0;
+    const hasResources = !!this.system.resources?.value;
+    const resourcesStr = this.system.resources?.value ?? "";
+
+    // Collect levels that have a spellLevelN entry with content.
+    const spellLevels = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+      .filter(n => this.system[`spellLevel${n}`]?.value);
+    const hasSpellLevels = spellLevels.length > 0;
+
+    const content = `
+      <form>
+        ${hasUses ? `
+        <div class="form-group">
+          <label>
+            ${game.i18n.localize("ARCHMAGE.CHAT.consumeUsage")}
+            ${usesLeft <= 0 ? `<i class="fas fa-triangle-exclamation" data-tooltip="${game.i18n.localize("ARCHMAGE.CHAT.NoUses")}"></i>` : ""}
+          </label>
+          <input type="checkbox" name="consumeUsage" checked/>
+        </div>` : ""}
+        ${hasResources ? `
+        <div class="form-group">
+          <label>
+            ${game.i18n.localize("ARCHMAGE.CHAT.consumeResources")}
+            <i class="fas fa-circle-info" data-tooltip="${resourcesStr.replace(/"/g, "&quot;")}"></i>
+          </label>
+          <input type="checkbox" name="consumeResources" checked/>
+        </div>` : ""}
+      </form>`;
+
+    return new Promise(resolve => {
+      let resolved = false;
+      const makeCallback = lvl => (event, button) => {
+        const form = button.form;
+        const finalLvl = lvl ?? (hasSpellLevels ? Number(form.level.value) : baseLvl);
+        const consume = hasUses ? form.consumeUsage.checked : true;
+        const consumeRes = hasResources ? form.consumeResources.checked : true;
+        overrides['system.powerLevel.value'] = finalLvl;
+        resolved = true;
+        resolve({ overrides, consumeUsage: consume, consumeResources: consumeRes });
+      };
+
+      let buttons;
+      if (hasSpellLevels) {
+        const allOdd = spellLevels.every(n => n % 2 === 1);
+        const floorLevel = Math.max(1, spellLevels[0] - (allOdd ? 2 : 1));
+        const allLevels = [...new Set([...spellLevels, floorLevel, baseLvl])].sort((a, b) => a - b);
+        buttons = allLevels.map(n => ({
+          action: `level${n}`,
+          label: `${n}`,
+          icon: n === baseLvl ? "fas fa-circle-dot" : undefined,
+          default: n === baseLvl,
+          callback: makeCallback(n)
+        }));
+      } else {
+        buttons = [{
+          action: "normal",
+          label: game.i18n.localize("ARCHMAGE.CHAT.powerRollUse"),
+          default: true,
+          callback: makeCallback(null)
+        }];
+      }
+
+      new foundry.applications.api.DialogV2({
+        window: { title: `${game.i18n.localize("ARCHMAGE.CHAT.powerRollTitle")}: ${this.name}` },
+        content,
+        buttons,
+        close: () => { if (!resolved) resolve(null); }
+      }).render({ force: true });
+    });
   }
 
-  async _rollResourceCheck(itemUpdateData, actorUpdateData, itemToRender, usageMode) {
+  async _rollResourceCheck(itemUpdateData, actorUpdateData, itemToRender, usageMode, consumeResources = true) {
     // Updates resources if field is set
     let resStr = this.system.resources?.value;
     if (!resStr) return false;
 
     // Exit early with no actor.
     if (!this.actor) return false;
+
+    // Respect the consume-resources choice from the power roll dialog.
+    if (!consumeResources) return false;
 
     let resources = resStr.split(",").map(item => item.trim());
     let res = this.actor.system.resources;

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -280,10 +280,10 @@ export class ItemArchmage extends Item {
       baseLvl = Math.max(this.itemActor.system.attributes.level.value, baseLvl);
     }
 
-    // Only show the dialog if the item has a power level defined.
-    if (this.system.powerLevel?.value == undefined) {
+    // Only show the dialog if the item has a power level defined and alt is held.
+    if (this.system.powerLevel?.value == undefined || !event?.altKey) {
       overrides['system.powerLevel.value'] = baseLvl;
-      return { overrides, consumeUsage: true };
+      return { overrides, consumeUsage: true, consumeResources: true };
     }
 
     const hasUses = this.system.quantity?.value != null;

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -296,6 +296,12 @@ export class ItemArchmage extends Item {
       .filter(n => this.system[`spellLevel${n}`]?.value);
     const hasSpellLevels = spellLevels.length > 0;
 
+    // Nothing to show — skip the dialog entirely.
+    if (!hasSpellLevels && !hasUses && !hasResources) {
+      overrides['system.powerLevel.value'] = baseLvl;
+      return { overrides, consumeUsage: true, consumeResources: true };
+    }
+
     const content = `
       <form>
         ${hasUses ? `

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -280,12 +280,6 @@ export class ItemArchmage extends Item {
       baseLvl = Math.max(this.itemActor.system.attributes.level.value, baseLvl);
     }
 
-    // Only show the dialog if the item has a power level defined and alt is held.
-    if (this.system.powerLevel?.value == undefined || !event?.altKey) {
-      overrides['system.powerLevel.value'] = baseLvl;
-      return { overrides, consumeUsage: true, consumeResources: true };
-    }
-
     const hasUses = this.system.quantity?.value != null;
     const usesLeft = this.system.quantity?.value ?? 0;
     const hasResources = !!this.system.resources?.value;
@@ -296,8 +290,8 @@ export class ItemArchmage extends Item {
       .filter(n => this.system[`spellLevel${n}`]?.value);
     const hasSpellLevels = spellLevels.length > 0;
 
-    // Nothing to show — skip the dialog entirely.
-    if (!hasSpellLevels && !hasUses && !hasResources) {
+    // Skip the dialog if alt isn't held, or there's nothing for it to display.
+    if (!event?.altKey || (!hasSpellLevels && !hasUses && !hasResources)) {
       overrides['system.powerLevel.value'] = baseLvl;
       return { overrides, consumeUsage: true, consumeResources: true };
     }

--- a/src/scss/global/_archmage-global.scss
+++ b/src/scss/global/_archmage-global.scss
@@ -228,6 +228,13 @@ option[selected] {
   background: $c-power-other;
 }
 
+.power-modified {
+  font-size: 0.75em;
+  font-weight: normal;
+  font-style: italic;
+  opacity: 0.8;
+}
+
 // Actor Sheet
 
 .archmage {

--- a/src/templates/chat/power-card.html
+++ b/src/templates/chat/power-card.html
@@ -1,7 +1,7 @@
 <div class="archmage chat-card item-card" data-actor-id="{{actor.id}}" data-item-id="{{item.id}}" {{#if tokenId}}data-token-id="{{tokenId}}"{{/if}} data-actor-uuid="{{actor.uuid}}">
     <header class="card-header flexrow">
         <img src="{{item.img}}" title="{{item.name}}" width="36" height="36"/>
-        <h3 class="ability-usage ability-usage--{{usageClass}}">{{item.name}}</h3>
+        <h3 class="ability-usage ability-usage--{{usageClass}}">{{item.name}}{{#if modifiedTooltip}} <span class="power-modified" data-tooltip="{{modifiedTooltip}}">{{localize "ARCHMAGE.CHAT.modified"}}</span>{{/if}}</h3>
     </header>
 
     <div class="item-summary">


### PR DESCRIPTION
## Summary

- Replaces the old alt-click behaviour (which silently bumped power level by +1) with a `DialogV2`
- Dialog shows level shortcut buttons built from populated `spellLevelN` fields, the floor level (one step below the lowest entry, respecting odd-only progressions), and the current base level (marked with a `●` icon and set as the default button)
- Checkboxes to opt out of consuming uses and/or resources, shown only when the item has them
- ⚠ icon on "Consume Usage" when the item has no uses remaining
- ℹ icon on "Consume Resources" with a tooltip showing the resource string
- Closing the dialog without clicking a button cancels the roll
- Decorates the chat card with "(modified)" and a tooltip to describe what was changed


https://github.com/user-attachments/assets/2a3da122-add7-4283-8ef0-4ac73ea75b19


🤖 Generated with [Claude Code](https://claude.com/claude-code)