### PR TITLE
release/1.40.1

### DIFF
--- a/release-notes/1.40.0.md
+++ b/release-notes/1.40.0.md
@@ -14,7 +14,7 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.40.0/syste
 
 ## Changelog
 
-Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.39.0...1.39.1
+Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.39.1...1.40.0
 
 ## Contributors
 

--- a/release-notes/1.40.1.md
+++ b/release-notes/1.40.1.md
@@ -10,7 +10,7 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.40.1/syste
 ## Changes
 
 - Fix staggered/dead/unconscious not being visually displayed on tokens despite being automatically created (if the related setting is active).
-- Fix the "display staggered/dead/unconscious as overlay" setting non being honored.
+- Fix the "display staggered/dead/unconscious as overlay" setting not being honored.
 - Fix the Active Effect sheet not saving changes since v14.
 - Enable additional fields on the Active Effect sheet for NPCs (monsters) that were incorrectly gated to PCs only.
 - Adjust the behavior of token movement trails, and add optional system setting to disable them altogether.

--- a/release-notes/1.40.1.md
+++ b/release-notes/1.40.1.md
@@ -1,0 +1,25 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.40.1/system.json
+
+## Compatible Foundry versions
+
+![Foundry v14.364](https://img.shields.io/badge/Foundry-v14.364-green)
+
+
+## Changes
+
+- Fix staggered/dead/unconscious not being visually displayed on tokens despite being automatically created (if the related setting is active).
+- Fix the "display staggered/dead/unconscious as overlay" setting non being honored.
+- Fix the Active Effect sheet not saving changes since v14.
+- Enable additional fields on the Active Effect sheet for NPCs (monsters) that were incorrectly gated to PCs only.
+- Add optional system setting to disable movement trails.
+- Fix actors instantiated by the baseline monster creator having the wrong default icon for their action(s).
+
+## Changelog
+
+Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.40.0...1.40.1
+
+## Contributors
+
+@ben, @LegoFed3, @asacolips

--- a/release-notes/1.40.1.md
+++ b/release-notes/1.40.1.md
@@ -13,7 +13,7 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.40.1/syste
 - Fix the "display staggered/dead/unconscious as overlay" setting non being honored.
 - Fix the Active Effect sheet not saving changes since v14.
 - Enable additional fields on the Active Effect sheet for NPCs (monsters) that were incorrectly gated to PCs only.
-- Add optional system setting to disable movement trails.
+- Adjust the behavior of token movement trails, and add optional system setting to disable them altogether.
 - Fix actors instantiated by the baseline monster creator having the wrong default icon for their action(s).
 
 ## Changelog

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -1,6 +1,6 @@
 id: archmage
 title: 13th Age
-version: "1.40.0"
+version: "1.40.1"
 authors:
   - name: Matt Smith
     discord: asacolips

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -278,7 +278,7 @@ languages:
 socket: true
 url: https://github.com/asacolips-projects/13th-age
 manifest: https://asacolips-artifacts.s3.amazonaws.com/archmage/latest/system.json
-download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.40.0/archmage.zip
+download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.40.1/archmage.zip
 changelog: https://github.com/asacolips-projects/13th-age/releases
 initiative: 1d20 + (@abilities?.dex.mod || 0) + @attributes.init.value + @attributes.level.value
 grid:


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.40.1/system.json

## Compatible Foundry versions

![Foundry v14.364](https://img.shields.io/badge/Foundry-v14.364-green)


## Changes

- Fix staggered/dead/unconscious not being visually displayed on tokens despite being automatically created (if the related setting is active).
- Fix the "display staggered/dead/unconscious as overlay" setting non being honored.
- Fix the Active Effect sheet not saving changes since v14.
- Enable additional fields on the Active Effect sheet for NPCs (monsters) that were incorrectly gated to PCs only.q
- Add optional system setting to disable movement trails.
- Fix actors instantiated by the baseline monster creator having the wrong default icon for their action(s).

## Changelog

Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.40.0...1.40.1

## Contributors

@ben, @LegoFed3, @asacolips