### PR TITLE
Hiding distance rulers is now optional

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -225,6 +225,8 @@ ARCHMAGE:
     automateBaseStatsFromClassName: Automatically compute base stats
     automateHPConditionsHint: If enabled, the Staggered, Dead and Unconscious conditions will be automatically applied and removed after hp changes. Disable this if you are using custom conditions via modules such as Combat Utility Belt - it is implicitly disabled if that module is active.
     automateHPConditionsName: Auto-manage Dead and Staggered
+    disableMovementDistancesHint: Removes the distance labels when dragging tokens.
+    disableMovementDistancesName: Disable Movement Distances
     disableMovementTrailsHint: Clears movement history trails immediately after a token is dropped. Disable to allow Foundry's default persistent trail behavior.
     disableMovementTrailsName: Disable Movement Trails
     ColorblindHint: Change the colors of the power cards to a more accessibile color palette.

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -576,6 +576,16 @@ Hooks.once('init', async function() {
     requiresReload: true
   });
 
+  game.settings.register('archmage', 'disableMovementDistances', {
+    name: "ARCHMAGE.SETTINGS.disableMovementDistancesName",
+    hint: "ARCHMAGE.SETTINGS.disableMovementDistancesHint",
+    scope: 'client',
+    config: true,
+    default: true,
+    type: Boolean,
+    requiresReload: true
+  });
+
   game.settings.register('archmage', 'disableMovementTrails', {
     name: "ARCHMAGE.SETTINGS.disableMovementTrailsName",
     hint: "ARCHMAGE.SETTINGS.disableMovementTrailsHint",
@@ -648,9 +658,6 @@ Hooks.once('init', async function() {
     return this.actor?.getInitiativeFormula() ?? "1d20";
   };
 
-  // Hide ruler distance labels — 13th Age uses abstract movement where distances are irrelevant.
-  CONFIG.Token.rulerClass.WAYPOINT_LABEL_TEMPLATE = "";
-
   ArchmageUtility.fixVuePopoutBug();
 });
 
@@ -671,6 +678,11 @@ Hooks.on('ready', () => {
           ]
       })
   );
+
+  // Optionally Hide ruler distance labels — 13th Age uses abstract movement where distances are irrelevant.
+  if (game.settings.get('archmage', 'disableMovementDistances')) {
+    CONFIG.Token.rulerClass.WAYPOINT_LABEL_TEMPLATE = "";
+  }
 });
 
 Hooks.on('setup', (data, options, id) => {
@@ -994,9 +1006,7 @@ Hooks.on('renderSettingsConfig', (app, html, data) => {
     {
       label: 'ARCHMAGE.SETTINGS.groups.edition',
       settings: ['secondEdition', 'alternateIconRollingMethod'],
-      highlights: [
-        'alternateIconRollingMethod',
-      ],
+      highlights: [ ],
     },
     {
       label: 'ARCHMAGE.SETTINGS.groups.automation',
@@ -1042,6 +1052,7 @@ Hooks.on('renderSettingsConfig', (app, html, data) => {
     {
       label: 'ARCHMAGE.SETTINGS.groups.general',
       settings: [
+        "disableMovementDistances",
         "disableMovementTrails",
         'allowPasteParsing',
         'initiativeDexTiebreaker',
@@ -1050,6 +1061,7 @@ Hooks.on('renderSettingsConfig', (app, html, data) => {
         'tourVisibility',
       ],
       highlights: [
+        "disableMovementDistances",
         "disableMovementTrails",
       ],
     }


### PR DESCRIPTION
Adds a new option to remove movement distances, which is enabled by default.

Switched on:

<img width="1064" height="568" alt="CleanShot 2026-07-14 at 06 36 51@2x" src="https://github.com/user-attachments/assets/c759b619-016a-47d9-96dc-0a610a6a50b3" />

Switched off:

<img width="1107" height="639" alt="CleanShot 2026-07-14 at 06 37 29@2x" src="https://github.com/user-attachments/assets/9beb5bd4-8ec9-459c-a8c4-9edb295ba1af" />
