### PR TITLE
Disable movement distance labels and add optional trail clearing

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -225,6 +225,8 @@ ARCHMAGE:
     automateBaseStatsFromClassName: Automatically compute base stats
     automateHPConditionsHint: If enabled, the Staggered, Dead and Unconscious conditions will be automatically applied and removed after hp changes. Disable this if you are using custom conditions via modules such as Combat Utility Belt - it is implicitly disabled if that module is active.
     automateHPConditionsName: Auto-manage Dead and Staggered
+    disableMovementTrailsHint: Clears movement history trails immediately after a token is dropped. Disable to allow Foundry's default persistent trail behavior.
+    disableMovementTrailsName: Disable Movement Trails
     ColorblindHint: Change the colors of the power cards to a more accessibile color palette.
     ColorblindName: Enable Colorblind Accessibility Mode
     ColorblindIssuesMessage: We're always trying to improve our accessibility. Suggest accessibility improvements at <a href="https://gitlab.com/asacolips-projects/foundry-mods/archmage/-/issues/new" target="_blank">our issue tracker</a> and include the <strong>a11y</strong> label.

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -576,6 +576,15 @@ Hooks.once('init', async function() {
     requiresReload: true
   });
 
+  game.settings.register('archmage', 'disableMovementTrails', {
+    name: "ARCHMAGE.SETTINGS.disableMovementTrailsName",
+    hint: "ARCHMAGE.SETTINGS.disableMovementTrailsHint",
+    scope: 'world',
+    config: true,
+    default: false,
+    type: Boolean,
+  });
+
   game.settings.register('archmage', 'allowPasteParsing', {
     name: "ARCHMAGE.SETTINGS.allowPasteParsingName",
     hint: "ARCHMAGE.SETTINGS.allowPasteParsingHint",
@@ -1033,6 +1042,7 @@ Hooks.on('renderSettingsConfig', (app, html, data) => {
     {
       label: 'ARCHMAGE.SETTINGS.groups.general',
       settings: [
+        "disableMovementTrails",
         'allowPasteParsing',
         'initiativeDexTiebreaker',
         'initiativeStaticNpc',
@@ -1040,6 +1050,7 @@ Hooks.on('renderSettingsConfig', (app, html, data) => {
         'tourVisibility',
       ],
       highlights: [
+        "disableMovementTrails",
       ],
     }
   ];
@@ -1251,6 +1262,15 @@ Hooks.on('preCreateToken', async (scene, data, options, id) => {
       data.height = 3;
       data.width = 3;
     }
+  }
+});
+
+/* -------------------------------------------- */
+
+Hooks.on("updateToken", (tokenDoc, changes, options, userId) => {
+  if (!game.settings.get('archmage', 'disableMovementTrails')) return;
+  if ("x" in changes || "y" in changes) {
+    tokenDoc.clearMovementHistory?.();
   }
 });
 

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -639,6 +639,9 @@ Hooks.once('init', async function() {
     return this.actor?.getInitiativeFormula() ?? "1d20";
   };
 
+  // Hide ruler distance labels — 13th Age uses abstract movement where distances are irrelevant.
+  CONFIG.Token.rulerClass.WAYPOINT_LABEL_TEMPLATE = "";
+
   ArchmageUtility.fixVuePopoutBug();
 });
 


### PR DESCRIPTION
## Description

FoundryVTT v14 introduced movement trails and distance labels on token rulers. Since 13th Age uses abstract/narrative movement where distances are irrelevant, this PR:

- [x] Unconditionally hides ruler distance labels (distances never matter in 13th Age)
- [x] Adds a world setting "Disable Movement Trails" (default: on) that clears movement history immediately after a token is dropped
- [x] Players still see the temporary drag line while moving (useful for showing intent like "I'm going around this enemy")

The setting can be turned off by GMs who prefer Foundry's default persistent trail behavior.

Before:


https://github.com/user-attachments/assets/e547e078-3f87-43f0-8438-a0f01b92b147

After (with trails still enabled), note no distance counters:


https://github.com/user-attachments/assets/da79e78d-5462-47dc-a7bc-20561ec76c79

After (with trails disabled):


https://github.com/user-attachments/assets/5cb99b53-ef61-49d3-ba73-ea25c9d021b5

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>