### PR TITLE
Fix editing and display of "block ED" active effect

### DIFF
--- a/src/vue/ArchmageActiveEffectSheetVue.vue
+++ b/src/vue/ArchmageActiveEffectSheetVue.vue
@@ -114,7 +114,7 @@ const modes = {
 const changes = computed(() => {
   const changesArray = [];
   effect.value.changes.forEach(c => {
-    if (c.key && c.value) {
+    if (c.key && c.value != null) {
       const label = game.archmage.ArchmageUtility.cleanActiveEffectLabel(c.key);
       let change = {
         name: label,
@@ -176,7 +176,7 @@ watch(effect, async (newEffect) => {
 		}
 
 		if (change.key === 'system.attributes.escalation.value') {
-			viewModel.edBlocked = change.value === '0';
+			viewModel.edBlocked = change.value == 0;
 		}
 	}
 }, { immediate: true, deep: true })

--- a/src/vue/components/actor/character/main/CharEffects.vue
+++ b/src/vue/components/actor/character/main/CharEffects.vue
@@ -92,7 +92,7 @@ export default {
         'override': 'undo'
       }
       effect.changes.forEach(c => {
-        if (c.key && c.value) {
+        if (c.key && c.value != null) {
           const label = game.archmage.ArchmageUtility.cleanActiveEffectLabel(c.key);
           let change = {
             name: label,


### PR DESCRIPTION
Looks like Foundry v14 is coercing `"0"` to `0`, which was messing with our expectations for display.