### PR TITLE
Release 1.39.1

### DIFF
--- a/release-notes/1.39.1.md
+++ b/release-notes/1.39.1.md
@@ -13,6 +13,8 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.39.1/syste
 - Updated and expanded the attributes & inline roll reference
 - Fixed styles on popped-out chat messages
 - Fixed the application of item skill check bonuses
+- Fixed recovery math to round to the nearest instead of down per a 2e rules clarification
+- Fixed i18n keys in the power editor for remaining and max uses hints
 - Replaces the old alt-click behaviour (which silently bumped power level by +1) with a `DialogV2`
   - Dialog shows level shortcut buttons built from populated `spellLevelN` fields, the floor level (one step below the lowest entry, respecting odd-only progressions), and the current base level (marked with a ● icon and set as the default button)
   - Checkboxes to opt out of consuming uses and/or resources, shown only when the item has them

--- a/release-notes/1.39.1.md
+++ b/release-notes/1.39.1.md
@@ -1,0 +1,30 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.39.1/system.json
+
+## Compatible Foundry versions
+
+![Foundry v13.351](https://img.shields.io/badge/Foundry-v13.351-green)
+
+**Note**: This is the closing release for v13 on the system and backports various fixes and improvements we implemented in the incoming v14 release of the system.
+
+## Changes
+
+- Updated and expanded the attributes & inline roll reference
+- Fixed styles on popped-out chat messages
+- Fixed the application of item skill check bonuses
+- Replaces the old alt-click behaviour (which silently bumped power level by +1) with a `DialogV2`
+  - Dialog shows level shortcut buttons built from populated `spellLevelN` fields, the floor level (one step below the lowest entry, respecting odd-only progressions), and the current base level (marked with a ● icon and set as the default button)
+  - Checkboxes to opt out of consuming uses and/or resources, shown only when the item has them
+  - ⚠ icon on "Consume Usage" when the item has no uses remaining
+  - ℹ icon on "Consume Resources" with a tooltip showing the resource string
+  - Closing the dialog without clicking a button cancels the roll
+  - Decorates the chat card with "(modified)" and a tooltip to describe what was changed
+
+## Changelog
+
+Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.39.0...1.39.1
+
+## Contributors
+
+@ben, @LegoFed3

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -1,6 +1,6 @@
 id: archmage
 title: 13th Age
-version: "1.39.0"
+version: "1.39.1"
 authors:
   - name: Matt Smith
     discord: asacolips
@@ -278,7 +278,7 @@ languages:
 socket: true
 url: https://github.com/asacolips-projects/13th-age
 manifest: https://asacolips-artifacts.s3.amazonaws.com/archmage/latest/system.json
-download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.38.1/archmage.zip
+download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.39.1/archmage.zip
 changelog: https://github.com/asacolips-projects/13th-age/releases
 initiative: 1d20 + (@abilities?.dex.mod || 0) + @attributes.init.value + @attributes.level.value
 grid:


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.39.1/system.json

## Compatible Foundry versions

![Foundry v13.351](https://img.shields.io/badge/Foundry-v13.351-green)

**Note**: This is the closing release for v13 on the system and backports various fixes and improvements we implemented in the incoming v14 release of the system.

## Changes

- Updated and expanded the attributes & inline roll reference
- Fixed styles on popped-out chat messages
- Fixed the application of item skill check bonuses
- Fixed recovery math to round to the nearest instead of down per a 2e rules clarification
- Fixed i18n keys in the power editor for remaining and max uses hints
- Replaces the old alt-click behaviour (which silently bumped power level by +1) with a `DialogV2`
  - Dialog shows level shortcut buttons built from populated `spellLevelN` fields, the floor level (one step below the lowest entry, respecting odd-only progressions), and the current base level (marked with a ● icon and set as the default button)
  - Checkboxes to opt out of consuming uses and/or resources, shown only when the item has them
  - ⚠ icon on "Consume Usage" when the item has no uses remaining
  - ℹ icon on "Consume Resources" with a tooltip showing the resource string
  - Closing the dialog without clicking a button cancels the roll
  - Decorates the chat card with "(modified)" and a tooltip to describe what was changed

## Changelog

Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.39.0...1.39.1

## Contributors

ben, LegoFed3
