### PR TITLE
Release/1.41.0

### DIFF
--- a/release-notes/1.41.0.md
+++ b/release-notes/1.41.0.md
@@ -57,7 +57,7 @@ Also fixed parsing and display of non-standard save-ends values, for both ongoin
 
 ## Other Additions
 
-- **2e Skirmisher macro** that stores a temporary fake combatant at half initiative, whih is automatically cleaned up at the end of the round.
+- **2e Skirmisher macro** that stores a temporary fake combatant at half initiative, which is automatically cleaned up at the end of the round.
 - **Great Dragon Incarnation**'s macro now actually transforms the user's token into a dragon, temporarily.
 - **Powers targeting multiple defences** — targeting support for e.g. `vs. PD or MD`, which targets the lower of the two.
 - **Compendium browser icon filter** — filter items by their associated icon.

--- a/release-notes/1.41.0.md
+++ b/release-notes/1.41.0.md
@@ -4,15 +4,15 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.41.0/syste
 
 ## Compatible Foundry versions
 
-![Foundry v14.365](https://img.shields.io/badge/Foundry-v14.365-green)
+![Foundry v14.366](https://img.shields.io/badge/Foundry-v14.366-green)
 
 **Note**: this release *only* supports Foundry v14.
 
 ## Secondary Power Usage
 
-Powers can now track a second, independent pool of uses — the classic case being the 1e paladin's *Smite Evil*, which is both per-battle and daily. The sheet shows both counts (e.g. `1-3`), the row's colour switches to the secondary usage once the primary is expended, resting resets both pools as appropriate, and rolling a power falls through to the secondary uses when the primary are gone.
+Powers can now track a second, independent pool of uses — the classic case being the 1e paladin's *Smite Evil*, which is both per-battle and daily. The sheet shows both counts (e.g. `1-3`), the row's colour switches to the secondary usage once the primary is expended, resting resets both pools as appropriate, and rolling a power falls through to the secondary uses when the primary ones are gone.
 
-As a bonus, Maximum-uses fields also accept inline rolls now, so the above-mentioned smite daily uses automatically scale based on the character's charisma.
+In addition, Maximum-uses fields also accept inline rolls now, so the above-mentioned smite daily uses automatically scale based on the character's charisma.
 
 ## Unified Power Rendering
 
@@ -48,26 +48,26 @@ Drag-and-drop sorting on the character and NPC sheets was inconsistent; it now w
 - Added a 3x ongoing damage modifier (first tick only), the ongoing-damage counterpart to double-damage crits — for things like empowered sorcerer spells.
 - Half damage now stores the exact half value, so a half-damage double-damage crit rounds the way you'd expect; rounding changed to round up.
 
-As a bonus: fixed parsing and display of non-standard save-ends values, for both ongoing damage and conditions.
+Also fixed parsing and display of non-standard save-ends values, for both ongoing damage and conditions.
 
 ## Other Additions
 
 - **2e Skirmisher macro** that stores a temporary fake combatant at half initiative, that's automatically cleaned up at the end of the round.
 - **Great Dragon Incarnation**'s macro now actually transforms the user's token into a dragon, temporarily.
-- **Powers targeting multiple defences** — support for `vs. PD or MD`, which targets the lower of the two.
+- **Powers targeting multiple defences** — support for e.g. `vs. PD or MD`, which targets the lower of the two.
 - **Compendium browser icon filter** — filter items by their associated icon.
 - **Optional movement distance labels** — hiding the distance rulers is now a setting (on by default).
 - **Dice So Nice overrides** gained a global speed modifier, and the system now tells you via a UI notification when it changes one of DsN's defaults.
-- The end-of-turn chat card can be popped out.
+- The end-of-turn chat card can now be popped out.
 - Disengage dialog quick modifiers readjusted to better cover the available powers.
+- Players can now drag effects and conditions onto a token on the canvas, not just onto their sheet's effects tab. Thanks @kjaranso!
 
 ## Bug Fixes
 
-- Players can now drag effects and conditions onto a token on the canvas, not just onto their sheet's effects tab. Thanks @kjaranso!
 - Dropping an active effect on the canvas no longer has Foundry apply it directly before the system's own dialog gets a chance to process it.
 - Fixed the `Chaotic Benefit` system macro.
 - Fixed alt-clicking a power that has no level set.
-- Fixed several wrong guards — among other things this should clear up the UI error messages players (as opposed to the GM) saw when removing active effects from the system's chat messages.
+- Fixed several wrong code guards — among other things this should clear up the UI error messages players (as opposed to the GM) saw when removing active effects from the system's chat messages.
 - Fixed the song sustain reminder not firing under v14.
 - Fixed manual recharge rolls not writing to chat (outdated Foundry constant).
 - Fixed the `Unconscious` status not applying when the last gasp save fails.
@@ -75,7 +75,6 @@ As a bonus: fixed parsing and display of non-standard save-ends values, for both
 - Death save steps now reflect the number of steps actually configured.
 - Fixed hyphen cleaning in the PDF-parsing automation.
 - Fixed (and localised) the `Strategist` extra starting command point.
-- Fixed a few missed active effect `icon` → `img` property renames.
 - Fixed an error when players without macro permissions use a power with an embedded macro.
 - Fixed intermittent mis-parsing of expanded damage rolls in the damage applicator, plus a damage application edge case.
 - Removed the implicit crit-on-19+ assumption on rerolls.
@@ -83,14 +82,15 @@ As a bonus: fixed parsing and display of non-standard save-ends values, for both
 - Fixed drag-and-drop on the inventory tab.
 - ProseMirror editors get a minimum height (some inherited `0` from their parent), and their header wraps in narrow instances instead of overflowing.
 - Fixed 2e equipment bonus labels: the disengage & initiative bonus rendered as a raw i18n key, and three other bonuses showed their raw property name in the collapsed summary row.
-- Powers no longer appear to be "modified" a little too eagerly.
+- Powers no longer appear to be "(modified)" a little too eagerly.
 
 ## Under the Hood
 
 - Build tooling refactored from gulp to Vite with custom plugins, and npm dependencies updated to clear vulnerabilities.
-- Added a `.gitattributes` to keep line endings uniform going forward.
+- Added a `.gitattributes` file to keep line endings uniform going forward.
 - Actor updates are slightly faster (only the data needed for the diff is flattened), and resource checks were optimised.
 - Removed the redundant `preCreateToken` hook — the functionality is duplicated and expanded in the actor's `_preUpdate`.
+- Fixed a few missed active effect `icon` → `img` property renames.
 - A fair amount of dead and duplicated code removed along the way: three copies of the feat helpers, four copies of the usage-colour rule, two copies of the inline roll formatter, and several unused computed properties and template files.
 
 ## Changelog

--- a/release-notes/1.41.0.md
+++ b/release-notes/1.41.0.md
@@ -4,7 +4,7 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.41.0/syste
 
 ## Compatible Foundry versions
 
-![Foundry v14.366](https://img.shields.io/badge/Foundry-v14.366-green)
+![Foundry v14.367](https://img.shields.io/badge/Foundry-v14.367-green)
 
 **Note**: this release *only* supports Foundry v14.
 
@@ -12,7 +12,7 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.41.0/syste
 
 Powers can now track a second, independent pool of uses — the classic case being the 1e paladin's *Smite Evil*, which is both per-battle and daily. The sheet shows both counts (e.g. `1-3`), the row's colour switches to the secondary usage once the primary is expended, resting resets both pools as appropriate, and rolling a power falls through to the secondary uses when the primary ones are gone.
 
-In addition, Maximum-uses fields also accept inline rolls now, so the above-mentioned smite daily uses automatically scale based on the character's charisma.
+In addition, Maximum-uses fields also accept inline rolls now, so the above-mentioned smite daily uses can automatically scale based on the character's charisma.
 
 ## Unified Power Rendering
 
@@ -34,16 +34,16 @@ The conditional lines on power and monster action cards — `Natural even hit:`,
 In addition:
 
 - Rows now have three distinct, meaningful states: **active** (filled — every stated condition holds), **possible** (outlined with a dashed underline — undecidable, e.g. parity holds but no target is selected) and **inactive** (faded — positively ruled out).
-- Crit rows read the real crit state, so the optional 18+ rule, crit modifiers and the 1e barbarian double-crit are finally respected.
+- Crit rows read the real crit state, so the optional 18+ rule, crit modifiers and the 1e barbarian rage-crit are respected.
 - Added support for `Natural X-Y:` ranges, common in monster stat blocks.
 - A natural 20 that fails to beat the defence no longer counts as both a crit and a miss, and a natural 1 with big modifiers no longer counts as a hit. This also feeds damage application and missed-attack animations.
-- Removed the "hide instead of fade" setting: it never actually worked, and the game has enough edge cases that just hiding some rows is liable to lead to friction instead of being helpful.
+- Removed the "hide instead of fade" setting: it hasn't worked for half a decade, and the game has enough edge cases that just hiding some rows is liable to lead to friction instead of being helpful.
 
 ## Sheet Sorting and Group Ordering
 
-Drag-and-drop sorting on the character and NPC sheets was inconsistent; it now works reliably for entries within a group, and you can reorder the groups themselves as well.
+Drag-and-drop sorting on the character and NPC sheets was inconsistent; it should now work reliably for entries within a group, and you can reorder the groups themselves as well.
 
-## Ongoing Damage Multipliers
+## Ongoing Damage Multiplier Improvements
 
 - Added a 3x ongoing damage modifier (first tick only), the ongoing-damage counterpart to double-damage crits — for things like empowered sorcerer spells.
 - Half damage now stores the exact half value, so a half-damage double-damage crit rounds the way you'd expect; rounding changed to round up.
@@ -52,7 +52,7 @@ Also fixed parsing and display of non-standard save-ends values, for both ongoin
 
 ## Other Additions
 
-- **2e Skirmisher macro** that stores a temporary fake combatant at half initiative, that's automatically cleaned up at the end of the round.
+- **2e Skirmisher macro** that stores a temporary fake combatant at half initiative, whih is automatically cleaned up at the end of the round.
 - **Great Dragon Incarnation**'s macro now actually transforms the user's token into a dragon, temporarily.
 - **Powers targeting multiple defences** — support for e.g. `vs. PD or MD`, which targets the lower of the two.
 - **Compendium browser icon filter** — filter items by their associated icon.
@@ -60,16 +60,16 @@ Also fixed parsing and display of non-standard save-ends values, for both ongoin
 - **Dice So Nice overrides** gained a global speed modifier, and the system now tells you via a UI notification when it changes one of DsN's defaults.
 - The end-of-turn chat card can now be popped out.
 - Disengage dialog quick modifiers readjusted to better cover the available powers.
-- Players can now drag effects and conditions onto a token on the canvas, not just onto their sheet's effects tab. Thanks @kjaranso!
 
 ## Bug Fixes
 
+- Players can now drag effects and conditions onto a token on the canvas, not just onto their sheet's effects tab. Thanks @kjaranso!
 - Dropping an active effect on the canvas no longer has Foundry apply it directly before the system's own dialog gets a chance to process it.
 - Fixed the `Chaotic Benefit` system macro.
 - Fixed alt-clicking a power that has no level set.
 - Fixed several wrong code guards — among other things this should clear up the UI error messages players (as opposed to the GM) saw when removing active effects from the system's chat messages.
-- Fixed the song sustain reminder not firing under v14.
-- Fixed manual recharge rolls not writing to chat (outdated Foundry constant).
+- Fixed the bard song sustain reminder not firing under v14.
+- Fixed manual recharge rolls not writing to chat (due to referencing an outdated Foundry constant).
 - Fixed the `Unconscious` status not applying when the last gasp save fails.
 - Successful death saves no longer *silently* roll a recovery — they produce the usual chat card.
 - Death save steps now reflect the number of steps actually configured.

--- a/release-notes/1.41.0.md
+++ b/release-notes/1.41.0.md
@@ -8,28 +8,30 @@ Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.41.0/syste
 
 **Note**: this release *only* supports Foundry v14.
 
-## Secondary Power Usage
+## Highlights
 
-Powers can now track a second, independent pool of uses — the classic case being the 1e paladin's *Smite Evil*, which is both per-battle and daily. The sheet shows both counts (e.g. `1-3`), the row's colour switches to the secondary usage once the primary is expended, resting resets both pools as appropriate, and rolling a power falls through to the secondary uses when the primary ones are gone.
+### Secondary Power Usage
 
-In addition, Maximum-uses fields also accept inline rolls now, so the above-mentioned smite daily uses can automatically scale based on the character's charisma.
+Powers can now track a second, independent pool of uses — the classic example being the 1e paladin's *Smite Evil*, which is both per-battle and daily. The sheet shows both counts (both quick-editable as before), the row's colour switches to the secondary usage once the primary is expended, resting resets both pools as appropriate, and rolling a power falls through to the secondary uses when the primary ones are gone.
 
-## Unified Power Rendering
+In addition, both Maximum-uses fields also accept inline rolls now, so the above-mentioned smite daily uses can automatically scale based on the character's charisma.
+
+### Unified Power Rendering
 
 Powers used to be drawn by five separate code paths that had drifted apart, so the same power could look different on the character sheet, in the item sheet preview, in the compendium browser, in the power importer and on the chat card. Field order differed, spell tiers showed up in one place but not another, and four different implementations disagreed about what colour a power should be. That's now a single renderer, so a power looks the same everywhere.
 
 In practice, this means that:
 
-- **Chat cards** follow the sheet's field order (`recharge` moved to the end of the properties block, `special` moved before `effect`), stop showing even-numbered spell tiers under 1e (the sheets never did), and honour `overridePowerLevel` when picking which tiers to show.
-- **The compendium browser** now understands cyclic alternation, `recharge-desperate` (colour *and* the recharge pip), secondary-usage colouring, the `unavailable` hatching, and shows real feat state instead of lighting every pip.
-- **The power importer** is a proper Vue app rendering the same component as the sheet: coloured rows, sheet field order, expandable entries, all spell tiers, all relevant levels, and a restored two-column layout that collapses to one on narrow windows.
-- **Dual-usage and cyclic powers** get a wider angled band representing the secondary mode of usage that flips as needed, and for the former each usage mode is visually marked as spent once it runs out.
+- **Chat cards** follow the sheet's field order, stop showing even-numbered spell tiers under 1e, and honour `overridePowerLevel` when picking which tiers to show.
+- **The compendium browser** now understands cyclic alternation, `recharge-desperate`, secondary-usage colouring, and even the `unavailable` hatching.
+- **The power importer** is a proper Vue app rendering the same component as the sheet.
+- **Dual-usage and cyclic powers** get an angled band representing the secondary mode of usage that flips as needed, and for the former each usage mode is visually marked as spent once it runs out.
 
 As a bonus, usage labels in the power body now read from the edition config, so 2e correctly says "Arc" instead of "Daily".
 
-## Trigger Rows Refactoring
+### Trigger Rows Refactoring
 
-The conditional lines on power and monster action cards — `Natural even hit:`, `Natural 16+ miss:`, `Natural 1-5:` — now decide whether they apply by treating the label as a *conjunction* of conditions, all of which have to hold for the **same** roll. Previously each trigger answered on its own and the first one to say yes won, which lead to many wrong detections, hopefully fixed now.
+The conditional lines on power and monster action cards — `Natural even hit:`, `Natural 16+ miss:`, `Natural 1-5:` — now decide whether they apply by treating the label as a *conjunction* of conditions, all of which have to hold for the **same** roll. Previously each trigger answered on its own and the first one to say yes won, which led to many wrong detections, hopefully fixed now.
 
 In addition:
 
@@ -39,13 +41,13 @@ In addition:
 - A natural 20 that fails to beat the defence no longer counts as both a crit and a miss, and a natural 1 with big modifiers no longer counts as a hit. This also feeds damage application and missed-attack animations.
 - Removed the "hide instead of fade" setting: it hasn't worked for half a decade, and the game has enough edge cases that just hiding some rows is liable to lead to friction instead of being helpful.
 
-## Sheet Sorting and Group Ordering
+### Sheet Sorting and Group Ordering
 
 Drag-and-drop sorting on the character and NPC sheets was inconsistent; it should now work reliably for entries within a group, and you can reorder the groups themselves as well.
 
-## Ongoing Damage Multiplier Improvements
+### Ongoing Damage Multiplier Improvements
 
-- Added a 3x ongoing damage modifier (first tick only), the ongoing-damage counterpart to double-damage crits — for things like empowered sorcerer spells.
+- Added a 3x ongoing damage modifier (first tick only), the ongoing-damage counterpart to double-damage crits — mainly for empowered sorcerer spells.
 - Half damage now stores the exact half value, so a half-damage double-damage crit rounds the way you'd expect; rounding changed to round up.
 
 Also fixed parsing and display of non-standard save-ends values, for both ongoing damage and conditions.
@@ -54,16 +56,16 @@ Also fixed parsing and display of non-standard save-ends values, for both ongoin
 
 - **2e Skirmisher macro** that stores a temporary fake combatant at half initiative, whih is automatically cleaned up at the end of the round.
 - **Great Dragon Incarnation**'s macro now actually transforms the user's token into a dragon, temporarily.
-- **Powers targeting multiple defences** — support for e.g. `vs. PD or MD`, which targets the lower of the two.
+- **Powers targeting multiple defences** — targeting support for e.g. `vs. PD or MD`, which targets the lower of the two.
 - **Compendium browser icon filter** — filter items by their associated icon.
 - **Optional movement distance labels** — hiding the distance rulers is now a setting (on by default).
 - **Dice So Nice overrides** gained a global speed modifier, and the system now tells you via a UI notification when it changes one of DsN's defaults.
 - The end-of-turn chat card can now be popped out.
 - Disengage dialog quick modifiers readjusted to better cover the available powers.
 
-## Bug Fixes
+## Other Bug Fixes
 
-- Players can now drag effects and conditions onto a token on the canvas, not just onto their sheet's effects tab. Thanks @kjaranso!
+- Players can now drag effects and conditions directly onto a token on the canvas, not just onto their sheet's effects tab. Thanks @kjaranso!
 - Dropping an active effect on the canvas no longer has Foundry apply it directly before the system's own dialog gets a chance to process it.
 - Fixed the `Chaotic Benefit` system macro.
 - Fixed alt-clicking a power that has no level set.

--- a/release-notes/1.41.0.md
+++ b/release-notes/1.41.0.md
@@ -18,7 +18,7 @@ In addition, both Maximum-uses fields also accept inline rolls now, so the above
 
 ### Unified Power Rendering
 
-Powers used to be drawn by five separate code paths that had drifted apart, so the same power could look different on the character sheet, in the item sheet preview, in the compendium browser, in the power importer and on the chat card. Field order differed, spell tiers showed up in one place but not another, and four different implementations disagreed about what colour a power should be. That's now a single renderer, so a power looks the same everywhere.
+Powers used to be drawn by five separate code paths that had drifted apart, so the same power could look different on the character sheet, item sheet preview, compendium browser, power importer and on the chat card. Field order differed, spell tiers showed up in one place but not another, and four different implementations disagreed about what colour a power should be. That's now a single renderer, so a power mostly looks the same everywhere.
 
 In practice, this means that:
 
@@ -35,7 +35,10 @@ The conditional lines on power and monster action cards — `Natural even hit:`,
 
 In addition:
 
-- Rows now have three distinct, meaningful states: **active** (filled — every stated condition holds), **possible** (outlined with a dashed underline — undecidable, e.g. parity holds but no target is selected) and **inactive** (faded — positively ruled out).
+- Rows now have three distinct states:
+  - **active**: filled — every stated condition holds
+  - **possible**: outlined with a dashed underline — undecidable, e.g. parity holds but no target is selected for `Natural even hit:`
+  - **inactive**: faded — positively ruled out
 - Crit rows read the real crit state, so the optional 18+ rule, crit modifiers and the 1e barbarian rage-crit are respected.
 - Added support for `Natural X-Y:` ranges, common in monster stat blocks.
 - A natural 20 that fails to beat the defence no longer counts as both a crit and a miss, and a natural 1 with big modifiers no longer counts as a hit. This also feeds damage application and missed-attack animations.
@@ -47,7 +50,7 @@ Drag-and-drop sorting on the character and NPC sheets was inconsistent; it shoul
 
 ### Ongoing Damage Multiplier Improvements
 
-- Added a 3x ongoing damage modifier (first tick only), the ongoing-damage counterpart to double-damage crits — mainly for empowered sorcerer spells.
+- Added a 3x ongoing damage modifier (first tick only), the ongoing-damage counterpart to triple-damage crits — mainly for empowered sorcerer spells.
 - Half damage now stores the exact half value, so a half-damage double-damage crit rounds the way you'd expect; rounding changed to round up.
 
 Also fixed parsing and display of non-standard save-ends values, for both ongoing damage and conditions.
@@ -69,7 +72,7 @@ Also fixed parsing and display of non-standard save-ends values, for both ongoin
 - Dropping an active effect on the canvas no longer has Foundry apply it directly before the system's own dialog gets a chance to process it.
 - Fixed the `Chaotic Benefit` system macro.
 - Fixed alt-clicking a power that has no level set.
-- Fixed several wrong code guards — among other things this should clear up the UI error messages players (as opposed to the GM) saw when removing active effects from the system's chat messages.
+- Fixed several wrong code guards — among other things this should clear up the UI error messages players (as opposed to the GM) saw when removing active effects using the system's chat messages.
 - Fixed the bard song sustain reminder not firing under v14.
 - Fixed manual recharge rolls not writing to chat (due to referencing an outdated Foundry constant).
 - Fixed the `Unconscious` status not applying when the last gasp save fails.
@@ -85,6 +88,7 @@ Also fixed parsing and display of non-standard save-ends values, for both ongoin
 - ProseMirror editors get a minimum height (some inherited `0` from their parent), and their header wraps in narrow instances instead of overflowing.
 - Fixed 2e equipment bonus labels: the disengage & initiative bonus rendered as a raw i18n key, and three other bonuses showed their raw property name in the collapsed summary row.
 - Powers no longer appear to be "(modified)" a little too eagerly.
+- Fixed start/end of next (source) turn duration not expiring automatically.
 
 ## Under the Hood
 

--- a/release-notes/1.41.0.md
+++ b/release-notes/1.41.0.md
@@ -1,0 +1,102 @@
+## Downloads
+
+Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.41.0/system.json
+
+## Compatible Foundry versions
+
+![Foundry v14.365](https://img.shields.io/badge/Foundry-v14.365-green)
+
+**Note**: this release *only* supports Foundry v14.
+
+## Secondary Power Usage
+
+Powers can now track a second, independent pool of uses — the classic case being the 1e paladin's *Smite Evil*, which is both per-battle and daily. The sheet shows both counts (e.g. `1-3`), the row's colour switches to the secondary usage once the primary is expended, resting resets both pools as appropriate, and rolling a power falls through to the secondary uses when the primary are gone.
+
+As a bonus, Maximum-uses fields also accept inline rolls now, so the above-mentioned smite daily uses automatically scale based on the character's charisma.
+
+## Unified Power Rendering
+
+Powers used to be drawn by five separate code paths that had drifted apart, so the same power could look different on the character sheet, in the item sheet preview, in the compendium browser, in the power importer and on the chat card. Field order differed, spell tiers showed up in one place but not another, and four different implementations disagreed about what colour a power should be. That's now a single renderer, so a power looks the same everywhere.
+
+In practice, this means that:
+
+- **Chat cards** follow the sheet's field order (`recharge` moved to the end of the properties block, `special` moved before `effect`), stop showing even-numbered spell tiers under 1e (the sheets never did), and honour `overridePowerLevel` when picking which tiers to show.
+- **The compendium browser** now understands cyclic alternation, `recharge-desperate` (colour *and* the recharge pip), secondary-usage colouring, the `unavailable` hatching, and shows real feat state instead of lighting every pip.
+- **The power importer** is a proper Vue app rendering the same component as the sheet: coloured rows, sheet field order, expandable entries, all spell tiers, all relevant levels, and a restored two-column layout that collapses to one on narrow windows.
+- **Dual-usage and cyclic powers** get a wider angled band representing the secondary mode of usage that flips as needed, and for the former each usage mode is visually marked as spent once it runs out.
+
+As a bonus, usage labels in the power body now read from the edition config, so 2e correctly says "Arc" instead of "Daily".
+
+## Trigger Rows Refactoring
+
+The conditional lines on power and monster action cards — `Natural even hit:`, `Natural 16+ miss:`, `Natural 1-5:` — now decide whether they apply by treating the label as a *conjunction* of conditions, all of which have to hold for the **same** roll. Previously each trigger answered on its own and the first one to say yes won, which lead to many wrong detections, hopefully fixed now.
+
+In addition:
+
+- Rows now have three distinct, meaningful states: **active** (filled — every stated condition holds), **possible** (outlined with a dashed underline — undecidable, e.g. parity holds but no target is selected) and **inactive** (faded — positively ruled out).
+- Crit rows read the real crit state, so the optional 18+ rule, crit modifiers and the 1e barbarian double-crit are finally respected.
+- Added support for `Natural X-Y:` ranges, common in monster stat blocks.
+- A natural 20 that fails to beat the defence no longer counts as both a crit and a miss, and a natural 1 with big modifiers no longer counts as a hit. This also feeds damage application and missed-attack animations.
+- Removed the "hide instead of fade" setting: it never actually worked, and the game has enough edge cases that just hiding some rows is liable to lead to friction instead of being helpful.
+
+## Sheet Sorting and Group Ordering
+
+Drag-and-drop sorting on the character and NPC sheets was inconsistent; it now works reliably for entries within a group, and you can reorder the groups themselves as well.
+
+## Ongoing Damage Multipliers
+
+- Added a 3x ongoing damage modifier (first tick only), the ongoing-damage counterpart to double-damage crits — for things like empowered sorcerer spells.
+- Half damage now stores the exact half value, so a half-damage double-damage crit rounds the way you'd expect; rounding changed to round up.
+
+As a bonus: fixed parsing and display of non-standard save-ends values, for both ongoing damage and conditions.
+
+## Other Additions
+
+- **2e Skirmisher macro** that stores a temporary fake combatant at half initiative, that's automatically cleaned up at the end of the round.
+- **Great Dragon Incarnation**'s macro now actually transforms the user's token into a dragon, temporarily.
+- **Powers targeting multiple defences** — support for `vs. PD or MD`, which targets the lower of the two.
+- **Compendium browser icon filter** — filter items by their associated icon.
+- **Optional movement distance labels** — hiding the distance rulers is now a setting (on by default).
+- **Dice So Nice overrides** gained a global speed modifier, and the system now tells you via a UI notification when it changes one of DsN's defaults.
+- The end-of-turn chat card can be popped out.
+- Disengage dialog quick modifiers readjusted to better cover the available powers.
+
+## Bug Fixes
+
+- Players can now drag effects and conditions onto a token on the canvas, not just onto their sheet's effects tab. Thanks @kjaranso!
+- Dropping an active effect on the canvas no longer has Foundry apply it directly before the system's own dialog gets a chance to process it.
+- Fixed the `Chaotic Benefit` system macro.
+- Fixed alt-clicking a power that has no level set.
+- Fixed several wrong guards — among other things this should clear up the UI error messages players (as opposed to the GM) saw when removing active effects from the system's chat messages.
+- Fixed the song sustain reminder not firing under v14.
+- Fixed manual recharge rolls not writing to chat (outdated Foundry constant).
+- Fixed the `Unconscious` status not applying when the last gasp save fails.
+- Successful death saves no longer *silently* roll a recovery — they produce the usual chat card.
+- Death save steps now reflect the number of steps actually configured.
+- Fixed hyphen cleaning in the PDF-parsing automation.
+- Fixed (and localised) the `Strategist` extra starting command point.
+- Fixed a few missed active effect `icon` → `img` property renames.
+- Fixed an error when players without macro permissions use a power with an embedded macro.
+- Fixed intermittent mis-parsing of expanded damage rolls in the damage applicator, plus a damage application edge case.
+- Removed the implicit crit-on-19+ assumption on rerolls.
+- Fixed edge cases in custom resource setup and in stacking rule application.
+- Fixed drag-and-drop on the inventory tab.
+- ProseMirror editors get a minimum height (some inherited `0` from their parent), and their header wraps in narrow instances instead of overflowing.
+- Fixed 2e equipment bonus labels: the disengage & initiative bonus rendered as a raw i18n key, and three other bonuses showed their raw property name in the collapsed summary row.
+- Powers no longer appear to be "modified" a little too eagerly.
+
+## Under the Hood
+
+- Build tooling refactored from gulp to Vite with custom plugins, and npm dependencies updated to clear vulnerabilities.
+- Added a `.gitattributes` to keep line endings uniform going forward.
+- Actor updates are slightly faster (only the data needed for the diff is flattened), and resource checks were optimised.
+- Removed the redundant `preCreateToken` hook — the functionality is duplicated and expanded in the actor's `_preUpdate`.
+- A fair amount of dead and duplicated code removed along the way: three copies of the feat helpers, four copies of the usage-colour rule, two copies of the inline roll formatter, and several unused computed properties and template files.
+
+## Changelog
+
+Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.40.1...1.41.0
+
+## Contributors
+
+@LegoFed3, @ben, @asacolips, @kjaranso

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -15,7 +15,7 @@ description: The official 13th Age system for Foundry Virtual Tabletop.
 
 compatibility:
   minimum: "14"
-  verified: "14.366"
+  verified: "14.367"
   maximum: "14"
 
 esmodules:

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -15,7 +15,7 @@ description: The official 13th Age system for Foundry Virtual Tabletop.
 
 compatibility:
   minimum: "14"
-  verified: "14.365"
+  verified: "14.366"
   maximum: "14"
 
 esmodules:

--- a/src/system.yaml
+++ b/src/system.yaml
@@ -1,6 +1,6 @@
 id: archmage
 title: 13th Age
-version: "1.40.1"
+version: "1.41.0"
 authors:
   - name: Matt Smith
     discord: asacolips
@@ -15,7 +15,7 @@ description: The official 13th Age system for Foundry Virtual Tabletop.
 
 compatibility:
   minimum: "14"
-  verified: "14.364"
+  verified: "14.365"
   maximum: "14"
 
 esmodules:
@@ -278,7 +278,7 @@ languages:
 socket: true
 url: https://github.com/asacolips-projects/13th-age
 manifest: https://asacolips-artifacts.s3.amazonaws.com/archmage/latest/system.json
-download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.40.1/archmage.zip
+download: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.41.0/archmage.zip
 changelog: https://github.com/asacolips-projects/13th-age/releases
 initiative: 1d20 + (@abilities?.dex.mod || 0) + @attributes.init.value + @attributes.level.value
 grid:


### PR DESCRIPTION
## Downloads

Manifest URL: https://asacolips-artifacts.s3.amazonaws.com/archmage/1.41.0/system.json

## Compatible Foundry versions

![Foundry v14.367](https://img.shields.io/badge/Foundry-v14.367-green)

**Note**: this release *only* supports Foundry v14.

## Highlights

### Secondary Power Usage

Powers can now track a second, independent pool of uses — the classic example being the 1e paladin's *Smite Evil*, which is both per-battle and daily. The sheet shows both counts (both quick-editable as before), the row's colour switches to the secondary usage once the primary is expended, resting resets both pools as appropriate, and rolling a power falls through to the secondary uses when the primary ones are gone.

In addition, both Maximum-uses fields also accept inline rolls now, so the above-mentioned smite daily uses can automatically scale based on the character's charisma.

### Unified Power Rendering

Powers used to be drawn by five separate code paths that had drifted apart, so the same power could look different on the character sheet, item sheet preview, compendium browser, power importer and on the chat card. Field order differed, spell tiers showed up in one place but not another, and four different implementations disagreed about what colour a power should be. That's now a single renderer, so a power mostly looks the same everywhere.

In practice, this means that:

- **Chat cards** follow the sheet's field order, stop showing even-numbered spell tiers under 1e, and honour `overridePowerLevel` when picking which tiers to show.
- **The compendium browser** now understands cyclic alternation, `recharge-desperate`, secondary-usage colouring, and even the `unavailable` hatching.
- **The power importer** is a proper Vue app rendering the same component as the sheet.
- **Dual-usage and cyclic powers** get an angled band representing the secondary mode of usage that flips as needed, and for the former each usage mode is visually marked as spent once it runs out.

As a bonus, usage labels in the power body now read from the edition config, so 2e correctly says "Arc" instead of "Daily".

### Trigger Rows Refactoring

The conditional lines on power and monster action cards — `Natural even hit:`, `Natural 16+ miss:`, `Natural 1-5:` — now decide whether they apply by treating the label as a *conjunction* of conditions, all of which have to hold for the **same** roll. Previously each trigger answered on its own and the first one to say yes won, which led to many wrong detections, hopefully fixed now.

In addition:

- Rows now have three distinct states:
  - **active**: filled — every stated condition holds
  - **possible**: outlined with a dashed underline — undecidable, e.g. parity holds but no target is selected for `Natural even hit:`
  - **inactive**: faded — positively ruled out
- Crit rows read the real crit state, so the optional 18+ rule, crit modifiers and the 1e barbarian rage-crit are respected.
- Added support for `Natural X-Y:` ranges, common in monster stat blocks.
- A natural 20 that fails to beat the defence no longer counts as both a crit and a miss, and a natural 1 with big modifiers no longer counts as a hit. This also feeds damage application and missed-attack animations.
- Removed the "hide instead of fade" setting: it hasn't worked for half a decade, and the game has enough edge cases that just hiding some rows is liable to lead to friction instead of being helpful.

### Sheet Sorting and Group Ordering

Drag-and-drop sorting on the character and NPC sheets was inconsistent; it should now work reliably for entries within a group, and you can reorder the groups themselves as well.

### Ongoing Damage Multiplier Improvements

- Added a 3x ongoing damage modifier (first tick only), the ongoing-damage counterpart to triple-damage crits — mainly for empowered sorcerer spells.
- Half damage now stores the exact half value, so a half-damage double-damage crit rounds the way you'd expect; rounding changed to round up.

Also fixed parsing and display of non-standard save-ends values, for both ongoing damage and conditions.

## Other Additions

- **2e Skirmisher macro** that stores a temporary fake combatant at half initiative, which is automatically cleaned up at the end of the round.
- **Great Dragon Incarnation**'s macro now actually transforms the user's token into a dragon, temporarily.
- **Powers targeting multiple defences** — targeting support for e.g. `vs. PD or MD`, which targets the lower of the two.
- **Compendium browser icon filter** — filter items by their associated icon.
- **Optional movement distance labels** — hiding the distance rulers is now a setting (on by default).
- **Dice So Nice overrides** gained a global speed modifier, and the system now tells you via a UI notification when it changes one of DsN's defaults.
- The end-of-turn chat card can now be popped out.
- Disengage dialog quick modifiers readjusted to better cover the available powers.

## Other Bug Fixes

- Players can now drag effects and conditions directly onto a token on the canvas, not just onto their sheet's effects tab. Thanks @kjaranso!
- Dropping an active effect on the canvas no longer has Foundry apply it directly before the system's own dialog gets a chance to process it.
- Fixed the `Chaotic Benefit` system macro.
- Fixed alt-clicking a power that has no level set.
- Fixed several wrong code guards — among other things this should clear up the UI error messages players (as opposed to the GM) saw when removing active effects using the system's chat messages.
- Fixed the bard song sustain reminder not firing under v14.
- Fixed manual recharge rolls not writing to chat (due to referencing an outdated Foundry constant).
- Fixed the `Unconscious` status not applying when the last gasp save fails.
- Successful death saves no longer *silently* roll a recovery — they produce the usual chat card.
- Death save steps now reflect the number of steps actually configured.
- Fixed hyphen cleaning in the PDF-parsing automation.
- Fixed (and localised) the `Strategist` extra starting command point.
- Fixed an error when players without macro permissions use a power with an embedded macro.
- Fixed intermittent mis-parsing of expanded damage rolls in the damage applicator, plus a damage application edge case.
- Removed the implicit crit-on-19+ assumption on rerolls.
- Fixed edge cases in custom resource setup and in stacking rule application.
- Fixed drag-and-drop on the inventory tab.
- ProseMirror editors get a minimum height (some inherited `0` from their parent), and their header wraps in narrow instances instead of overflowing.
- Fixed 2e equipment bonus labels: the disengage & initiative bonus rendered as a raw i18n key, and three other bonuses showed their raw property name in the collapsed summary row.
- Powers no longer appear to be "(modified)" a little too eagerly.
- Fixed start/end of next (source) turn duration not expiring automatically.

## Under the Hood

- Build tooling refactored from gulp to Vite with custom plugins, and npm dependencies updated to clear vulnerabilities.
- Added a `.gitattributes` file to keep line endings uniform going forward.
- Actor updates are slightly faster (only the data needed for the diff is flattened), and resource checks were optimised.
- Removed the redundant `preCreateToken` hook — the functionality is duplicated and expanded in the actor's `_preUpdate`.
- Fixed a few missed active effect `icon` → `img` property renames.
- A fair amount of dead and duplicated code removed along the way: three copies of the feat helpers, four copies of the usage-colour rule, two copies of the inline roll formatter, and several unused computed properties and template files.

## Changelog

Full changelog: https://github.com/asacolips-projects/13th-age/compare/1.40.1...1.41.0

## Contributors

@LegoFed3, @ben, @asacolips, @kjaranso
