### PR TITLE
Allow players to drag effects/conditions to a token.

### DIFF
--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -1297,7 +1297,7 @@ Hooks.on('dropCanvasData', async (canvas, data) => {
     const gridSize = canvas.scene.grid.size;
     // Get the set of targeted tokens
     const targets = Array.from(canvas.scene.tokens.values()).filter(t => {
-      if (!t.visible) return false;
+      if (t.hidden || !t.isOwner) return false;
       return (t.x <= x
           && (t.x + t.width * gridSize) >= x
           && t.y <= y


### PR DESCRIPTION
Dragging effects/conditions to a token worked for a GM but for some reason, it was not working for players. This change makes it work for players as well. The t.visible was returning false for some reason even when dragging to your own token. I made it check for it being hidden and onwership instead which appears to work. Note that the hidden here is different from the 13th age hidden condition. I believe it's when the GM hides a token, but I'm not 100% certain.

Before this change, a player had to drag the effect/condition to the effects tab of their actor's sheet. Now they can drag it to the token on the scene.