### PR TITLE
Fix/proseMirror size

### DIFF
--- a/src/scss/global/_archmage-global.scss
+++ b/src/scss/global/_archmage-global.scss
@@ -256,6 +256,19 @@ option[selected] {
     border-radius: 4px;
   }
 
+  // An active ProseMirror editor is a menu bar plus an .editor-container sized
+  // `flex: 1 1 0%`, so it only has a writing area if an ancestor supplies a
+  // height. Guarantee one rather than relying on each layout to do it.
+  .editor.prosemirror {
+    min-height: 220px;
+
+    .editor-container {
+      flex: 1 1 auto;
+      min-height: 180px;
+      overflow-y: auto;
+    }
+  }
+
   .tox-tinymce,
   .tox-editor-container,
   .tox-sidebar-wrap,

--- a/src/scss/v2/components/_sheet.scss
+++ b/src/scss/v2/components/_sheet.scss
@@ -119,6 +119,19 @@ img[data-edit="img"] {
 .editor.prosemirror {
   min-height: 220px;
 
+  // Narrow columns (the One Unique Thing unit in the sidebar, the NPC header
+  // next to the portrait) can't fit the toolbar on one line, so let it wrap and
+  // grow instead of clipping the buttons. It stays outside the flex sizing
+  // below, so extra toolbar rows add height rather than stealing writing space.
+  > menu,
+  .editor-menu {
+    flex: 0 0 auto;
+    flex-wrap: wrap;
+    height: auto;
+    max-height: none;
+    overflow: visible;
+  }
+
   .editor-container {
     flex: 1 1 auto;
     min-height: 180px;

--- a/src/scss/v2/components/_sheet.scss
+++ b/src/scss/v2/components/_sheet.scss
@@ -109,6 +109,27 @@ img[data-edit="img"] {
   border-radius: $padding-sm;
 }
 
+// Activating an editor makes ProseMirror restructure .editor into a menu bar
+// plus an .editor-container, where the container is `flex: 1 1 0%`. That means
+// the writing area only gets a height if something above it provides one: where
+// the read-only rendering is deliberately compact (the NPC flavor text zeroes
+// the wrapper's min-height) the container collapses to nothing and all that's
+// left is the toolbar. Give the *active* editor its own floor, so the compact
+// display styles can stay compact.
+.editor.prosemirror {
+  min-height: 220px;
+
+  .editor-container {
+    flex: 1 1 auto;
+    min-height: 180px;
+    overflow-y: auto;
+  }
+
+  .editor-content {
+    min-height: 100%;
+  }
+}
+
 .tox-tinymce,
 .tox-editor-container,
 .tox-sidebar-wrap,

--- a/src/scss/v2/components/_sheet.scss
+++ b/src/scss/v2/components/_sheet.scss
@@ -117,14 +117,21 @@ img[data-edit="img"] {
 // left is the toolbar. Give the *active* editor its own floor, so the compact
 // display styles can stay compact.
 .editor.prosemirror {
+  display: flex;
+  flex-direction: column;
   min-height: 220px;
+  padding-top: 0;
 
   // Narrow columns (the One Unique Thing unit in the sidebar, the NPC header
-  // next to the portrait) can't fit the toolbar on one line, so let it wrap and
-  // grow instead of clipping the buttons. It stays outside the flex sizing
-  // below, so extra toolbar rows add height rather than stealing writing space.
+  // next to the portrait) can't fit the toolbar on one line. Core keeps it out
+  // of the flow at a fixed one-row height and offsets the content below it, so
+  // simply letting it wrap makes the extra rows sit on top of the text. Put it
+  // back in the flow instead, and drop the offset that compensated for it: as a
+  // plain flex item its rows push the writing area down rather than over it.
   > menu,
   .editor-menu {
+    position: relative;
+    inset: auto;
     flex: 0 0 auto;
     flex-wrap: wrap;
     height: auto;
@@ -133,6 +140,8 @@ img[data-edit="img"] {
   }
 
   .editor-container {
+    margin-top: 0;
+    padding-top: 0;
     flex: 1 1 auto;
     min-height: 180px;
     overflow-y: auto;

--- a/src/vue/components/actor/npc/NpcHeader.vue
+++ b/src/vue/components/actor/npc/NpcHeader.vue
@@ -395,6 +395,15 @@
       margin: 0.2em 0;
     }
 
+    // The compact rules above are for the rendered flavor text. Once the editor
+    // is activated it needs to read as an editable field again - and it must
+    // come after them, since the specificity is identical.
+    .editor.prosemirror .editor-content {
+      background: $c-black--05;
+      border-radius: $padding-sm;
+      padding: $padding-sm;
+      min-height: 100%;
+    }
   }
 
   .toggle-header {


### PR DESCRIPTION
- Add min height to all proseMirror instances (they inherited it from the parent, and it was 0 in some cases).
- Make header wrap in narrow instances (OUT, mostly)