### PR TITLE
feature/OngoingDamageMultiplier

### DIFF
--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -670,7 +670,10 @@ ARCHMAGE:
     meleeBonus: Melee Attack Bonus
     meleeWeaponDamageBonus: Melee Weapon Damage Bonus
     ongoingDamage: Ongoing Damage
-    ongoingDamageCrit: Ongoing Damage is from a critical hit
+    ongoingDamageMultiplier: Ongoing Damage multiplier (first tick only)
+    ongoingDamageMultiplierx1: Normal damage (x1)
+    ongoingDamageMultiplierx2: Double damage (x2)
+    ongoingDamageMultiplierx3: Triple damage (x3)
     otherBonuses: Other Bonuses
     pdBonus: PD Bonus
     price: Price
@@ -835,6 +838,9 @@ ARCHMAGE:
     odd: odd
     ongoingDamageTooltip: '{damage} ongoing {type} damage'
     ongoingDamage: '{target} takes [[{damage}]] ongoing {type}damage due to {source}'
+    ongoingHalfDamage: Half damage
+    ongoingDoubleDamage: 2x damage (1st tick only)
+    ongoingTripleDamage: 3x damage (1st tick only)
     ongoingSelfEnded: The following Effects <strong>have ended on this</strong> Actor
     ongoingOtherEnded: The following Effects <strong>have ended on another</strong> Actor
     ongoingSaveEnds: The following Effects <strong>require a Save</strong> to end

--- a/src/module/active-effects/effect-sheet.js
+++ b/src/module/active-effects/effect-sheet.js
@@ -1,3 +1,5 @@
+import { getOngoingDamageMultiplier } from "./ongoing-damage.mjs";
+
 export class EffectArchmageSheet extends foundry.applications.sheets.ActiveEffectConfig {
 
   /** @override */
@@ -50,7 +52,9 @@ export class EffectArchmageSheet extends foundry.applications.sheets.ActiveEffec
     context.duration = context.effect.flags.archmage?.duration || "Unknown";
     context.ongoingDamage = context.effect.flags.archmage?.ongoingDamage || 0;
     context.ongoingDamageType = context.effect.flags.archmage?.ongoingDamageType || "";
-    context.ongoingDamageCrit = context.effect.flags.archmage?.ongoingDamageCrit || false;
+    // Stringified so that it matches the select option keys.
+    context.ongoingDamageMultiplier = String(getOngoingDamageMultiplier(context.effect));
+    context.ongoingDamageMultipliers = CONFIG.ARCHMAGE.ongoingDamageMultipliers;
     context.stacksAlways = context.effect.flags.archmage?.stacksAlways || false;
 
     return context;
@@ -93,7 +97,7 @@ export class EffectArchmageSheet extends foundry.applications.sheets.ActiveEffec
       duration: formData.duration,
       ongoingDamage: formData.ongoingDamage,
       ongoingDamageType: formData.ongoingDamageType,
-      ongoingDamageCrit: formData.ongoingDamageCrit,
+      ongoingDamageMultiplier: Number(formData.ongoingDamageMultiplier) || 1,
       stacksAlways: formData.stacksAlways,
     };
 

--- a/src/module/active-effects/ongoing-damage.mjs
+++ b/src/module/active-effects/ongoing-damage.mjs
@@ -1,0 +1,63 @@
+/**
+ * Helpers for ongoing damage active effects.
+ *
+ * Ongoing damage can be applied at double or triple value (e.g. from a critical
+ * hit), which is stored on the `flags.archmage.ongoingDamageMultiplier` flag.
+ * The multiplier only applies to the first tick, after which it reverts to 1.
+ *
+ * The `ongoingDamage` flag itself may hold a fractional value, e.g. when an
+ * effect is applied at half damage. It is only rounded when the damage is
+ * actually dealt, so that halving and multiplying cancel each other out.
+ */
+
+/**
+ * Round an ongoing damage value up, away from zero so that healing (stored as
+ * a negative value) rounds in the recipient's favor too.
+ * @param {number} value  The raw damage.
+ * @returns {number}  The rounded damage.
+ */
+export function roundOngoingDamage(value) {
+  return Math.sign(value) * Math.ceil(Math.abs(value));
+}
+
+/**
+ * Read the damage multiplier of an ongoing damage effect.
+ * @param {ActiveEffect|object} effect  The effect (or its data) to inspect.
+ * @returns {number}  The multiplier, 1 if none is set.
+ */
+export function getOngoingDamageMultiplier(effect) {
+  const multiplier = Number(effect?.flags?.archmage?.ongoingDamageMultiplier);
+  return Number.isFinite(multiplier) && multiplier >= 1 ? Math.floor(multiplier) : 1;
+}
+
+/**
+ * Reset an ongoing damage effect back to a x1 multiplier, if needed.
+ * @param {ActiveEffect} effect  The effect to reset.
+ * @returns {Promise<ActiveEffect|void>}
+ */
+export async function resetOngoingDamageMultiplier(effect) {
+  if (!effect?.update) return;
+  if (getOngoingDamageMultiplier(effect) === 1) return;
+  return effect.update({'flags.archmage.ongoingDamageMultiplier': 1});
+}
+
+/**
+ * Annotate an effect with the derived ongoing damage properties used by the
+ * ongoing effects chat card.
+ * @param {ActiveEffect} effect  The effect to annotate, modified in place.
+ * @returns {ActiveEffect}  The same effect.
+ */
+export function prepareOngoingDamage(effect) {
+  const isOngoing = effect.flags.archmage?.ongoingDamage ? true : false;
+  const multiplier = isOngoing ? getOngoingDamageMultiplier(effect) : 1;
+  effect.isOngoing = isOngoing;
+  effect.isCrit = multiplier > 1;
+  effect.critMult = multiplier;
+  const rawDamage = isOngoing ? Number(effect.flags.archmage?.ongoingDamage) : 0;
+  effect.ongoingTooltip = game.i18n.format('ARCHMAGE.CHAT.ongoingDamageTooltip', {
+    damage: roundOngoingDamage(rawDamage),
+    type: effect.flags.archmage?.ongoingDamageType ?? '',
+  });
+  effect.ongoingDamage = roundOngoingDamage(rawDamage * multiplier);
+  return effect;
+}

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -20,6 +20,7 @@ import { preloadHandlebarsTemplates } from "./setup/templates.js";
 import { TourGuide } from './tours/tourguide.js';
 import { ActorHelpersV2 } from './actor/helpers/actor-helpers-v2.js';
 import { EffectArchmageSheet } from "./active-effects/effect-sheet.js";
+import { resetOngoingDamageMultiplier } from "./active-effects/ongoing-damage.mjs";
 import { registerModuleArt } from './setup/register-module-art.js';
 import { TokenArchmage } from './actor/token.js';
 import {combatRound, combatStart, combatTurn, preDeleteCombat} from "./hooks/combat.mjs";
@@ -1402,7 +1403,7 @@ async function _applyAE(actor, data) {
         archmage: {
           ongoingDamage: data.value,
           ongoingDamageType: data.damageType,
-          ongoingDamageCrit: false,
+          ongoingDamageMultiplier: 1,
           duration: data.ends,
           tooltip: data.tooltip
         }
@@ -1454,7 +1455,8 @@ async function _applyAEDurationDialog(actor, effectData, duration, source, type 
             duration = html.find('[name="duration"]:checked').val();
             const ongoing = {
               half: html.find('[name="ongoingHalf"]')?.is(":checked") ?? false,
-              crit: html.find('[name="ongoingCrit"]')?.is(":checked") ?? false,
+              double: html.find('[name="ongoingDouble"]')?.is(":checked") ?? false,
+              triple: html.find('[name="ongoingTriple"]')?.is(":checked") ?? false,
             };
             if ( !duration ) duration = "Unknown";
             let options = {};
@@ -1465,11 +1467,11 @@ async function _applyAEDurationDialog(actor, effectData, duration, source, type 
               options = {round: game.combat?.round || 1};
             }
             if (ongoing.half) {
-              effectData.flags.archmage.ongoingDamage = Math.floor(Number(effectData.flags.archmage.ongoingDamage) / 2);
+              // Kept fractional, it's rounded up when the damage is dealt.
+              effectData.flags.archmage.ongoingDamage = Number(effectData.flags.archmage.ongoingDamage) / 2;
             }
-            if (ongoing.crit) {
-              effectData.flags.archmage.ongoingDamageCrit = true;
-            }
+            if (ongoing.triple) effectData.flags.archmage.ongoingDamageMultiplier = 3;
+            else if (ongoing.double) effectData.flags.archmage.ongoingDamageMultiplier = 2;
             game.archmage.MacroUtils.setDuration(effectData, duration, options);
             return actor.createEmbeddedDocuments("ActiveEffect", [effectData]);
           }
@@ -1479,7 +1481,14 @@ async function _applyAEDurationDialog(actor, effectData, duration, source, type 
           callback: () => {}
         },
       },
-      default: 'apply'
+      default: 'apply',
+      render: (html) => {
+        // The damage multiplier checkboxes are mutually exclusive.
+        const multipliers = $(html).find('[name="ongoingDouble"], [name="ongoingTriple"]');
+        multipliers.on('change', (event) => {
+          if (event.currentTarget.checked) multipliers.not(event.currentTarget).prop('checked', false);
+        });
+      }
     }).render(true);
   });
 }
@@ -1727,10 +1736,8 @@ Hooks.on('renderChatMessageHTML', (chatMessage, rawhtml, options) => {
         await actor.update({ "system.attributes.hp.value": base - value });
         if (chatMessage.isAuthor || game.user.isGM) await chatMessage.setFlag('archmage', `effectApplied.${effectId}`, true);
         else game.socket.emit('system.archmage', {type: 'condButton', msg: chatMessage.id, flg: `effectApplied.${effectId}`});
-        // Unset crit flag on ongoing damage if needed.
-        if (effect?.flags?.archmage?.ongoingDamageCrit === true) {
-          await effect.update({'flags.archmage.ongoingDamageCrit': false});
-        }
+        // Ongoing damage is only multiplied on its first tick, revert to x1.
+        await resetOngoingDamageMultiplier(effect);
         break;
       case "save":
         const duration = parent.dataset.save;

--- a/src/module/hooks/combat.mjs
+++ b/src/module/hooks/combat.mjs
@@ -1,3 +1,5 @@
+import { prepareOngoingDamage } from '../active-effects/ongoing-damage.mjs';
+
 export async function combatStart(updateData) {
     // Ensure the start-of-turn hook fires for the first combatant, combatTurn doesn't fire here
     const firstCombatant = updateData.turns[0];
@@ -48,18 +50,7 @@ export async function handleTurnEffects(prefix, combat, combatant, context, opti
     for (const effect of combatant.actor.effects) {
         if (!effect.active) continue;
         // Handle ongoing.
-        const isOngoing = effect.flags.archmage?.ongoingDamage ? true: false;
-        effect.isOngoing = isOngoing;
-        const isCrit = isOngoing && effect.flags.archmage?.ongoingDamageCrit === true;
-        effect.isCrit = isCrit;
-        effect.ongoingDamage = isOngoing ? Number(effect.flags.archmage?.ongoingDamage) : 0;
-        effect.ongoingTooltip = game.i18n.format('ARCHMAGE.CHAT.ongoingDamageTooltip', {
-            damage: effect.ongoingDamage,
-            type: effect.flags.archmage?.ongoingDamageType ?? '',
-        });
-        if (isCrit) {
-            effect.ongoingDamage = effect.ongoingDamage * 2;
-        }
+        prepareOngoingDamage(effect);
         // Handle durations.
         if (effect.name === game.i18n.localize("ARCHMAGE.EFFECT.StatusDead")) isDead = true;
         const duration = effect.flags.archmage?.duration || "Unknown";
@@ -86,18 +77,7 @@ export async function handleTurnEffects(prefix, combat, combatant, context, opti
         effectsToDelete = [];
         if (otherCombatant?.actor?.effects) {
             for (const effect of otherCombatant.actor.effects) {
-                const isOngoing = effect.flags.archmage?.ongoingDamage ? true: false;;
-                effect.isOngoing = isOngoing;
-                const isCrit = isOngoing && effect.flags.archmage?.ongoingDamageCrit === true;
-                effect.isCrit = isCrit;
-                effect.ongoingDamage = isOngoing ? Number(effect.flags.archmage?.ongoingDamage) : 0;
-                effect.ongoingTooltip = game.i18n.format('ARCHMAGE.CHAT.ongoingDamageTooltip', {
-                    damage: effect.ongoingDamage,
-                    type: effect.flags.archmage?.ongoingDamageType ?? '',
-                });
-                if (isCrit) {
-                    effect.ongoingDamage = effect.ongoingDamage * 2;
-                }
+                prepareOngoingDamage(effect);
                 const duration = effect.flags.archmage?.duration || "Unknown";
                 if (duration === `${prefix}OfNextSourceTurn` && effect.origin === combatant.actor.uuid) {
                     // Ensure it's the *next* turn
@@ -195,18 +175,7 @@ export async function preDeleteCombat(combat, context, options) {
 
             for (const effect of combatant.actor.effects) {
                 if (!effect.active) continue;
-                const isOngoing = effect.flags.archmage?.ongoingDamage ? true: false;
-                effect.isOngoing = isOngoing;
-                const isCrit = isOngoing && effect.flags.archmage?.ongoingDamageCrit === true;
-                effect.isCrit = isCrit;
-                effect.ongoingDamage = isOngoing ? Number(effect.flags.archmage.ongoingDamage) : 0;
-                effect.ongoingTooltip = game.i18n.format('ARCHMAGE.CHAT.ongoingDamageTooltip', {
-                    damage: effect.ongoingDamage,
-                    type: effect.flags.archmage?.ongoingDamageType ?? '',
-                });
-                if (isCrit) {
-                    effect.ongoingDamage = effect.ongoingDamage * 2;
-                }
+                prepareOngoingDamage(effect);
                 const duration = effect.flags.archmage?.duration || "Unknown";
                 // If duration is longer than battle skip
                 if (["Infinite", "EndOfArc"].includes(duration)) continue;

--- a/src/module/hooks/preCreateChatMessageHandler.mjs
+++ b/src/module/hooks/preCreateChatMessageHandler.mjs
@@ -13,23 +13,25 @@ export default class preCreateChatMessageHandler {
                 for (const match of conditionInstances.sort((a,b) => b.index - a.index)) {
                     const duration = ((val) => {
                         if (!val) return "Unknown";
+                        // Lowercased on both sides: some of these are title cased UI labels.
+                        const localize = (key) => game.i18n.localize(key).toLowerCase();
                         switch(val.toLowerCase()){
-                            case game.i18n.localize("ARCHMAGE.DURATION.SaveEnds"):
-                            case game.i18n.localize("ARCHMAGE.DURATION.NormalSaveEnds"):
+                            case localize("ARCHMAGE.DURATION.SaveEnds"):
+                            case localize("ARCHMAGE.DURATION.NormalSaveEnds"):
                                 return "NormalSaveEnds";
-                            case game.i18n.localize("ARCHMAGE.DURATION.HardSaveEnds"):
+                            case localize("ARCHMAGE.DURATION.HardSaveEnds"):
                                 return "HardSaveEnds";
-                            case game.i18n.localize("ARCHMAGE.DURATION.EasySaveEnds"):
+                            case localize("ARCHMAGE.DURATION.EasySaveEnds"):
                                 return "EasySaveEnds";
-                            case game.i18n.localize("ARCHMAGE.DURATION.StartOfNextTurnFull"):
-                            case game.i18n.localize("ARCHMAGE.DURATION.StartOfNextTurnFull2"):
+                            case localize("ARCHMAGE.DURATION.StartOfNextTurnFull"):
+                            case localize("ARCHMAGE.DURATION.StartOfNextTurnFull2"):
                                 return "StartOfNextTurn";
-                            case game.i18n.localize("ARCHMAGE.DURATION.EndOfNextTurnFull"):
-                            case game.i18n.localize("ARCHMAGE.DURATION.EndOfNextTurnFull2"):
+                            case localize("ARCHMAGE.DURATION.EndOfNextTurnFull"):
+                            case localize("ARCHMAGE.DURATION.EndOfNextTurnFull2"):
                                 return "EndOfNextTurn";
-                            case game.i18n.localize("ARCHMAGE.DURATION.StartOfNextSourceTurnFull"):
+                            case localize("ARCHMAGE.DURATION.StartOfNextSourceTurnFull"):
                                 return "StartOfNextSourceTurn";
-                            case game.i18n.localize("ARCHMAGE.DURATION.EndOfNextSourceTurnFull"):
+                            case localize("ARCHMAGE.DURATION.EndOfNextSourceTurnFull"):
                                 return "EndOfNextSourceTurn";
                             default:
                                 return "Unknown";

--- a/src/module/hooks/preCreateChatMessageHandler.mjs
+++ b/src/module/hooks/preCreateChatMessageHandler.mjs
@@ -80,18 +80,20 @@ export default class preCreateChatMessageHandler {
                     let damageValue = Number(ongoingEffect[2]);
                     let damageType = ongoingEffect[4];
                     if ( damageType ) damageType += " ";
-                    let savesEndsText = ongoingEffect[5];
-                    let saveEndsValue = ongoingEffect[6];
+                    // Undefined without a save ends clause, empty for a plain "(save ends)".
+                    let saveEndsValue = ongoingEffect[5]?.toLowerCase();
                     let saveEndsConfigValue = "NormalSaveEnds";
                     if ( saveEndsValue === "easy" ) saveEndsConfigValue = "EasySaveEnds";
                     else if ( saveEndsValue === "hard" ) saveEndsConfigValue = "HardSaveEnds";
                     let source = uuid;
                     let message = `${damageValue} ongoing ${damageType}damage`;
+                    if ( saveEndsValue !== undefined ) {
+                        message += ` (${game.i18n.localize(CONFIG.ARCHMAGE.effectDurationTypes[saveEndsConfigValue])})`;
+                    }
                     let name = options.item.name;
                     // Replace any R: at the start of the name
                     name = name.replace(/^R: /, "");
                     let tooltip = message;
-                    if ( savesEndsText ) tooltip += " " + savesEndsText;
                     const img = damageValue >= 0 ? "icons/svg/degen.svg" : "icons/svg/regen.svg";
                     let ongoingEffectLink = `<a class="effect-link" draggable="true" data-type="ongoing-damage" data-id="ongoing" title=""
                         data-value="${damageValue}" data-damage-type="${damageType}" data-ends="${saveEndsConfigValue}"

--- a/src/module/item/item-sheet.js
+++ b/src/module/item/item-sheet.js
@@ -1,3 +1,5 @@
+import { roundOngoingDamage } from "../active-effects/ongoing-damage.mjs";
+
 /**
  * Override and extend the basic :class:`ItemSheet` implementation
  */
@@ -91,7 +93,7 @@ export class ItemArchmageSheet extends foundry.appv1.sheets.ItemSheet {
         ? game.i18n.localize(CONFIG.ARCHMAGE.effectDurationTypes[effect.flags.archmage.duration])
         : false;
       context.effects[index].ongoingDamage = effect.flags?.archmage?.ongoingDamage
-        ? `${effect.flags.archmage.ongoingDamage} ongoing ${effect.flags.archmage.ongoingDamageType} damage`
+        ? `${roundOngoingDamage(effect.flags.archmage.ongoingDamage)} ongoing ${effect.flags.archmage.ongoingDamageType} damage`
         : false;
       context.effects[index].bonuses = getChanges(effect);
       context.effects[index].img = effect?.img ?? effect?.icon;

--- a/src/module/setup/config.js
+++ b/src/module/setup/config.js
@@ -583,6 +583,13 @@ ARCHMAGE.effectDurationTypes = {
   'StartOfEachTurn': 'ARCHMAGE.DURATION.StartOfEachTurn'
 };
 
+// Damage multipliers for the first tick of an ongoing damage effect.
+ARCHMAGE.ongoingDamageMultipliers = {
+  1: 'ARCHMAGE.ITEM.ongoingDamageMultiplierx1',
+  2: 'ARCHMAGE.ITEM.ongoingDamageMultiplierx2',
+  3: 'ARCHMAGE.ITEM.ongoingDamageMultiplierx3'
+};
+
 ARCHMAGE.creatureTypes = {
   'aberration': 'ARCHMAGE.CREATURETYPES.aberration',
   'beast': 'ARCHMAGE.CREATURETYPES.beast',

--- a/src/packs/src/srd-magic-items/Magic_Oil__Adventurer__fvPFOgomRoH6gU83.yml
+++ b/src/packs/src/srd-magic-items/Magic_Oil__Adventurer__fvPFOgomRoH6gU83.yml
@@ -12,7 +12,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/items/potions/minor-green.jpg
     name: Magic Oil (Adventurer, Armor)
@@ -54,7 +53,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/items/potions/minor-green.jpg
     name: Magic Oil (Adventurer, Melee Weapon)
@@ -96,7 +94,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/items/potions/minor-green.jpg
     name: Magic Oil (Adventurer, Ranged Weapon)
@@ -138,7 +135,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/items/potions/minor-green.jpg
     name: Magic Oil (Adventurer, Implement)

--- a/src/packs/src/srd-magic-items/Magic_Oil__Champion__l1EK3xmGFAdGPByu.yml
+++ b/src/packs/src/srd-magic-items/Magic_Oil__Champion__l1EK3xmGFAdGPByu.yml
@@ -12,7 +12,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/items/potions/major-green.jpg
     name: Magic Oil (Champion, Armor)
@@ -54,7 +53,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/items/potions/major-green.jpg
     name: Magic Oil (Champion, Melee Weapon)
@@ -96,7 +94,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/items/potions/major-green.jpg
     name: Magic Oil (Champion, Ranged Weapon)
@@ -138,7 +135,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/items/potions/major-green.jpg
     name: Magic Oil (Champion, Implement)

--- a/src/packs/src/srd-magic-items/Magic_Oil__Epic__e6y7NbwbpCkIHpjF.yml
+++ b/src/packs/src/srd-magic-items/Magic_Oil__Epic__e6y7NbwbpCkIHpjF.yml
@@ -12,7 +12,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/items/potions/grand-green.jpg
     name: Magic Oil (Epic, Armor)
@@ -54,7 +53,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/items/potions/grand-green.jpg
     name: Magic Oil (Epic, Melee Weapon)
@@ -96,7 +94,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/items/potions/grand-green.jpg
     name: Magic Oil (Epic, Ranged Weapon)
@@ -138,7 +135,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/items/potions/grand-green.jpg
     name: Magic Oil (Epic, Implement)

--- a/src/packs/src/srd-magic-items/Rune__Adventurer__ievCx711qpOs5aK9.yml
+++ b/src/packs/src/srd-magic-items/Rune__Adventurer__ievCx711qpOs5aK9.yml
@@ -12,7 +12,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/spells/runes-blue-1.jpg
     name: Magic Rune (Adventurer, Armor)
@@ -54,7 +53,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/spells/runes-blue-1.jpg
     name: Magic Rune (Adventurer, Melee Weapon)
@@ -96,7 +94,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/spells/runes-blue-1.jpg
     name: Magic Rune (Adventurer, Ranged Weapon)
@@ -138,7 +135,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/spells/runes-blue-1.jpg
     name: Magic Rune (Adventurer, Implement)

--- a/src/packs/src/srd-magic-items/Rune__Champion__5btRdwk6I87mcK4N.yml
+++ b/src/packs/src/srd-magic-items/Rune__Champion__5btRdwk6I87mcK4N.yml
@@ -12,7 +12,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/spells/runes-blue-2.jpg
     name: Magic Rune (Champion, Armor)
@@ -54,7 +53,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/spells/runes-blue-2.jpg
     name: Magic Rune (Champion, Melee Weapon)
@@ -96,7 +94,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/spells/runes-blue-2.jpg
     name: Magic Rune (Champion, Ranged Weapon)
@@ -138,7 +135,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/spells/runes-blue-2.jpg
     name: Magic Rune (Champion, Implement)

--- a/src/packs/src/srd-magic-items/Rune__Epic__mtHqtsRO54qE3v0p.yml
+++ b/src/packs/src/srd-magic-items/Rune__Epic__mtHqtsRO54qE3v0p.yml
@@ -12,7 +12,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/spells/runes-blue-3.jpg
     name: Magic Rune (Epic, Armor)
@@ -54,7 +53,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/spells/runes-blue-3.jpg
     name: Magic Rune (Epic, Melee Weapon)
@@ -96,7 +94,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/spells/runes-blue-3.jpg
     name: Magic Rune (Epic, Ranged Weapon)
@@ -138,7 +135,6 @@ effects:
       archmage:
         duration: EndOfCombat
         ongoingDamage: 0
-        ongoingDamageCrit: false
         ongoingDamageType: ''
     img: systems/archmage/assets/icons/spells/runes-blue-3.jpg
     name: Magic Rune (Epic, Implement)

--- a/src/templates/active-effects/effect.html
+++ b/src/templates/active-effects/effect.html
@@ -199,8 +199,10 @@
                     </div>
 
                     <div class="settings-group">
-                        <strong class="attribute-name">{{localize 'ARCHMAGE.ITEM.ongoingDamageCrit'}}</strong>
-                        <input class="attribute-input" name="ongoingDamageCrit" type="checkbox" {{checked ongoingDamageCrit}}/>
+                        <strong class="attribute-name">{{localize 'ARCHMAGE.ITEM.ongoingDamageMultiplier'}}</strong>
+                        <select class="attribute-input" name="ongoingDamageMultiplier" data-dtype="Number">
+                            {{selectOptions ongoingDamageMultipliers selected=ongoingDamageMultiplier localize=true}}
+                        </select>
                     </div>
 
                     <div class="settings-group form-group" style="padding-top: 10px;">

--- a/src/templates/chat/apply-AE.html
+++ b/src/templates/chat/apply-AE.html
@@ -10,8 +10,9 @@
   {{#if ongoing}}
   <div class="form-group">
     <label>{{localize 'ARCHMAGE.ITEM.ongoingDamage'}}</label>
-    <label><input type="checkbox" name="ongoingHalf" />Half damage</label>
-    <label><input type="checkbox" name="ongoingCrit" />Critical Hit</label>
+    <label><input type="checkbox" name="ongoingHalf" />{{localize 'ARCHMAGE.CHAT.ongoingHalfDamage'}}</label>
+    <label><input type="checkbox" name="ongoingDouble" />{{localize 'ARCHMAGE.CHAT.ongoingDoubleDamage'}}</label>
+    <label><input type="checkbox" name="ongoingTriple" />{{localize 'ARCHMAGE.CHAT.ongoingTripleDamage'}}</label>
   </div>
   {{/if}}
   <div class="form-group">

--- a/src/templates/chat/ongoing-effects-card.html
+++ b/src/templates/chat/ongoing-effects-card.html
@@ -45,7 +45,7 @@
 {{!-- Ongoing damage row partial. --}}
 {{#*inline "ongoing-damage"}}
 <div class="grid grid-7col effect {{#if effect.isCrit}}crit{{/if}}" data-effect-id="{{effect._id}}" data-uuid="{{effect.parent.uuid}}" data-value="{{effect.ongoingDamage}}" data-save="{{effect.flags.archmage.duration}}">
-    <a class="effect-link grid-span-4" draggable="true" data-type="ongoing-damage" data-uuid="{{effect.uuid}}" data-id="{{effect.id}}" data-tooltip="{{effect.ongoingTooltip}}{{#if effect.isCrit}} (x2){{/if}}" data-name="{{effect.name}}"
+    <a class="effect-link grid-span-4" draggable="true" data-type="ongoing-damage" data-uuid="{{effect.uuid}}" data-id="{{effect.id}}" data-tooltip="{{effect.ongoingTooltip}}{{#if effect.isCrit}} (x{{effect.critMult}}){{/if}}" data-name="{{effect.name}}"
         data-value="{{effect.ongoingDamage}}" data-damage-type="{{effect.flags.archmage.ongoingDamageType}}" data-ends="{{effect.flags.archmage.duration}}" data-source="{{effect.origin}}">
         <img class="effects-icon" src="{{effect.img}}" /> <span class="effect-name">{{effect.name}}</span>
     </a>

--- a/src/vue/ArchmageActiveEffectSheetVue.vue
+++ b/src/vue/ArchmageActiveEffectSheetVue.vue
@@ -89,6 +89,7 @@ import {
 } from '@/components';
 import { computed, inject, reactive, toRaw, watch } from 'vue';
 import { concat, localize, numberFormat } from '@/methods/Helpers';
+import { roundOngoingDamage } from '@src/module/active-effects/ongoing-damage.mjs';
 
 const props = defineProps(['context']);
 const foundryEffect = inject('itemDocument')
@@ -138,7 +139,7 @@ const duration = computed(() => {
 });
 
 const ongoingDamage = computed(() => {
-  const dmg = effect.value.flags.archmage.ongoingDamage || 0
+  const dmg = roundOngoingDamage(effect.value.flags.archmage.ongoingDamage || 0)
   const type = effect.value.flags.archmage.ongoingDamageType || ''
   return `${dmg} ongoing ${type} damage`;
 });

--- a/src/vue/components/actor/character/main/CharEffects.vue
+++ b/src/vue/components/actor/character/main/CharEffects.vue
@@ -61,6 +61,7 @@
 
 <script>
 import { concat, localize, numberFormat } from '@/methods/Helpers';
+import { roundOngoingDamage } from '@src/module/active-effects/ongoing-damage.mjs';
 import { reactive, computed, toRefs } from 'vue';
 // This component includes an example of using the composition API
 // https://www.vuemastery.com/pdf/Vue-3-Cheat-Sheet.pdf
@@ -115,7 +116,7 @@ export default {
     }
 
     function getOngoingDamage(effect) {
-      return `${effect.flags.archmage.ongoingDamage} ongoing ${effect.flags.archmage.ongoingDamageType} damage`;
+      return `${roundOngoingDamage(effect.flags.archmage.ongoingDamage)} ongoing ${effect.flags.archmage.ongoingDamageType} damage`;
     }
 
     // Return our custom data, methods, and any imported methods.

--- a/src/vue/components/effects/EffectOngoing.vue
+++ b/src/vue/components/effects/EffectOngoing.vue
@@ -2,7 +2,7 @@
 	<div class="form-group">
 		<label> {{ localize('ARCHMAGE.ITEM.ongoingDamage') }} </label>
 		<div class="field">
-			<input type="number" v-model="flags.ongoingDamage" />
+			<input type="number" step="0.5" v-model="flags.ongoingDamage" />
 		</div>
 	</div>
 
@@ -14,9 +14,13 @@
 	</div>
 
 	<div class="form-group">
-		<label> {{ localize('ARCHMAGE.ITEM.ongoingDamageCrit') }} </label>
+		<label> {{ localize('ARCHMAGE.ITEM.ongoingDamageMultiplier') }} </label>
 		<div class="field">
-			<input type="checkbox" v-model="flags.ongoingDamageCrit" />
+			<select v-model.number="flags.ongoingDamageMultiplier">
+				<option v-for="(label, value) in multipliers" :key="value" :value="Number(value)">
+					{{ localize(label) }}
+				</option>
+			</select>
 		</div>
 	</div>
 </template>
@@ -29,10 +33,13 @@ const props = defineProps(['effect', 'context']);
 const { effect } = props;
 const foundryEffect = inject('itemDocument')
 
+const multipliers = CONFIG.ARCHMAGE.ongoingDamageMultipliers;
+
 const flags = reactive(effect.flags.archmage || {});
+if (!flags.ongoingDamageMultiplier) flags.ongoingDamageMultiplier = 1;
 watch(() => flags, (newValue) => {
 	foundryEffect.setFlag('archmage', 'ongoingDamage', newValue.ongoingDamage);
 	foundryEffect.setFlag('archmage', 'ongoingDamageType', newValue.ongoingDamageType);
-	foundryEffect.setFlag('archmage', 'ongoingDamageCrit', newValue.ongoingDamageCrit);
+	foundryEffect.setFlag('archmage', 'ongoingDamageMultiplier', newValue.ongoingDamageMultiplier);
 }, { deep: true })
 </script>


### PR DESCRIPTION
- Implement 3x ongoing damage modifier (1st tick only) to complement douwwble damage crits (for e.g. empowered sorcerer spells).
- Fix half damage handling to store the exact half value (so that a half damage 2x crit rounds as expected) and change rounding to ceil.
- Fix non-normal save ends parsing and display (for both ongoing damage and conditions).

Note: reimplements and supersedes #568 