### PR TITLE
Feature/refactor triggers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Text files are stored and checked out with LF endings, so that editors on Windows
+# don't leave whole-file diffs behind. Most of the repo is already LF.
+* text=auto eol=lf
+
+# Assets git shouldn't inspect or convert.
+*.jpg binary
+*.png binary
+*.webp binary
+*.otf binary
+*.zip binary

--- a/src/languages/en.yaml
+++ b/src/languages/en.yaml
@@ -239,8 +239,6 @@ ARCHMAGE:
     allowPasteParsingName: Paste Roll Parsing
     hideExtraRollsHint: If enabled, powers with multiple attack rolls will display at most one attack per targeted token if any is targeted.
     hideExtraRollsName: Limit extra rolls to targeted tokens
-    hideInsteadOfOpaqueHint: Enable this if you prefer not seeing inactive details at all.
-    hideInsteadOfOpaqueName: Hide inactive Features / Triggers instead of making them faded-out
     initiativeDexTiebreakerHint: If enabled initiative ties will be resolved using the initiative modifier; if not, monsters win by default.
     initiativeDexTiebreakerName: Initiative Modifier as Tiebreaker
     initiativeStaticNpcHint: If enabled NPC actors will always 'take 10' on initiative rolls.

--- a/src/module/Triggers/CritTrigger.mjs
+++ b/src/module/Triggers/CritTrigger.mjs
@@ -1,20 +1,15 @@
 import ITrigger from "./ITrigger.mjs";
 
-export default class CritTrigger extends ITrigger{
-    isActive(triggerText, rollResult, hitEvaluationResults) {
-        let active = undefined;
-
-        if (rollResult == undefined) return active;
-
-        // TODO: Handle expanded crit range
-        return rollResult == 20;
+export default class CritTrigger extends ITrigger {
+    appliesTo(label) {
+        return ITrigger.mentions(label, ITrigger.word("crit"), ["s", "ical", "icals"]);
     }
 
-    triggersOn() {
-        return [ game.i18n.localize("ARCHMAGE.CHAT.crit").toLowerCase() ];
-    }
-
-    doesntTriggerOn() {
-        return [ ];
+    // The crit range is not fixed at 20: it moves with the optional 18+ rule, with attacker and
+    // target crit modifiers, and with the 1e barbarian's double-crit. HitEvaluation already
+    // resolves all of that per roll, so we just read its verdict.
+    test(outcome) {
+        if (outcome.crit === undefined) return undefined;
+        return outcome.crit;
     }
 }

--- a/src/module/Triggers/EvenTrigger.mjs
+++ b/src/module/Triggers/EvenTrigger.mjs
@@ -1,36 +1,12 @@
 import ITrigger from "./ITrigger.mjs";
 
-export default class EvenTrigger extends ITrigger{
-    isActive(triggerText, rollResult, hitEvaluationResults) {
-        let active = undefined;
-
-        if (rollResult == undefined) return active;
-        
-        if (rollResult % 2 == 0) {
-            active = true;
-            if (hitEvaluationResults?.hasHit != undefined) {
-                if (triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.hit").toLowerCase()) && !hitEvaluationResults.hasHit) {
-                    active = false;
-                }
-            }
-            if (hitEvaluationResults?.hasMissed != undefined) {
-                if (triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.miss").toLowerCase()) && !hitEvaluationResults.hasMissed) {
-                    active = false;
-                }
-            }
-        }
-        else {
-            active = false;
-        }
-
-        return active;
+export default class EvenTrigger extends ITrigger {
+    appliesTo(label) {
+        return ITrigger.mentions(label, ITrigger.word("even"));
     }
 
-    triggersOn() {
-        return [ game.i18n.localize("ARCHMAGE.CHAT.even").toLowerCase() ];
-    }
-
-    doesntTriggerOn() {
-        return [ game.i18n.localize("ARCHMAGE.CHAT.odd").toLowerCase() ];
+    test(outcome) {
+        if (outcome.natural === undefined) return undefined;
+        return outcome.natural % 2 === 0;
     }
 }

--- a/src/module/Triggers/HitTrigger.mjs
+++ b/src/module/Triggers/HitTrigger.mjs
@@ -1,22 +1,12 @@
 import ITrigger from "./ITrigger.mjs";
 
-export default class HitTrigger extends ITrigger{
-    isActive(triggerText, rollResult, hitEvaluationResults) {
-        if (hitEvaluationResults == undefined) return undefined;
-        
-        if (hitEvaluationResults.hasHit) {
-            return true;
-        }
-        else {
-            return false;
-        }
+export default class HitTrigger extends ITrigger {
+    appliesTo(label) {
+        return ITrigger.mentions(label, ITrigger.word("hit"), ["s"]);
     }
 
-    triggersOn() {
-        return [ game.i18n.localize("ARCHMAGE.CHAT.hit").toLowerCase() ];
-    }
-
-    doesntTriggerOn() {
-        return [ game.i18n.localize("ARCHMAGE.CHAT.even").toLowerCase(), game.i18n.localize("ARCHMAGE.CHAT.odd").toLowerCase() ];
+    test(outcome) {
+        if (outcome.hit === undefined) return undefined;
+        return outcome.hit;
     }
 }

--- a/src/module/Triggers/ITrigger.mjs
+++ b/src/module/Triggers/ITrigger.mjs
@@ -1,17 +1,78 @@
 /**
+ * A single condition that a trigger row can express, such as "even", "hit" or "natural 16+".
+ *
+ * A row label is a conjunction of conditions ("natural even hit" means even AND hit), so each
+ * trigger only answers for its own condition: whether the label mentions it (`appliesTo`) and
+ * whether a given roll satisfies it (`test`). Combining them is Triggers' job.
+ *
  * @interface ITrigger
  */
 export default class ITrigger {
-    
-    isActive(triggerText, rollResult, hitEvaluationResults) {
-        throw new Error("A subclass of ITrigger must implement the isActive method");
+
+    /**
+     * Does the row label mention this trigger's condition?
+     * @param {string} label Lowercased row label, as returned by Triggers.labelOf.
+     * @returns {boolean}
+     */
+    appliesTo(label) {
+        throw new Error("A subclass of ITrigger must implement the appliesTo method");
     }
 
-    triggersOn() {
-        throw new Error("A subclass of ITrigger must implement the triggersOn method");
+    /**
+     * Is this trigger's condition satisfied by a single roll outcome?
+     * @param {object} outcome One entry of HitEvaluation's rollOutcomes.
+     * @param {string} label Lowercased row label, as returned by Triggers.labelOf.
+     * @returns {boolean|undefined} undefined when the outcome carries no information to decide,
+     *   for example hit/miss when no target was selected.
+     */
+    test(outcome, label) {
+        throw new Error("A subclass of ITrigger must implement the test method");
     }
 
-    doesntTriggerOn() {
-        throw new Error("A subclass of ITrigger must implement the doesntTriggerOn method");
+    /**
+     * Localized, lowercased keyword from the ARCHMAGE.CHAT block.
+     * @param {string} key
+     * @returns {string}
+     */
+    static word(key) {
+        return game.i18n.localize(`ARCHMAGE.CHAT.${key}`).toLowerCase();
+    }
+
+    /**
+     * Does `label` mention `word` as a whole word?
+     *
+     * Boundaries are expressed as "not a letter or a digit" rather than \b, so that translations
+     * containing accented characters behave. Inflections have to be listed explicitly - matching
+     * any suffix would make "miss" match "missile" and "hit" match "hitherto".
+     *
+     * @param {string} label
+     * @param {string} word
+     * @param {string[]} [suffixes] Optional trailing forms to also accept, e.g. ['s', 'es'].
+     * @returns {boolean}
+     */
+    static mentions(label, word, suffixes = []) {
+        const tail = suffixes.length > 0 ? `(?:${suffixes.join('|')})?` : '';
+        const regex = new RegExp(
+            `${ITrigger.NOT_ALPHANUM_BEFORE}${ITrigger._escape(word)}${tail}${ITrigger.NOT_ALPHANUM_AFTER}`, 'u');
+        return regex.test(label);
+    }
+
+    /**
+     * Builds a regex anchored on the localized "natural" keyword, so that the number-matching
+     * triggers can only read a score that actually follows it.
+     * @param {string} pattern Regex source appended right after the keyword.
+     * @returns {RegExp}
+     */
+    static naturalRegex(pattern) {
+        const natural = ITrigger._escape(ITrigger.word("natural"));
+        return new RegExp(`${ITrigger.NOT_ALPHANUM_BEFORE}${natural}${pattern}`, 'u');
+    }
+
+    static get NOT_ALPHANUM_BEFORE() { return '(?<![\\p{L}\\p{N}])'; }
+
+    static get NOT_ALPHANUM_AFTER() { return '(?![\\p{L}\\p{N}])'; }
+
+    static _escape(text) {
+        return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     }
 }

--- a/src/module/Triggers/MissTrigger.mjs
+++ b/src/module/Triggers/MissTrigger.mjs
@@ -1,22 +1,12 @@
 import ITrigger from "./ITrigger.mjs";
 
-export default class MissTrigger extends ITrigger{
-    isActive(triggerText, rollResult, hitEvaluationResults) {
-        if (hitEvaluationResults == undefined) return undefined;
-
-        if (hitEvaluationResults.hasMissed) {
-            return true;
-        }
-        else {
-            return false;
-        }
+export default class MissTrigger extends ITrigger {
+    appliesTo(label) {
+        return ITrigger.mentions(label, ITrigger.word("miss"), ["es"]);
     }
 
-    triggersOn() {
-        return [ game.i18n.localize("ARCHMAGE.CHAT.miss").toLowerCase() ];
-    }
-
-    doesntTriggerOn() {
-        return [ game.i18n.localize("ARCHMAGE.CHAT.even").toLowerCase(), game.i18n.localize("ARCHMAGE.CHAT.odd").toLowerCase() ];
+    test(outcome) {
+        if (outcome.hit === undefined) return undefined;
+        return !outcome.hit;
     }
 }

--- a/src/module/Triggers/NaturalExactTrigger.mjs
+++ b/src/module/Triggers/NaturalExactTrigger.mjs
@@ -1,36 +1,25 @@
 import ITrigger from "./ITrigger.mjs";
 
+/**
+ * "Natural 1" - the natural roll has to be exactly this score.
+ *
+ * The score has to follow the "natural" keyword, and must not be the start of a threshold
+ * ("natural 16+") or of a range ("natural 1-5"), both of which have their own trigger.
+ */
 export default class NaturalExactTrigger extends ITrigger {
-    /**
-     * @param triggerText
-     * @param rollResult
-     * @param hitEvaluationResults
-     * @returns {boolean}
-     */
-    isActive(triggerText, rollResult, hitEvaluationResults) {
-        let active = undefined;
-
-        // This regex just finds any numbers in the string, and we use the first one
-        var regex = new RegExp("\\d+");
-        var scoreToMatchArray = regex.exec(triggerText);
-        if (scoreToMatchArray && scoreToMatchArray.length == 1) {
-            var scoreToMatch = parseInt(scoreToMatchArray[0]);
-            if (rollResult == scoreToMatch) {
-                active = true;
-            }
-            else {
-                active = false;
-            }
-        }
-
-        return active;
+    appliesTo(label) {
+        return this._score(label) !== undefined;
     }
 
-    triggersOn() {
-        return [ game.i18n.localize("ARCHMAGE.CHAT.natural").toLowerCase() ];
+    test(outcome, label) {
+        if (outcome.natural === undefined) return undefined;
+        const score = this._score(label);
+        if (score === undefined) return undefined;
+        return outcome.natural === score;
     }
 
-    doesntTriggerOn() {
-        return [ game.i18n.localize("ARCHMAGE.CHAT.hit").toLowerCase(), game.i18n.localize("ARCHMAGE.CHAT.miss").toLowerCase(), "+" ];
+    _score(label) {
+        const match = label.match(ITrigger.naturalRegex('\\s*(\\d+)(?!\\d)(?!\\s*[+\\-])'));
+        return match ? parseInt(match[1]) : undefined;
     }
 }

--- a/src/module/Triggers/NaturalMatchTrigger.mjs
+++ b/src/module/Triggers/NaturalMatchTrigger.mjs
@@ -1,30 +1,25 @@
 import ITrigger from "./ITrigger.mjs";
 
-export default class NaturalMatchTrigger extends ITrigger{
-    isActive(triggerText, rollResult, hitEvaluationResults) {
-        let active = undefined;
-
-        // This regex just finds any numbers in the string, and we use the first one
-        var regex = new RegExp("\\d+");
-        var scoreToBeatArray = regex.exec(triggerText);
-        if (scoreToBeatArray && scoreToBeatArray.length == 1) {
-            var scoreToBeat = parseInt(scoreToBeatArray[0]);
-            if (rollResult >= scoreToBeat) {
-                active = true;
-            }
-            else {
-                active = false;
-            }
-        }
-
-        return active;
+/**
+ * "Natural 16+" - the natural roll has to meet or beat a threshold.
+ *
+ * The threshold is read as "a number immediately followed by a +", rather than from a bare "+"
+ * anywhere in the row: the latter also matched plus signs coming from damage formulas.
+ */
+export default class NaturalMatchTrigger extends ITrigger {
+    appliesTo(label) {
+        return this._threshold(label) !== undefined;
     }
 
-    triggersOn() {
-        return [ "+" ];
+    test(outcome, label) {
+        if (outcome.natural === undefined) return undefined;
+        const threshold = this._threshold(label);
+        if (threshold === undefined) return undefined;
+        return outcome.natural >= threshold;
     }
 
-    doesntTriggerOn() {
-        return [ game.i18n.localize("ARCHMAGE.CHAT.hit").toLowerCase(), game.i18n.localize("ARCHMAGE.CHAT.miss").toLowerCase() ];
+    _threshold(label) {
+        const match = label.match(/(\d+)\s*\+/);
+        return match ? parseInt(match[1]) : undefined;
     }
 }

--- a/src/module/Triggers/NaturalRangeTrigger.mjs
+++ b/src/module/Triggers/NaturalRangeTrigger.mjs
@@ -1,0 +1,29 @@
+import ITrigger from "./ITrigger.mjs";
+
+/**
+ * "Natural 1-5" - the natural roll has to fall inside an inclusive range.
+ *
+ * Common in monster stat blocks. Without this, the exact-score trigger used to read such a row
+ * as "natural 1" and light it up on the wrong roll.
+ */
+export default class NaturalRangeTrigger extends ITrigger {
+    appliesTo(label) {
+        return this._range(label) !== undefined;
+    }
+
+    test(outcome, label) {
+        if (outcome.natural === undefined) return undefined;
+        const range = this._range(label);
+        if (range === undefined) return undefined;
+        return outcome.natural >= range.from && outcome.natural <= range.to;
+    }
+
+    _range(label) {
+        const match = label.match(ITrigger.naturalRegex('\\s*(\\d+)\\s*-\\s*(\\d+)'));
+        if (!match) return undefined;
+        const from = parseInt(match[1]);
+        const to = parseInt(match[2]);
+        if (from > to) return undefined;
+        return {from, to};
+    }
+}

--- a/src/module/Triggers/OddTrigger.mjs
+++ b/src/module/Triggers/OddTrigger.mjs
@@ -1,36 +1,12 @@
 import ITrigger from "./ITrigger.mjs";
 
-export default class OddTrigger extends ITrigger{
-    isActive(triggerText, rollResult, hitEvaluationResults) {
-        let active = undefined;
-
-        if (rollResult == undefined) return active;
-        
-        if (rollResult % 2 == 1) {
-            active = true;
-            if (hitEvaluationResults?.hasHit != undefined) {
-                if (triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.hit").toLowerCase()) && !hitEvaluationResults.hasHit) {
-                    active = false;
-                }
-            }
-            if (hitEvaluationResults?.hasMissed != undefined) {
-                if (triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.miss").toLowerCase()) && !hitEvaluationResults.hasMissed) {
-                    active = false;
-                }
-            }
-        }
-        else {
-            active = false;
-        }
-
-        return active;
+export default class OddTrigger extends ITrigger {
+    appliesTo(label) {
+        return ITrigger.mentions(label, ITrigger.word("odd"));
     }
 
-    triggersOn() {
-        return [ game.i18n.localize("ARCHMAGE.CHAT.odd").toLowerCase() ];
-    }
-
-    doesntTriggerOn() {
-        return [ ];
+    test(outcome) {
+        if (outcome.natural === undefined) return undefined;
+        return outcome.natural % 2 === 1;
     }
 }

--- a/src/module/Triggers/Triggers.mjs
+++ b/src/module/Triggers/Triggers.mjs
@@ -61,6 +61,12 @@ export default class Triggers {
    * condition it mentions has to hold - and hold for the *same* roll, otherwise a row could go
    * active on one target's parity and another target's hit.
    *
+   * A power may roll several attacks, and they are alternatives: the row applies if *any* roll
+   * satisfies it. So one roll cannot rule the row out on its own - it is only inapplicable when
+   * every roll contradicts it. A roll that contradicts nothing but cannot be confirmed either
+   * (an even natural with no target to settle the hit) leaves the row undecided rather than
+   * inactive, which is what a bare "hit" row on the same attack already reports.
+   *
    * @param {string|null} label As returned by labelOf.
    * @param {object[]} rollOutcomes HitEvaluation's per-roll outcomes.
    * @returns {boolean|undefined} true when the row applies, false when it definitely does not,
@@ -73,12 +79,15 @@ export default class Triggers {
     const conditions = this.registeredTriggers.filter(trigger => trigger.appliesTo(label));
     if (conditions.length === 0) return undefined;
 
-    let anyRuledOut = false;
-    for (const outcome of rollOutcomes ?? []) {
+    const outcomes = rollOutcomes ?? [];
+    let anyUndecided = false;
+    for (const outcome of outcomes) {
       const verdicts = conditions.map(condition => condition.test(outcome, label));
       if (verdicts.every(verdict => verdict === true)) return true;
-      if (verdicts.some(verdict => verdict === false)) anyRuledOut = true;
+      // Nothing about this roll contradicts the row, so it may yet apply to it.
+      if (!verdicts.some(verdict => verdict === false)) anyUndecided = true;
     }
-    return anyRuledOut ? false : undefined;
+    if (outcomes.length === 0 || anyUndecided) return undefined;
+    return false;
   }
 }

--- a/src/module/Triggers/Triggers.mjs
+++ b/src/module/Triggers/Triggers.mjs
@@ -2,9 +2,10 @@ import CritTrigger from "./CritTrigger.mjs";
 import EvenTrigger from "./EvenTrigger.mjs";
 import HitTrigger from "./HitTrigger.mjs";
 import MissTrigger from "./MissTrigger.mjs";
-import NaturalMatchTrigger from "./NaturalMatchTrigger.mjs";
-import OddTrigger from "./OddTrigger.mjs";
 import NaturalExactTrigger from "./NaturalExactTrigger.mjs";
+import NaturalMatchTrigger from "./NaturalMatchTrigger.mjs";
+import NaturalRangeTrigger from "./NaturalRangeTrigger.mjs";
+import OddTrigger from "./OddTrigger.mjs";
 
 export default class Triggers {
 
@@ -14,39 +15,70 @@ export default class Triggers {
       new OddTrigger(),
       new HitTrigger(),
       new MissTrigger(),
-      new NaturalMatchTrigger(),
       new CritTrigger(),
+      new NaturalMatchTrigger(),
+      new NaturalRangeTrigger(),
       new NaturalExactTrigger()
     ];
   }
 
-  evaluateRow(row_text, $rolls, hitEvaluationResults) {
-    var triggerText = row_text.toLowerCase();
+  /**
+   * The label of a card row: the text of its leading <strong>, without the trailing ':',
+   * lowercased. This is the only part of a row that states conditions.
+   *
+   * Rows that carry no such label are free-form prose (a power's description, say). Returning null
+   * for those keeps their text from being read as conditions - we must never fade out a row of
+   * plain rules text because it happened to contain the word "hit".
+   *
+   * Note this reads text, never HTML: markup attributes contribute stray digits and plus signs
+   * that a threshold like "16+" would otherwise pick up.
+   *
+   * @param {jQuery} $row A .card-prop element.
+   * @returns {string|null}
+   */
+  static labelOf($row) {
+    const $label = $row.children('strong').first();
+    if ($label.length === 0) return null;
+    const text = $label.text().trim();
+    if (!text.endsWith(':')) return null;
+    return text.slice(0, -1).toLowerCase();
+  }
 
-    // Only match against the part before ':'
-    if (triggerText.includes(":")) {
-      triggerText = triggerText.split(":", 2)[0];
+  /**
+   * Does this label state any condition we know how to evaluate?
+   * @param {string|null} label As returned by labelOf.
+   * @returns {boolean}
+   */
+  isTriggerRow(label) {
+    if (!label) return false;
+    return this.registeredTriggers.some(trigger => trigger.appliesTo(label));
+  }
+
+  /**
+   * Evaluate a trigger row against the rolls that were made.
+   *
+   * A label states a conjunction of conditions ("natural even hit" is even AND hit), so every
+   * condition it mentions has to hold - and hold for the *same* roll, otherwise a row could go
+   * active on one target's parity and another target's hit.
+   *
+   * @param {string|null} label As returned by labelOf.
+   * @param {object[]} rollOutcomes HitEvaluation's per-roll outcomes.
+   * @returns {boolean|undefined} true when the row applies, false when it definitely does not,
+   *   undefined when there is not enough information to tell - either the row states no condition
+   *   we recognize, or the outcomes cannot decide one (hit/miss with no target selected, parity
+   *   with no roll). Callers should present undefined as a possible match, never as a match.
+   */
+  evaluateRow(label, rollOutcomes) {
+    if (!label) return undefined;
+    const conditions = this.registeredTriggers.filter(trigger => trigger.appliesTo(label));
+    if (conditions.length === 0) return undefined;
+
+    let anyRuledOut = false;
+    for (const outcome of rollOutcomes ?? []) {
+      const verdicts = conditions.map(condition => condition.test(outcome, label));
+      if (verdicts.every(verdict => verdict === true)) return true;
+      if (verdicts.some(verdict => verdict === false)) anyRuledOut = true;
     }
-
-    // We've previously setup all d20's in the rolls to have a value. Rolls that aren't a d20 will have a value of 0, which gets filtered out.
-    var rollResults = $rolls.toArray().map(x => x.d20result).filter(x => x > 0);
-    for (let rollResult of rollResults) {
-      for (let x = 0; x < this.registeredTriggers.length; x++) {
-        let trigger = this.registeredTriggers[x];
-        let triggers_on = trigger.triggersOn();
-        let doesnt_trigger_on = trigger.doesntTriggerOn();
-
-        if (triggers_on.length > 0 && !triggers_on.some(x => triggerText.includes(x))) {
-            continue;
-        }
-        if (doesnt_trigger_on.some(x => triggerText.includes(x))) {
-            continue;
-        }
-
-        if (trigger.isActive(triggerText, rollResult, hitEvaluationResults)) {
-            return true;
-        }
-      }
-    }
+    return anyRuledOut ? false : undefined;
   }
 }

--- a/src/module/archmage.js
+++ b/src/module/archmage.js
@@ -428,15 +428,6 @@ Hooks.once('init', async function() {
     config: true
   });
 
-  game.settings.register("archmage", "hideInsteadOfOpaque", {
-    name: "ARCHMAGE.SETTINGS.hideInsteadOfOpaqueName",
-    hint: "ARCHMAGE.SETTINGS.hideInsteadOfOpaqueHint",
-    scope: "world",
-    type: Boolean,
-    default: false,
-    config: true
-  });
-
   game.settings.register("archmage", "enableOngoingEffectsMessages", {
     name: "ARCHMAGE.SETTINGS.enableOngoingEffectsMessagesName",
     hint: "ARCHMAGE.SETTINGS.enableOngoingEffectsMessagesHint",
@@ -1019,7 +1010,6 @@ Hooks.on('renderSettingsConfig', (app, html, data) => {
         'hideExtraRolls',
         'showDefensesInChat',
         'showVulnsInChat',
-        'hideInsteadOfOpaque',
         'roundUpDamageApplication',
         'allowTargetDamageApplication',
         'allowRerolls',

--- a/src/module/hooks/preCreateChatMessageHandler.mjs
+++ b/src/module/hooks/preCreateChatMessageHandler.mjs
@@ -141,7 +141,6 @@ export default class preCreateChatMessageHandler {
 
     static handle(data, options, userId) {
         let $content = $(`<div class="wrapper">${data.content}</div>`);
-        let $rolls = $content.find('.inline-result');
         let updated_content = null;
         let hitEvaluationResults = undefined;
         let targets = [...game.user.targets.values()]; // needed to checkRowText of npcs
@@ -202,6 +201,7 @@ export default class preCreateChatMessageHandler {
         let sequencerReversed = options.sequencer?.reversed;
 
         let highestPowerLevelToHighlight;
+        const triggers = new Triggers();
 
         if ($rows.length > 0) {
 
@@ -242,8 +242,6 @@ export default class preCreateChatMessageHandler {
                 }
 
                 if (hitEvaluationResults) {
-                    $rolls = hitEvaluationResults.$rolls;
-
                     // Append hit targets to text
                     if (row_text_clean.startsWith(game.i18n.localize("ARCHMAGE.CHAT.hit") + ':') && hitEvaluationResults.targetsHit.length > 0) {
                         $row_self.find('strong').after("<span class='dc-target'> (" + HitEvaluation.getNames(
@@ -264,28 +262,19 @@ export default class preCreateChatMessageHandler {
                 }
 
                 // Determine if this line is a "Trigger" - something like "Natural 16+:" or "Even Miss:"
-                var triggerText = row_text.toLowerCase();
-                if (triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.natural").toLowerCase()) ||
-                    triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.miss").toLowerCase() + ':') ||
-                    triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.hit").toLowerCase() + ':') ||
-                    triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.crit").toLowerCase() + ':') ||
-                    triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.hitEven").toLowerCase() + ':') ||
-                    triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.hitOdd").toLowerCase() + ':')) {
-                    let triggers = new Triggers();
-                    let active = triggers.evaluateRow(row_text, $rolls, hitEvaluationResults);
+                const row_label = Triggers.labelOf($row_self);
+                if (triggers.isTriggerRow(row_label)) {
+                    let active = triggers.evaluateRow(row_label, hitEvaluationResults?.rollOutcomes);
 
                     if (active == undefined) {
                         $row_self.addClass("trigger-unknown");
                     } else if (active) {
                         $row_self.addClass("trigger-active");
-                        if (triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.miss").toLowerCase() + ':')) {
+                        if (row_label.includes(game.i18n.localize("ARCHMAGE.CHAT.miss").toLowerCase())) {
                             $row_self.addClass("trigger-miss");
                         }
                     } else {
                         $row_self.addClass("trigger-inactive");
-                        if (game.settings.get("archmage", "hideInsteadOfOpaque")) {
-                            $row_self.addClass("hide");
-                        }
                     }
                 }
 

--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -45,7 +45,7 @@ export class ItemArchmage extends Item {
     // For powers with a level, show a dialog to set level and consume-usage.
     const rollOptions = await this._rollTemporaryOverrides();
     if (!rollOptions) return;
-    const { overrides: tempOverrides, consumeUsage, consumeResources } = rollOptions;
+    const { overrides: tempOverrides, consumeUsage, consumeResources, modified } = rollOptions;
 
     // Check remaining uses, honoring the consume-usage choice from the dialog.
     let early_exit = await this._rollUsesCheck(itemUpdateData, usageMode, consumeUsage);
@@ -83,7 +83,7 @@ export class ItemArchmage extends Item {
     let token = this._rollGetToken(itemToRender);
 
     // Render the chat card.
-    let chatData = await this._rollRender(itemUpdateData, actorUpdateData, itemToRender, rollData, token, { tempOverrides, consumeUsage, consumeResources });
+    let chatData = await this._rollRender(itemUpdateData, actorUpdateData, itemToRender, rollData, token, { modified });
 
     // Evaluate outcomes and prepare animations.
     let [ sequencerAnim, hitEvalRes ] = preCreateChatMessageHandler.handle(chatData, {
@@ -274,8 +274,15 @@ export class ItemArchmage extends Item {
 
   async _rollTemporaryOverrides() {
     let overrides = {};
-    if (this.type != 'power') return { overrides, consumeUsage: true };
-    let baseLvl = this.system.powerLevel?.value ?? 0;
+    // Descriptions of what the *user* deliberately changed, for the "(modified)" label on the
+    // chat card. Only the dialog below writes to this. Automatic adjustments - the "Cast at
+    // Actor Level" flag in particular - are not modifications and must never land here, which is
+    // why this is recorded at the point of choice instead of inferred later by comparing levels.
+    let modified = [];
+    if (this.type != 'power') return { overrides, consumeUsage: true, consumeResources: true, modified };
+    // Powers store their level as a number or a numeric string, so normalize before comparing.
+    let baseLvl = Number(this.system.powerLevel?.value ?? 0);
+    if (!Number.isFinite(baseLvl)) baseLvl = 0;
     if (this.itemActor?.getFlag("archmage", "overridePowerLevel")) {
       baseLvl = Math.max(this.itemActor.system.attributes.level.value, baseLvl);
     }
@@ -293,7 +300,7 @@ export class ItemArchmage extends Item {
     // Skip the dialog if alt isn't held, or there's nothing for it to display.
     if (!event?.altKey || (!hasSpellLevels && !hasUses && !hasResources)) {
       overrides['system.powerLevel.value'] = baseLvl;
-      return { overrides, consumeUsage: true, consumeResources: true };
+      return { overrides, consumeUsage: true, consumeResources: true, modified };
     }
 
     const content = `
@@ -324,8 +331,16 @@ export class ItemArchmage extends Item {
         const consume = hasUses ? form.consumeUsage.checked : true;
         const consumeRes = hasResources ? form.consumeResources.checked : true;
         overrides['system.powerLevel.value'] = finalLvl;
+        // Compared against the level the dialog defaulted to, not the one stored on the power:
+        // the question is whether the user picked something other than what would have happened
+        // anyway. Both sides are numbers by this point.
+        if (finalLvl !== baseLvl) {
+          modified.push(game.i18n.format("ARCHMAGE.CHAT.modifiedLevel", { level: finalLvl }));
+        }
+        if (!consume) modified.push(game.i18n.localize("ARCHMAGE.CHAT.modifiedNoUsage"));
+        if (!consumeRes) modified.push(game.i18n.localize("ARCHMAGE.CHAT.modifiedNoResources"));
         resolved = true;
-        resolve({ overrides, consumeUsage: consume, consumeResources: consumeRes });
+        resolve({ overrides, consumeUsage: consume, consumeResources: consumeRes, modified });
       };
 
       let buttons;
@@ -658,17 +673,8 @@ export class ItemArchmage extends Item {
     // Basic template rendering data
     const template = `systems/archmage/templates/chat/${this.type.toLowerCase()}-card.html`
 
-    // Build a list of human-readable override descriptions for the "(modified)" tooltip.
-    const modifiedParts = [];
-    const { tempOverrides = {}, consumeUsage = true, consumeResources = true } = rollContext;
-    const origLvl = this.system.powerLevel?.value;
-    const newLvl = tempOverrides['system.powerLevel.value'];
-    // tempOverrides will set the new level to 0 even when the power doesn't have a level set
-    if (newLvl !== undefined && newLvl !== "" && newLvl !== (origLvl || 0)) {
-      modifiedParts.push(game.i18n.format("ARCHMAGE.CHAT.modifiedLevel", { level: newLvl }));
-    }
-    if (!consumeUsage) modifiedParts.push(game.i18n.localize("ARCHMAGE.CHAT.modifiedNoUsage"));
-    if (!consumeResources) modifiedParts.push(game.i18n.localize("ARCHMAGE.CHAT.modifiedNoResources"));
+    // The roll dialog reports what the user changed; we don't try to infer it from the values.
+    const { modified = [] } = rollContext;
 
     const templateData = {
       actor: this.itemActor,
@@ -676,7 +682,7 @@ export class ItemArchmage extends Item {
       item: itemToRender,
       data: await itemToRender.getChatData({ rollData: rollData }, true),
       usageClass: this._getUsageClass(itemToRender),
-      modifiedTooltip: modifiedParts.length ? modifiedParts.join(", ") : null
+      modifiedTooltip: modified.length ? modified.join(", ") : null
     };
 
     // Basic chat message data

--- a/src/module/rolls/HitEvaluation.mjs
+++ b/src/module/rolls/HitEvaluation.mjs
@@ -13,6 +13,10 @@ export default class HitEvaluation {
         let vulnerabilities = new Set();
         let hasHit = undefined;
         let hasMissed = undefined;
+        // One entry per d20 roll, in roll order. Unlike the targetsHit/targetsMissed pairs below,
+        // this keeps each roll's natural value, crit state and hit state together, which is what
+        // trigger rows need to evaluate conditions like "natural even hit" against a single roll.
+        let rollOutcomes = [];
 
         let targetedDefenses = HitEvaluation._getTargetDefenses(row_text);
         const baseCritrange = game.settings.get("archmage", "optionalBaseCritRange") ? 18 : 20;
@@ -22,6 +26,11 @@ export default class HitEvaluation {
         if ($rolls.length == 0) {
           // No rolls means it's an auto-hit
           targetsHit = targets;
+          hasHit = true;
+          hasMissed = false;
+          // A rollless outcome: enough to resolve "hit"/"miss" rows, not the roll-dependent ones.
+          rollOutcomes.push({natural: undefined, total: undefined, hit: true, crit: undefined,
+            fumble: undefined, target: undefined, defense: undefined});
         } else {
           let targetsToProcess = Math.min($rolls.length, targets.length);
           $rolls.each(function (roll_index) {
@@ -92,11 +101,26 @@ export default class HitEvaluation {
             $rolls[roll_index] = $roll_self[0];
             $rolls[roll_index].d20result = rollResult;
 
+            // Record what we know about this roll on its own. Hit state is filled in below, and
+            // stays undefined when there is no target to resolve it against.
+            const outcome = {natural: rollResult, total: rollTotal, hit: undefined, crit: hasCrit,
+              fumble: hasFumbled, target: target, defense: undefined};
+            rollOutcomes.push(outcome);
+
             // Target analysis, only perform if we actually have targets
             if (roll_index >= targetsToProcess) return;
             var targetDefense = HitEvaluation._getTargetDefenseValue(target, targetedDefenses);
+            outcome.defense = targetDefense;
             if (targetDefense != undefined) {
-              var hit = rollTotal >= targetDefense;
+              // The natural roll can override the arithmetic in both directions: a crit always
+              // counts as a hit even when the total falls short of the defense, and a natural 1
+              // always misses however high the total gets. Without this a natural 20 that doesn't
+              // beat the defense reads as a crit *and* a miss, lighting up a "Crit:" and a
+              // "Miss:" row off the same roll.
+              // Note this only decides hit/miss. What a fumble does to miss damage is left to the
+              // GM, like the rest of damage application.
+              var hit = (rollTotal >= targetDefense || hasCrit) && !hasFumbled;
+              outcome.hit = hit;
               if (hit) {
                 targetsHit.push(target);
                 targetsCrit.push(hasCrit);
@@ -128,6 +152,7 @@ export default class HitEvaluation {
             targetsFumbled: targetsFumbled,
             hasHit: hasHit,
             hasMissed: hasMissed,
+            rollOutcomes: rollOutcomes,
             defenses: defenses,
             vulnerabilities: Array.from(vulnerabilities),
             $rolls: $rolls

--- a/src/module/rolls/HitEvaluation.mjs
+++ b/src/module/rolls/HitEvaluation.mjs
@@ -101,10 +101,12 @@ export default class HitEvaluation {
             $rolls[roll_index] = $roll_self[0];
             $rolls[roll_index].d20result = rollResult;
 
-            // Record what we know about this roll on its own. Hit state is filled in below, and
-            // stays undefined when there is no target to resolve it against.
-            const outcome = {natural: rollResult, total: rollTotal, hit: undefined, crit: hasCrit,
-              fumble: hasFumbled, target: target, defense: undefined};
+            // Record what we know about this roll on its own. A crit hits whatever the target's
+            // defense turns out to be, so it settles the hit state by itself and a trigger row can
+            // rely on it with nothing targeted. Any other roll stays undefined until there is a
+            // target to resolve it against, below.
+            const outcome = {natural: rollResult, total: rollTotal, hit: hasCrit ? true : undefined,
+              crit: hasCrit, fumble: hasFumbled, target: target, defense: undefined};
             rollOutcomes.push(outcome);
 
             // Target analysis, only perform if we actually have targets

--- a/src/module/setup/damageApplicator.js
+++ b/src/module/setup/damageApplicator.js
@@ -206,9 +206,9 @@ export class DamageApplicator {
           if (hitEvaluationResults.defenses.length > 0) {
             // @todo Re-evaluate rolls here.
             const rows = element.closest('.card-row').querySelectorAll('.card-prop');
+            const triggers = new Triggers();
             rows.forEach((rowSelf) => {
               let $rowSelf = $(rowSelf);
-              let rowSelfText = $rowSelf.html();
               const rowCleanText = $rowSelf.text();
 
               // Remove existing targets.
@@ -232,15 +232,9 @@ export class DamageApplicator {
                 $rowSelf.append("<span class='dc-target'> (" + hitEvaluationResults.defenses.join(", ") + ") </span>")
               }
 
-              let triggerText = rowSelfText.toLowerCase();
-              if (triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.natural").toLowerCase()) ||
-                triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.miss").toLowerCase() + ':') ||
-                triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.hit").toLowerCase() + ':') ||
-                triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.crit").toLowerCase() + ':') ||
-                triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.hitEven").toLowerCase() + ':') ||
-                triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.hitOdd").toLowerCase() + ':')) {
-                let triggers = new Triggers();
-                let active = triggers.evaluateRow(rowSelfText, hitEvaluationResults.$rolls, hitEvaluationResults);
+              const rowLabel = Triggers.labelOf($rowSelf);
+              if (triggers.isTriggerRow(rowLabel)) {
+                let active = triggers.evaluateRow(rowLabel, hitEvaluationResults.rollOutcomes);
 
                 // Remove previous classes.
                 $rowSelf.removeClass('trigger-unknown')
@@ -252,14 +246,11 @@ export class DamageApplicator {
                   $rowSelf.addClass("trigger-unknown");
                 } else if (active) {
                   $rowSelf.addClass("trigger-active");
-                  if (triggerText.includes(game.i18n.localize("ARCHMAGE.CHAT.miss").toLowerCase() + ':')) {
+                  if (rowLabel.includes(game.i18n.localize("ARCHMAGE.CHAT.miss").toLowerCase())) {
                     $rowSelf.addClass("trigger-miss");
                   }
                 } else {
                   $rowSelf.addClass("trigger-inactive");
-                  if (game.settings.get("archmage", "hideInsteadOfOpaque")) {
-                    $rowSelf.addClass("hide");
-                  }
                 }
               }
             });

--- a/src/scss/global/_archmage-global.scss
+++ b/src/scss/global/_archmage-global.scss
@@ -2037,6 +2037,20 @@ option[selected] {
   text-decoration-color: $c-miss-underline;
 }
 
+// A row whose conditions might still apply, but where something needed to decide them is
+// unknown - most often hit/miss with no target selected. Same hue as an active trigger so it
+// reads as related, but with no fill and a dashed underline: present enough to draw the eye,
+// quiet enough that it can't be mistaken for a confirmed match.
+.trigger-unknown {
+  color: $c-hit;
+  background: none;
+  border-radius: 2px;
+  text-decoration: underline dashed;
+  text-decoration-color: $c-hit-underline;
+  text-underline-offset: 2px;
+  opacity: 0.8;
+}
+
 .trigger-inactive {
   opacity: 0.3;
 }


### PR DESCRIPTION
# `feature/TriggersRefactor`
Rewrites how "trigger rows" — the conditional lines on a power or monster action card, like `Natural even hit:` or `Natural 16+:` — decide whether they apply to the rolls that were just made.

## Why this started

A recent commit hoisted two calls into locals and flipped both guard conditions from `.length > 0` to `.length === 0`, inverting them:

```js
// before
if (trigger.triggersOn().length > 0 && !trigger.triggersOn().filter(...).length > 0) continue;
// after
if (triggers_on.length === 0 && !triggers_on.filter(...).length > 0) continue;
```

Every trigger's `triggersOn()` was non-empty, so the left operand was always `false` and the keyword gate never skipped anything. `HitTrigger`/`MissTrigger` ignore the row text entirely, so they ran on *every* row and returned `true` whenever anything hit — hence "always highlights".

Fixing those two lines restored the old behaviour. Reviewing the surrounding code then turned up enough structural problems to be worth a rewrite; the guard fix is subsumed by it.

---

## The core insight

**A row label is a conjunction.** `Natural even hit` means even AND hit. The old design gave each trigger one keyword and had `evaluateRow` return `true` on the *first* trigger that said yes, using hand-maintained `doesntTriggerOn()` exclusion lists to stop the wrong trigger from claiming a row.

Those lists were incomplete. `HitTrigger.doesntTriggerOn()` excluded `even`/`odd` but not `natural` or `+`, so:

- `Natural 16+ hit:` — `NaturalMatchTrigger` was skipped (its exclusions contain "hit"), leaving   `HitTrigger` to claim the row and return `true` on **any** hit. The threshold was never checked.
- `Natural 16+ miss:` — same via `MissTrigger`.

The rewrite models conditions rather than triggers. Each trigger answers only for itself, and combining them is the orchestrator's job.

---

## A — per-roll outcomes (`HitEvaluation.mjs`)

`processRowText` computed each roll's natural value, crit state, fumble state and hit state, then threw the correspondence away: `targetsHit`/`targetsCrit` are indexed by *hit order*, and `hasHit`/`hasMissed` are OR'd across all targets.

That let conditions be satisfied by different rolls. With two targets — roll 14 that missed and roll 7 that hit — `Natural even hit` went active: parity from the first roll, hit-ness from the second.

New additive return value, one entry per d20 roll in roll order:

```js
rollOutcomes: [{natural, total, hit, crit, fumble, target, defense}]
```

Every existing return (`hasHit`, `targetsHit`, `$rolls`, …) is untouched, so `macros.js` and the sequencer code are unaffected.

`hit` stays `undefined` when there's no target to resolve it against — that distinction is what makes the tri-state below work.

Auto-hit powers (no inline rolls) previously left `hasHit` undefined and gave `evaluateRow` nothing to iterate, so even a plain `Hit:` row could never resolve. They now push one roll-less outcome (`hit: true`, everything else `undefined`).

### Multi-roll attacks already worked this way

Worth recording, because it looks like a gap and isn't. `rollItemAdjustAttacks` (`ArchmageRolls.mjs:129-141`) builds multi-target attacks by string-repeating the inline roll, so Fireball on three targets emits three separate `.inline-result` elements — three `Roll` objects, one d20 term each. Hardcoded multi-attack powers (ranger) go through `numManualAttacks > 1` and are likewise separate inline rolls.

So `rollOutcomes` gets one entry per attack roll, and `evaluateRow` ORs across outcomes: a row lights if *any* roll satisfies all its conditions. An attack that both hits and misses correctly lights `Hit:` and `Miss:` at once.

---

## B — triggers as predicates (`ITrigger.mjs`, `Triggers.mjs`)

`ITrigger` went from `triggersOn()` / `doesntTriggerOn()` / `isActive()` to:

```js
appliesTo(label)      // does the label mention my condition?
test(outcome, label)  // true | false | undefined  (undefined = not determinable)
```

`evaluateRow` collects every trigger whose condition the label mentions and requires **all** of them to hold **for the same outcome**:

```js
const conditions = this.registeredTriggers.filter(t => t.appliesTo(label));
if (conditions.length === 0) return undefined;

let anyRuledOut = false;
for (const outcome of rollOutcomes ?? []) {
  const verdicts = conditions.map(c => c.test(outcome, label));
  if (verdicts.every(v => v === true)) return true;
  if (verdicts.some(v => v === false)) anyRuledOut = true;
}
return anyRuledOut ? false : undefined;
```

### The tri-state matters

The old `evaluateRow` had no `return false` anywhere — it fell off the end returning `undefined` for anything that wasn't a match. Both callers treat `undefined` as `trigger-unknown` and only `false` as `trigger-inactive`, so **`trigger-inactive` never applied** and the dimming CSS was dead code. This predates the guard regression; it's been that way since `8ff3d5c22`.

The three states are now distinct and meaningful:

- **`true`** — every stated condition holds for one roll.
- **`false`** — something was positively ruled out. `Natural odd miss` on a known-even roll is   *known not to apply*, even with no target selected, because parity alone settles it.
- **`undefined`** — nothing decidable. `Natural even hit` on an even roll with no target selected: the parity holds, the hit is unknowable. A *possible* match, never a match.

### Per-trigger notes

- `Even`/`Odd` lost their hand-rolled hit/miss checks. They compose with `HitTrigger` now instead   of racing it.
- `CritTrigger` reads `outcome.crit` instead of hardcoding `rollResult == 20` (that   `// TODO: Handle expanded crit range` is gone). The real threshold — the optional 18+ rule,   attacker and target crit modifiers, the 1e barbarian double-crit — is already resolved in   `HitEvaluation`; it just wasn't reaching the trigger.
- `NaturalMatchTrigger` reads a threshold as digits immediately followed by `+`, not a bare `+`   anywhere in the row. The old form also matched plus signs from damage formulas.
- **`NaturalRangeTrigger` is new**, for `Natural 1-5:` (common in monster stat blocks). Needed   because tightening the exact-score matcher to reject ranges would otherwise have regressed those   rows — they used to light on a natural 1 by accident.
- Keyword matching uses whole-word boundaries expressed as "not a letter or digit" (rather than   `\b`, so accented translations behave). Inflections are listed explicitly per trigger — matching   any suffix would make "miss" match "missile".

---

## C — match against text, structurally (`Triggers.labelOf`)

Both callers passed `$row.html()`. `NaturalMatchTrigger` triggered on a bare `+` and then read the first `\d+` **anywhere in the markup**, so a row with no `:` and an inline `data-formula="2d6+3"` supplied both the `+` and a threshold of `2` — always active.

Labels are now read structurally:

```js
static labelOf($row) {
  const $label = $row.children('strong').first();
  if ($label.length === 0) return null;
  const text = $label.text().trim();
  if (!text.endsWith(':')) return null;
  return text.slice(0, -1).toLowerCase();
}
```

Every labelled card row renders as `<strong>Label:</strong> value` (all of `templates/chat/*.html` plus `item.js:930`), so this is reliable. It also closes a hazard the colon-splitting version had: cards carry unlabelled `<div class="card-prop">{{{description}}}</div>` prose rows, and a keyword gate over the whole row would have evaluated — and faded — plain rules text that happened to contain the word "hit". **No label, no evaluation.** Nothing that isn't a stated condition should ever be dimmed.

The duplicated 6-way keyword gate in both callers collapses to `triggers.isTriggerRow(label)`, which asks the registered triggers instead of maintaining its own list. `new Triggers()` is also hoisted out of the per-row loops.

---

## Other fixes

**`hideInsteadOfOpaque` removed.** Setting registration, settings-group entry, both `addClass("hide")` sites, and the two i18n keys. It never worked (see the tri-state note above), and hiding is the wrong behaviour: the system should highlight what it thinks applies and never withhold information a GM might need. The `.hide` CSS class stays — the escalation die uses it.

**Natural roll overrides the arithmetic.** Hit/miss was purely `rollTotal >= targetDefense`, independent of the crit/fumble state computed from the natural die. A natural 20 that didn't beat the defense read as a crit *and* a miss, lighting both a `Crit:` and a `Miss:` row off one roll; a natural 1 with enough modifiers counted as a hit. Now:

```js
var hit = (rollTotal >= targetDefense || hasCrit) && !hasFumbled;
```

Fumble takes precedence, so an implausibly wide crit range can't invent a hit out of a natural 1. This only decides hit/miss — what a fumble does to miss damage stays with the GM, like the rest of damage application. Note this flows into `targetsHit`/`hasHit`, so it also affects damage application and the sequencer's missed-attack animations.

**`.trigger-unknown` styling** (`c753c17c0`). The class had no CSS rule at all. It now gets the active hue with no fill and a dashed underline, so the three states read as filled (confirmed), outlined (possible), faded (ruled out). Built from the same `--c-hit*` tokens as `.trigger-active`, so both colour-blind palettes follow. This would have been unusable before the rewrite, when almost every row ended up with the class.

---

## Known remaining

- **Multiple d20 *terms* in a single `Roll`**: `rollResult = part.total` is assigned per term, so only the last survives (`HitEvaluation.mjs:71`). Pre-existing and, as far as I can construct, not reachable from real 13th Age formulas — `2d20kh` is one term with two results, and multi-attack powers use separate inline rolls. Defensive hardening only.
- **Ranges other than `natural X-Y`** and any other label grammar not covered by the eight registered triggers resolve to `undefined` (possible match) rather than being guessed at.
- **`es.yaml` has none of the `ARCHMAGE.CHAT` trigger keywords**, so it falls back to English words. Pre-existing; that file is years out of date.

---

## Example screenshots
<img width="291" height="732" alt="immagine" src="https://github.com/user-attachments/assets/81251ca0-f550-4223-803f-5147a22e4fe8" />

